### PR TITLE
Re-enable Ignition 8.3 integration tests

### DIFF
--- a/msd-gateway-tests/pom.xml
+++ b/msd-gateway-tests/pom.xml
@@ -59,6 +59,12 @@
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>3.5.5</version>
+            <configuration>
+              <systemPropertyVariables>
+                <ignition.image.version>${ignition-image.version}</ignition.image.version>
+                <msd.module.path>${project.basedir}/../msd-build/target/Modbus-Server-Driver-Module-unsigned.modl</msd.module.path>
+              </systemPropertyVariables>
+            </configuration>
             <executions>
               <execution>
                 <goals>

--- a/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/IgnitionTestSupport.java
+++ b/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/IgnitionTestSupport.java
@@ -1,0 +1,45 @@
+package com.kevinherron.ignition.modbus;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** Shared configuration for the integration tests. */
+final class IgnitionTestSupport {
+
+  /**
+   * Ignition Docker image tag under test, overridable with {@code -Dignition.image.version}.
+   *
+   * <p>testcontainers-ignition requires a concrete {@code major.minor.patch} tag; {@code latest} and
+   * release-line tags such as {@code 8.3} are rejected.
+   */
+  static final String IGNITION_IMAGE =
+      "inductiveautomation/ignition:" + System.getProperty("ignition.image.version", "8.3.8");
+
+  /** Gateway backup restored into the container. */
+  static final Path GATEWAY_BACKUP = Path.of("./src/test/resources/ignition.gwbk");
+
+  /** Port the Modbus server device binds to inside the container. */
+  static final int MODBUS_PORT = 502;
+
+  /** Unsigned module archive produced by {@code msd-build}. */
+  private static final Path MODULE_ARCHIVE =
+      Path.of(
+          System.getProperty(
+              "msd.module.path", "../msd-build/target/Modbus-Server-Driver-Module-unsigned.modl"));
+
+  private IgnitionTestSupport() {}
+
+  /**
+   * Returns the module archive, failing with an actionable message when it has not been built.
+   *
+   * @return path to the unsigned module archive
+   */
+  static Path requireModuleArchive() {
+    if (!Files.isRegularFile(MODULE_ARCHIVE)) {
+      throw new IllegalStateException(
+          "Module archive not found at %s. Run 'mvn package' first."
+              .formatted(MODULE_ARCHIVE.toAbsolutePath()));
+    }
+    return MODULE_ARCHIVE;
+  }
+}

--- a/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/ModbusToOpcUaIT.java
+++ b/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/ModbusToOpcUaIT.java
@@ -18,16 +18,15 @@ import com.digitalpetri.modbus.pdu.WriteMultipleRegistersRequest;
 import com.digitalpetri.modbus.pdu.WriteSingleCoilRequest;
 import com.digitalpetri.modbus.pdu.WriteSingleRegisterRequest;
 import com.digitalpetri.modbus.tcp.client.NettyTcpClientTransport;
-import com.mussonindustrial.testcontainers.ignition.GatewayEdition;
 import com.mussonindustrial.testcontainers.ignition.IgnitionContainer;
-import com.mussonindustrial.testcontainers.ignition.Module;
+import com.mussonindustrial.testcontainers.ignition.IgnitionGatewayEdition;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 import java.util.stream.Stream;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
-import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfigBuilder;
+import org.eclipse.milo.opcua.sdk.client.identity.UsernameProvider;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
@@ -39,15 +38,12 @@ import org.eclipse.milo.opcua.stack.core.util.EndpointUtil;
 import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfigBuilder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-// TODO refactor and re-enable when there is Ignition 8.3 support
-@Disabled
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ModbusToOpcUaIT {
 
@@ -58,20 +54,25 @@ public class ModbusToOpcUaIT {
   @BeforeAll
   void setUpContainer() throws Exception {
     ignitionContainer =
-        new IgnitionContainer("inductiveautomation/ignition:8.1.43")
+        new IgnitionContainer(IgnitionTestSupport.IGNITION_IMAGE)
+            .acceptLicense()
             .withCredentials("admin", "password")
-            .withEdition(GatewayEdition.STANDARD)
-            .withGatewayBackup("./src/test/resources/ignition.gwbk", false)
-            .withModules(Module.OPC_UA)
-            .withThirdPartyModules("../msd-build/target/Modbus-Server-Driver-Module-unsigned.modl")
-            .withAdditionalExposedPort(502)
-            .withAdditionalExposedPort(62541);
+            .withEdition(IgnitionGatewayEdition.STANDARD)
+            .withAllowUnsignedModules()
+            // OPC UA is not requested here: it is a Gateway-scoped dependency of the module
+            // archive, so the 8.3 profile enables it and exposes its endpoint on our behalf.
+            .withGatewayBackup(IgnitionTestSupport.GATEWAY_BACKUP, false)
+            .withThirdPartyModule(IgnitionTestSupport.requireModuleArchive())
+            .withAdditionalExposedPort(IgnitionTestSupport.MODBUS_PORT);
 
     ignitionContainer.start();
 
-    String endpointUrl =
-        "opc.tcp://%s:%d/discovery"
-            .formatted(ignitionContainer.getHost(), ignitionContainer.getMappedPort(62541));
+    System.out.println("Ignition version: " + ignitionContainer.getIgnitionVersion());
+    System.out.println("Profile: " + ignitionContainer.getProfile().name());
+    System.out.println("Gateway URL: " + ignitionContainer.getGatewayUrl());
+
+    String endpointUrl = ignitionContainer.getOpcUaDiscoveryUrl();
+    int opcUaPort = ignitionContainer.getMappedOpcUaPort();
 
     System.out.println("Endpoint URL: " + endpointUrl);
 
@@ -83,14 +84,10 @@ public class ModbusToOpcUaIT {
                     .filter(
                         e -> Objects.equals(e.getSecurityPolicyUri(), SecurityPolicy.None.getUri()))
                     .findFirst()
-                    .map(
-                        e ->
-                            EndpointUtil.updateUrl(
-                                e,
-                                ignitionContainer.getHost(),
-                                ignitionContainer.getMappedPort(62541))),
+                    .map(e -> EndpointUtil.updateUrl(e, ignitionContainer.getHost(), opcUaPort)),
             OpcTcpClientTransportConfigBuilder::build,
-            OpcUaClientConfigBuilder::build);
+            builder ->
+                builder.setIdentityProvider(new UsernameProvider("opcuauser", "password")).build());
 
     opcUaClient.connect();
 
@@ -99,7 +96,7 @@ public class ModbusToOpcUaIT {
             NettyTcpClientTransport.create(
                 cfg -> {
                   cfg.hostname = ignitionContainer.getHost();
-                  cfg.port = ignitionContainer.getMappedPort(502);
+                  cfg.port = ignitionContainer.getMappedPort(IgnitionTestSupport.MODBUS_PORT);
                 }));
 
     modbusClient.connect();

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <!-- Test Dependencies -->
     <junit.version>6.1.0</junit.version>
     <milo.version>1.1.3</milo.version>
-    <testcontainers-ignition.version>0.5.0-SNAPSHOT</testcontainers-ignition.version>
+    <testcontainers-ignition.version>0.5.0</testcontainers-ignition.version>
     <slf4j.version>2.1.0-alpha1</slf4j.version>
 
     <!-- Integration test configuration -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,11 @@
     <!-- Test Dependencies -->
     <junit.version>6.1.0</junit.version>
     <milo.version>1.1.3</milo.version>
-    <testcontainers-ignition.version>0.2.0</testcontainers-ignition.version>
+    <testcontainers-ignition.version>0.5.0-SNAPSHOT</testcontainers-ignition.version>
     <slf4j.version>2.1.0-alpha1</slf4j.version>
+
+    <!-- Integration test configuration -->
+    <ignition-image.version>8.3.8</ignition-image.version>
 
     <!-- Plugin Dependencies -->
     <checkstyle.version>12.2.0</checkstyle.version>


### PR DESCRIPTION
## Summary

- migrate the Ignition integration test harness to the capability-based testcontainers-ignition 0.5.0 API
- run the gateway test container on Ignition 8.3.8 and discover OPC UA endpoints from the resolved profile
- replace the locally built 0.5.0-SNAPSHOT dependency with the published 0.5.0 release

## Impact

The Modbus-to-OPC-UA integration suite is enabled again for Ignition 8.3 and no longer depends on a locally installed snapshot artifact.

## Validation

- `mvn dependency:resolve`
- `mvn clean verify`
- `mvn -Pintegration clean verify` — 23 integration tests passed against Ignition 8.3.8