### PR TITLE
Add Modbus array and OPC UA IndexRange support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,14 @@ The syntax used in NodeIds has the following components:
 
 - Area (`C`, `DI`, `HR`, `IR`)
 - DataType (`bool`, `int16`, `int32`, `int64`, `uint16`, `uint32`, `uint64`, `float`, `double`,
-  `stringN`)
+  `stringN`). The `C` and `DI` areas only support `bool`; register-only data types are rejected.
+- Array dimensions (optional positive sizes in square brackets inside the angle brackets, after the
+  DataType and before any modifiers)
 - Offset (`0` to `65535`)
-- Bit (`.0` to `.N` where `N` is the number of bits in the underlying data type)
+- Element indices (optional zero-based indices in square brackets after the offset)
+- Bit (optional `.<index>` after the offset; for a register scalar value, use `0` through `N-1`
+  where `N` is the number of bits in the underlying data type). A bit index outside that width or
+  a bit selection on a non-integer data type is rejected.
 
 Additionally, the DataType can have "modifiers" applied to influence the byte order and word order:
 
@@ -38,7 +43,57 @@ Examples:
 - `HR<int32>0.5` (holding register area, offset 0, bit 5 within a 32-bit signed integer (2
   registers))
 - `HR<string10>0` (holding register area, offset 0, string of length 10 (5 registers))
-- `IR<int32@LE>0` (input register area, offset 0, 32-byte signed integer (2 registers),
+- `IR<int32@LE>0` (input register area, offset 0, 32-bit signed integer (2 registers),
   little-endian byte order)
-- `IR<float@LH>0` (input register area, offset 0, 32-byte floating point number (2 registers),
+- `IR<float@LH>0` (input register area, offset 0, 32-bit floating point number (2 registers),
   low-high word order)
+
+### Arrays
+
+One to three dimensions may follow the DataType inside the angle brackets. Dimensions must appear
+before modifiers: `HR<int16[10]>0` declares 10 signed 16-bit values, while
+`HR<int32[5][2]@LE>100` declares a 5-by-2 array with little-endian byte order. The placement
+`HR<int32@LE[5][2]>100` is rejected.
+
+An array address without indices identifies the whole value. A one-dimensional value reads and
+writes as a boxed array. A value with two or three dimensions reads and writes as an OPC UA
+`Matrix`; its `ValueRank` and `ArrayDimensions` match the declared rank and dimensions. For
+example, `C<bool[2][2]>0` is a 2-by-2 Boolean `Matrix`.
+
+Append one zero-based index per declared dimension after the offset to select a single element.
+The resulting node is scalar. For example, `HR<int16[10]>0[5]` selects element 5, and
+`HR<int32[5][2]>100[2][1]` selects row 2, column 1.
+
+Elements use row-major ordering: the last index varies fastest. For dimensions `[d0][d1]`, the
+linear element index for `[i0][i1]` is `i0 * d1 + i1`. For three dimensions it is
+`(i0 * d1 + i1) * d2 + i2`. The physical Modbus offset is the base offset plus the linear index
+times the entries used by one element. Thus, the indexed 5-by-2 `int32` example above has linear
+index `2 * 2 + 1 = 5`; because `int32` uses two registers, its physical offset is
+`100 + 5 * 2 = 110`.
+
+Each Modbus area contains exactly 65,536 entries, addressed from 0 through 65,535. Coils and
+discrete inputs use one entry per element. Holding and input register elements use the number of
+registers required by their DataType. An address is valid only when
+`base offset + element count * entries per element <= 65536`. Therefore,
+`HR<int16[36]>65500` exactly reaches the boundary, while `HR<int16[37]>65500` and
+`HR<int64[99999][99999][99999]>0` are rejected before any value allocation.
+
+The following combinations are also rejected:
+
+- `HR<int16[10]>0.5` because a bit cannot be selected from an unindexed array; index an element
+  first, then select its bit.
+- `HR0[5]` because element indices require dimensions in the DataType declaration.
+
+### OPC UA IndexRange
+
+OPC UA `IndexRange` is supported for both reads and writes of array nodes. Use the standard OPC UA
+range text on the Read or Write request, such as `2:5` for one dimension or `1:2,0:1` for two
+dimensions. It is request metadata, not part of the Modbus address syntax. Consequently,
+`HR<int16[10]>0[2:5]` is rejected; use the one-dimensional array address above and put `2:5` in
+the request's `IndexRange` field. A malformed range returns `Bad_IndexRangeInvalid`; a range that
+cannot select data from the addressed value returns `Bad_IndexRangeNoData`.
+
+Per the OPC UA rules for String values, `IndexRange` also selects characters: on a scalar
+`stringN` node the range selects a sub-string (e.g. `0:4`), and on a `stringN` array node an
+additional final dimension selects characters within the selected elements (e.g. `1,0:2` for the
+first 3 characters of element 1).

--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ The following combinations are also rejected:
   first, then select its bit.
 - `HR0[5]` because element indices require dimensions in the DataType declaration.
 
+### Stricter address validation
+
+Address validation is stricter than in earlier releases. Forms that previously parsed (and were
+silently reinterpreted or partially ignored) are now rejected, and tags that use them show bad
+quality after upgrading:
+
+- Register-only DataTypes on coil or discrete input areas, e.g. `C<int16>0`; those areas are
+  single bits and support only `bool`.
+- Bit specifiers on non-integer DataTypes, e.g. `C0.5` or `HR<float>0.3`, and bit indices past
+  the DataType's width.
+- Addresses whose extent passes the end of the 65,536-entry area, e.g. `HR<int32>65535`.
+- Trailing element subscripts without declared dimensions, e.g. `HR0[2]` (previously the
+  subscript was ignored and the address read `HR0`).
+- Invalid DataType modifiers, e.g. `HR<int16@EB>0` (previously ignored).
+
+Review existing tags that rely on these forms and update them to the documented syntax when
+upgrading.
+
 ### OPC UA IndexRange
 
 OPC UA `IndexRange` is supported for both reads and writes of array nodes. Use the standard OPC UA

--- a/msd-gateway-tests/pom.xml
+++ b/msd-gateway-tests/pom.xml
@@ -107,6 +107,14 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>3.1.4</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.5.0</version>
       </plugin>

--- a/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/ArrayModbusToOpcUaIT.java
+++ b/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/ArrayModbusToOpcUaIT.java
@@ -591,6 +591,21 @@ public class ArrayModbusToOpcUaIT {
       assertEquals("WORLDWORLD", readValue(nodeId).getValue().getValue());
     }
 
+    // The replacement length must exactly match the selected substring length.
+    @ParameterizedTest(name = "{0} scalar String size mismatch")
+    @MethodSource("registerAreas")
+    void scalarStringRangeWriteLengthMismatchIsRejectedWithoutMutation(String area)
+        throws Exception {
+
+      NodeId nodeId = nodeId(area + "<string10>" + ARRAY_OFFSET);
+      assertGood(writeValue(nodeId, "HELLOWORLD"));
+
+      assertStatus(
+          StatusCodes.Bad_IndexRangeDataMismatch,
+          writeValue(nodeId, "0:4", "NO"));
+      assertEquals("HELLOWORLD", readValue(nodeId).getValue().getValue());
+    }
+
     // OPC UA Part 4 §7.27 treats String arrays as an additional substring dimension after the
     // array dimensions.
     @ParameterizedTest(name = "{0} String array read")
@@ -618,6 +633,23 @@ public class ArrayModbusToOpcUaIT {
 
       assertArrayEquals(
           new String[] {"alpha", "BETa", "gamma", "delta"},
+          (String[]) readValue(nodeId).getValue().getValue());
+    }
+
+    // A range with only the array dimension selects complete String elements, not characters.
+    @ParameterizedTest(name = "{0} whole String elements")
+    @MethodSource("registerAreas")
+    void stringArrayElementRangesReadAndWriteWholeStrings(String area) throws Exception {
+      NodeId nodeId = nodeId(area + "<string8[4]>" + (ARRAY_OFFSET + 16));
+      assertGood(writeValue(nodeId, new String[] {"alpha", "beta", "gamma", "delta"}));
+
+      assertArrayEquals(
+          new String[] {"beta", "gamma"},
+          (String[]) readValue(nodeId, "1:2").getValue().getValue());
+
+      assertGood(writeValue(nodeId, "1:2", new String[] {"BETA", "GAMMA"}));
+      assertArrayEquals(
+          new String[] {"alpha", "BETA", "GAMMA", "delta"},
           (String[]) readValue(nodeId).getValue().getValue());
     }
 
@@ -651,6 +683,25 @@ public class ArrayModbusToOpcUaIT {
           writeValue(nodeId, testCase.indexRange(), testCase.writeValue()));
 
       assertArrayEquals(initial, (Short[]) readValue(nodeId).getValue().getValue());
+    }
+
+    // OPC UA Part 4 §7.27 requires a NumericRange component for every array dimension.
+    @Test
+    void multidimensionalRangesRequireEveryDimensionWithoutMutation() throws Exception {
+      NodeId nodeId = nodeId("HR<int16[2][2]>" + ARRAY_OFFSET);
+      Short[] initial = shorts(0, 1, 2, 3);
+      assertGood(
+          writeValue(
+              nodeId,
+              new Matrix(initial, new int[] {2, 2}, OpcUaDataType.Int16)));
+
+      assertStatus(StatusCodes.Bad_IndexRangeNoData, readValue(nodeId, "1").getStatusCode());
+      assertStatus(
+          StatusCodes.Bad_IndexRangeNoData,
+          writeValue(nodeId, "1", new Short[] {8, 9}));
+
+      Matrix actual = assertInstanceOf(Matrix.class, readValue(nodeId).getValue().getValue());
+      assertArrayEquals(initial, (Short[]) actual.getElements());
     }
 
     // NumericRange applies only to indexed values; a scalar read must report that no indexed data
@@ -1282,6 +1333,10 @@ public class ArrayModbusToOpcUaIT {
         new InvalidRangeCase(
             "malformed read range", "1::2", null, StatusCodes.Bad_IndexRangeInvalid),
         new InvalidRangeCase(
+            "trailing colon in read range", "1:", null, StatusCodes.Bad_IndexRangeInvalid),
+        new InvalidRangeCase(
+            "trailing comma in read range", "1,", null, StatusCodes.Bad_IndexRangeInvalid),
+        new InvalidRangeCase(
             "out-of-bounds read range", "99", null, StatusCodes.Bad_IndexRangeNoData));
   }
 
@@ -1293,10 +1348,25 @@ public class ArrayModbusToOpcUaIT {
             new Short[] {9, 9},
             StatusCodes.Bad_IndexRangeInvalid),
         new InvalidRangeCase(
+            "trailing colon in write range",
+            "1:",
+            new Short[] {9},
+            StatusCodes.Bad_IndexRangeInvalid),
+        new InvalidRangeCase(
+            "trailing comma in write range",
+            "1,",
+            new Short[] {9},
+            StatusCodes.Bad_IndexRangeInvalid),
+        new InvalidRangeCase(
             "write value does not fill range",
             "2:4",
             new Short[] {9, 9},
-            StatusCodes.Bad_IndexRangeNoData));
+            StatusCodes.Bad_IndexRangeDataMismatch),
+        new InvalidRangeCase(
+            "write value has wrong element type",
+            "2:3",
+            new Integer[] {9, 9},
+            StatusCodes.Bad_TypeMismatch));
   }
 
   private static Stream<String> registerAreas() {

--- a/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/ArrayModbusToOpcUaIT.java
+++ b/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/ArrayModbusToOpcUaIT.java
@@ -132,14 +132,20 @@ public class ArrayModbusToOpcUaIT {
 
   @AfterAll
   void tearDown() throws Exception {
-    if (opcUaClient != null) {
-      opcUaClient.disconnect();
-    }
-    if (modbusClient != null) {
-      modbusClient.disconnect();
-    }
-    if (ignitionContainer != null) {
-      ignitionContainer.stop();
+    try {
+      if (opcUaClient != null) {
+        opcUaClient.disconnect();
+      }
+    } finally {
+      try {
+        if (modbusClient != null) {
+          modbusClient.disconnect();
+        }
+      } finally {
+        if (ignitionContainer != null) {
+          ignitionContainer.stop();
+        }
+      }
     }
   }
 

--- a/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/ArrayModbusToOpcUaIT.java
+++ b/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/ArrayModbusToOpcUaIT.java
@@ -1,0 +1,1469 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package com.kevinherron.ignition.modbus;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.digitalpetri.modbus.client.ModbusClient;
+import com.digitalpetri.modbus.client.ModbusTcpClient;
+import com.digitalpetri.modbus.pdu.ReadCoilsRequest;
+import com.digitalpetri.modbus.pdu.ReadDiscreteInputsRequest;
+import com.digitalpetri.modbus.pdu.ReadHoldingRegistersRequest;
+import com.digitalpetri.modbus.pdu.ReadInputRegistersRequest;
+import com.digitalpetri.modbus.pdu.WriteMultipleCoilsRequest;
+import com.digitalpetri.modbus.pdu.WriteMultipleRegistersRequest;
+import com.digitalpetri.modbus.tcp.client.NettyTcpClientTransport;
+import com.mussonindustrial.testcontainers.ignition.IgnitionContainer;
+import com.mussonindustrial.testcontainers.ignition.IgnitionGatewayEdition;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.identity.UsernameProvider;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.WriteValue;
+import org.eclipse.milo.opcua.stack.core.util.EndpointUtil;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfigBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Verifies the externally observable array contract across the Ignition OPC UA server and the
+ * embedded Modbus server.
+ *
+ * <p>These tests use both protocol clients so an error in one adapter cannot be hidden by applying
+ * the same inverse error on the return path.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ArrayModbusToOpcUaIT {
+
+  private static final int ARRAY_OFFSET = 4096;
+
+  private IgnitionContainer ignitionContainer;
+  private OpcUaClient opcUaClient;
+  private ModbusClient modbusClient;
+
+  @BeforeAll
+  void setUpContainer() throws Exception {
+    ignitionContainer =
+        new IgnitionContainer(IgnitionTestSupport.IGNITION_IMAGE)
+            .acceptLicense()
+            .withCredentials("admin", "password")
+            .withEdition(IgnitionGatewayEdition.STANDARD)
+            .withAllowUnsignedModules()
+            .withGatewayBackup(IgnitionTestSupport.GATEWAY_BACKUP, false)
+            .withThirdPartyModule(IgnitionTestSupport.requireModuleArchive())
+            .withAdditionalExposedPort(IgnitionTestSupport.MODBUS_PORT);
+
+    ignitionContainer.start();
+
+    String endpointUrl = ignitionContainer.getOpcUaDiscoveryUrl();
+    int opcUaPort = ignitionContainer.getMappedOpcUaPort();
+
+    opcUaClient =
+        OpcUaClient.create(
+            endpointUrl,
+            endpoints ->
+                endpoints.stream()
+                    .filter(
+                        endpoint ->
+                            Objects.equals(
+                                endpoint.getSecurityPolicyUri(), SecurityPolicy.None.getUri()))
+                    .findFirst()
+                    .map(
+                        endpoint ->
+                            EndpointUtil.updateUrl(
+                                endpoint, ignitionContainer.getHost(), opcUaPort)),
+            OpcTcpClientTransportConfigBuilder::build,
+            builder ->
+                builder.setIdentityProvider(new UsernameProvider("opcuauser", "password")).build());
+    opcUaClient.connect();
+
+    modbusClient =
+        ModbusTcpClient.create(
+            NettyTcpClientTransport.create(
+                config -> {
+                  config.hostname = ignitionContainer.getHost();
+                  config.port = ignitionContainer.getMappedPort(IgnitionTestSupport.MODBUS_PORT);
+                }));
+    modbusClient.connect();
+  }
+
+  @AfterAll
+  void tearDown() throws Exception {
+    if (opcUaClient != null) {
+      opcUaClient.disconnect();
+    }
+    if (modbusClient != null) {
+      modbusClient.disconnect();
+    }
+    if (ignitionContainer != null) {
+      ignitionContainer.stop();
+    }
+  }
+
+  @Nested
+  class ValueShapeAndMetadata {
+
+    // Every supported register type and rank must survive the OPC UA-to-Modbus conversion without
+    // changing its Java element type or declared shape.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("registerArrayCases")
+    void registerArrayValuesRoundTripForEverySupportedAreaTypeAndRank(
+        RegisterArrayCase testCase) throws Exception {
+
+      NodeId nodeId = nodeId(testCase.address());
+
+      assertGood(writeValue(nodeId, testCase.value()));
+      assertValueShape(
+          readValue(nodeId).getValue().getValue(),
+          testCase.expectedElements(),
+          testCase.dimensions());
+    }
+
+    // OPC UA Part 3 §5.6.2 requires DataType, ValueRank, and ArrayDimensions to describe a
+    // Variable's value consistently. The fixtures cover every data type, rank, and Modbus area
+    // without repeating the full Cartesian product already exercised by the value tests.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("arrayMetadataCases")
+    void arrayNodesExposeTheirDeclaredMetadata(ArrayMetadataCase testCase) throws Exception {
+
+      assertArrayMetadata(
+          nodeId(testCase.address()), testCase.dataType(), testCase.dimensions());
+    }
+
+    // Boolean arrays use a bit-oriented Modbus representation but must retain their OPC UA rank
+    // and dimensions for both writable and read-only Modbus areas.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("booleanArrayCases")
+    void booleanArrayValuesRoundTripForEveryAreaAndRank(BooleanArrayCase testCase)
+        throws Exception {
+
+      NodeId nodeId = nodeId(testCase.address());
+
+      assertGood(writeValue(nodeId, testCase.value()));
+      assertValueShape(
+          readValue(nodeId).getValue().getValue(),
+          testCase.expectedElements(),
+          testCase.dimensions());
+    }
+
+    static Stream<RegisterArrayCase> registerArrayCases() {
+      return ArrayModbusToOpcUaIT.registerArrayCases();
+    }
+
+    static Stream<BooleanArrayCase> booleanArrayCases() {
+      return ArrayModbusToOpcUaIT.booleanArrayCases();
+    }
+
+    static Stream<ArrayMetadataCase> arrayMetadataCases() {
+      return ArrayModbusToOpcUaIT.arrayMetadataCases();
+    }
+  }
+
+  @Nested
+  class ModbusInteroperability {
+
+    // Reading through the independent Modbus client prevents a matching encoder/decoder defect
+    // from making an OPC UA-only round trip pass.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("registerArrayCases")
+    void opcUaRegisterArrayWritesPreserveModbusWireEncoding(RegisterArrayCase testCase)
+        throws Exception {
+
+      assertGood(writeValue(nodeId(testCase.address()), testCase.value()));
+
+      assertArrayEquals(
+          testCase.expectedRegisters(),
+          readRegisters(
+              testCase.address().substring(0, 2),
+              ARRAY_OFFSET,
+              testCase.expectedRegisters().length / 2));
+    }
+
+    // Boolean array elements must occupy consecutive Modbus bits in OPC UA array order.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("booleanArrayCases")
+    void opcUaBooleanArrayWritesPreserveModbusBitEncoding(BooleanArrayCase testCase)
+        throws Exception {
+
+      assertGood(writeValue(nodeId(testCase.address()), testCase.value()));
+
+      assertArrayEquals(
+          testCase.expectedBits(),
+          readBits(testCase.address(), testCase.expectedElements().length));
+    }
+
+    // Byte- and word-order modifiers are defined per scalar value, so every array element must be
+    // transformed independently rather than treating the array as one byte sequence.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("registerModifierCases")
+    void registerArrayModifiersTransformEveryWireElement(RegisterModifierCase testCase)
+        throws Exception {
+
+      assertGood(writeValue(nodeId(testCase.address()), testCase.value()));
+
+      assertArrayEquals(
+          testCase.expectedRegisters(),
+          readRegisters(
+              testCase.address().substring(0, 2),
+              ARRAY_OFFSET,
+              testCase.expectedRegisters().length / 2));
+    }
+
+    // Applying an address modifier on write and its inverse on read must preserve each original
+    // array value exposed to OPC UA clients.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("registerModifierCases")
+    void registerArrayModifiersAreReversibleThroughOpcUa(RegisterModifierCase testCase)
+        throws Exception {
+
+      NodeId nodeId = nodeId(testCase.address());
+
+      assertGood(writeValue(nodeId, testCase.value()));
+      assertArrayEquals(
+          (Object[]) testCase.value(), (Object[]) readValue(nodeId).getValue().getValue());
+    }
+
+    // A direct Modbus coil write must be visible as a one-dimensional OPC UA Boolean array rather
+    // than as the packed transport byte.
+    @Test
+    void modbusCoilWritesAreExposedAsOneDimensionalOpcUaArrays() throws Exception {
+      Boolean[] expected = {true, false, true, true, false, true};
+
+      modbusClient.writeMultipleCoils(
+          0,
+          new WriteMultipleCoilsRequest(ARRAY_OFFSET, expected.length, packBooleans(expected)));
+
+      assertArrayEquals(
+          expected,
+          (Boolean[])
+              readValue(nodeId("C<bool[6]>" + ARRAY_OFFSET)).getValue().getValue());
+    }
+
+    // A direct Modbus register write must be decoded into the declared OPC UA scalar element type.
+    @Test
+    void modbusRegisterWritesAreExposedAsOneDimensionalOpcUaArrays() throws Exception {
+      byte[] registers = hex("1234 FEDC 0001");
+
+      modbusClient.writeMultipleRegisters(
+          0,
+          new WriteMultipleRegistersRequest(
+              ARRAY_OFFSET, registers.length / 2, registers));
+
+      assertArrayEquals(
+          new Short[] {(short) 0x1234, (short) 0xFEDC, (short) 1},
+          (Short[])
+              readValue(nodeId("HR<int16[3]>" + ARRAY_OFFSET)).getValue().getValue());
+    }
+
+    // Multi-dimensional OPC UA values are flattened on the Modbus wire but must be reconstructed
+    // with the address-declared dimensions.
+    @Test
+    void modbusRegisterWritesAreExposedAsOpcUaMatrices() throws Exception {
+      byte[] registers = hex("00000001 00000002 00000003 00000004");
+
+      modbusClient.writeMultipleRegisters(
+          0,
+          new WriteMultipleRegistersRequest(
+              ARRAY_OFFSET, registers.length / 2, registers));
+
+      Matrix matrix =
+          assertInstanceOf(
+              Matrix.class,
+              readValue(nodeId("HR<int32[2][2]>" + ARRAY_OFFSET)).getValue().getValue());
+      assertNotNull(matrix);
+      int[] dimensions = matrix.getDimensions();
+      Object elements = matrix.getElements();
+      assertNotNull(dimensions);
+      assertNotNull(elements);
+      assertArrayEquals(new int[] {2, 2}, dimensions);
+      assertArrayEquals(new Integer[] {1, 2, 3, 4}, (Integer[]) elements);
+    }
+
+    static Stream<RegisterArrayCase> registerArrayCases() {
+      return ArrayModbusToOpcUaIT.registerArrayCases();
+    }
+
+    static Stream<BooleanArrayCase> booleanArrayCases() {
+      return ArrayModbusToOpcUaIT.booleanArrayCases();
+    }
+
+    static Stream<RegisterModifierCase> registerModifierCases() {
+      return ArrayModbusToOpcUaIT.registerModifierCases();
+    }
+  }
+
+  @Nested
+  class IndexedElements {
+
+    // Array-address indexes select scalar child nodes using OPC UA's row-major array ordering.
+    @Test
+    void indexedRegisterReadsUseRowMajorOffsets() throws Exception {
+      String address = "HR<int32[2][3]>" + ARRAY_OFFSET;
+      Integer[] initial = {10, 20, 30, 40, 50, 60};
+      assertGood(
+          writeValue(
+              nodeId(address),
+              new Matrix(initial, new int[] {2, 3}, OpcUaDataType.Int32)));
+
+      assertEquals(60, readValue(nodeId(address + "[1][2]")).getValue().getValue());
+    }
+
+    // Updating an indexed element must target only its row-major Modbus offset and leave adjacent
+    // elements unchanged.
+    @Test
+    void indexedRegisterWritesUseRowMajorOffsets() throws Exception {
+      String address = "HR<int32[2][3]>" + ARRAY_OFFSET;
+      Integer[] initial = {10, 20, 30, 40, 50, 60};
+      assertGood(
+          writeValue(
+              nodeId(address),
+              new Matrix(initial, new int[] {2, 3}, OpcUaDataType.Int32)));
+
+      assertGood(writeValue(nodeId(address + "[1][2]"), 99));
+
+      Matrix fullValue =
+          assertInstanceOf(Matrix.class, readValue(nodeId(address)).getValue().getValue());
+      assertNotNull(fullValue);
+      Object elements = fullValue.getElements();
+      assertNotNull(elements);
+      assertArrayEquals(
+          new Integer[] {10, 20, 30, 40, 50, 99}, (Integer[]) elements);
+      assertArrayEquals(
+          hex("00000063"), readRegisters("HR", ARRAY_OFFSET + (5 * 2), 2));
+    }
+
+    // OPC UA Part 3 §5.6.2 requires a selected element node to advertise scalar metadata even
+    // when its parent Variable is an array or matrix.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("indexedMetadataCases")
+    void indexedElementNodesExposeScalarMetadata(IndexedMetadataCase testCase)
+        throws Exception {
+
+      assertScalarMetadata(nodeId(testCase.address()), testCase.dataType());
+    }
+
+    // Bit selection is applied after array indexing, so a write must affect the selected integer
+    // element without spilling into the neighboring element.
+    @Test
+    void indexedIntegerElementsMaySelectAndWriteIndividualBits() throws Exception {
+      String address = "HR<int16[2]>" + ARRAY_OFFSET;
+      assertGood(writeValue(nodeId(address), new Short[] {0, 0}));
+      NodeId bitNode = nodeId(address + "[1].5");
+
+      assertGood(writeValue(bitNode, true));
+
+      assertEquals(Boolean.TRUE, readValue(bitNode).getValue().getValue());
+      assertArrayEquals(
+          new Short[] {0, 32},
+          (Short[]) readValue(nodeId(address)).getValue().getValue());
+    }
+
+    // Three-dimensional Boolean indexes must flatten in row-major order before selecting the
+    // backing Modbus bit.
+    @Test
+    void indexedBooleanWritesUseThreeDimensionalRowMajorOffsets() throws Exception {
+      String address = "C<bool[2][2][2]>" + ARRAY_OFFSET;
+      Boolean[] initial = new Boolean[8];
+      Arrays.fill(initial, false);
+      assertGood(
+          writeValue(
+              nodeId(address),
+              new Matrix(initial, new int[] {2, 2, 2}, OpcUaDataType.Boolean)));
+
+      NodeId indexedNode = nodeId(address + "[1][0][1]");
+      assertGood(writeValue(indexedNode, true));
+
+      assertEquals(Boolean.TRUE, readValue(indexedNode).getValue().getValue());
+      assertArrayEquals(new byte[] {0x20}, readBits(address, 8));
+    }
+
+    static Stream<IndexedMetadataCase> indexedMetadataCases() {
+      return ArrayModbusToOpcUaIT.indexedMetadataCases();
+    }
+  }
+
+  @Nested
+  class NumericRanges {
+
+    // OPC UA Part 4 §5.11.2 and §7.27 require a one-dimensional NumericRange read to return only
+    // the selected composite elements in their original order.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("oneDimensionalRangeCases")
+    void oneDimensionalRangeReadsReturnTheSelectedElements(OneDimensionalRangeCase testCase)
+        throws Exception {
+
+      NodeId nodeId = nodeId(testCase.address());
+      assertGood(writeValue(nodeId, testCase.initial()));
+
+      Object slice = readValue(nodeId, "2:4").getValue().getValue();
+
+      assertArrayEquals((Object[]) testCase.expectedSlice(), (Object[]) slice);
+    }
+
+    // OPC UA Part 4 §5.11.4 and §7.27 require a range write to replace exactly the selected
+    // elements while preserving every element outside the range.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("oneDimensionalRangeCases")
+    void oneDimensionalRangeWritesPreserveUnselectedElements(
+        OneDimensionalRangeCase testCase) throws Exception {
+
+      NodeId nodeId = nodeId(testCase.address());
+      assertGood(writeValue(nodeId, testCase.initial()));
+
+      assertGood(writeValue(nodeId, "1:2", testCase.update()));
+
+      assertArrayEquals(
+          (Object[]) testCase.expectedFullValue(),
+          (Object[]) readValue(nodeId).getValue().getValue());
+      assertArrayEquals(
+          testCase.expectedModbusValue(), readModbusArray(testCase.address(), 6));
+    }
+
+    // OPC UA Part 4 §7.27 defines one NumericRange component per matrix dimension; the returned
+    // Matrix must retain the dimensions of the selected block.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("twoDimensionalRangeCases")
+    void twoDimensionalRangeReadsPreserveTheSelectedShape(
+        TwoDimensionalRangeCase testCase) throws Exception {
+
+      NodeId nodeId = nodeId(testCase.address());
+      assertGood(
+          writeValue(
+              nodeId,
+              new Matrix(testCase.initialElements(), new int[] {3, 3}, testCase.dataType())));
+
+      Matrix slice =
+          assertInstanceOf(Matrix.class, readValue(nodeId, "1:2,0:1").getValue().getValue());
+
+      assertNotNull(slice);
+      int[] dimensions = slice.getDimensions();
+      Object elements = slice.getElements();
+      assertNotNull(dimensions);
+      assertNotNull(elements);
+      assertArrayEquals(new int[] {2, 2}, dimensions);
+      assertArrayEquals(
+          (Object[]) testCase.expectedSliceElements(), (Object[]) elements);
+    }
+
+    // A matrix range write must map each update coordinate into the full row-major matrix without
+    // overwriting values outside the selected block.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("twoDimensionalRangeCases")
+    void twoDimensionalRangeWritesPreserveUnselectedElements(
+        TwoDimensionalRangeCase testCase) throws Exception {
+
+      NodeId nodeId = nodeId(testCase.address());
+      assertGood(
+          writeValue(
+              nodeId,
+              new Matrix(testCase.initialElements(), new int[] {3, 3}, testCase.dataType())));
+      Matrix update =
+          new Matrix(testCase.updateElements(), new int[] {2, 2}, testCase.dataType());
+
+      assertGood(writeValue(nodeId, "0:1,1:2", update));
+
+      Matrix fullValue =
+          assertInstanceOf(Matrix.class, readValue(nodeId).getValue().getValue());
+      assertNotNull(fullValue);
+      Object elements = fullValue.getElements();
+      assertNotNull(elements);
+      assertArrayEquals(
+          (Object[]) testCase.expectedFullElements(), (Object[]) elements);
+      assertArrayEquals(
+          testCase.expectedModbusValue(), readModbusArray(testCase.address(), 9));
+    }
+
+    // A three-dimensional NumericRange proves that range coordinates are not accidentally handled
+    // as a two-dimensional special case.
+    @Test
+    void threeDimensionalRangeReadsPreserveTheSelectedShape() throws Exception {
+      String address = "IR<int16[2][2][2]>" + ARRAY_OFFSET;
+      NodeId nodeId = nodeId(address);
+      assertGood(
+          writeValue(
+              nodeId,
+              new Matrix(
+                  shorts(0, 1, 2, 3, 4, 5, 6, 7),
+                  new int[] {2, 2, 2},
+                  OpcUaDataType.Int16)));
+
+      Matrix slice =
+          assertInstanceOf(
+              Matrix.class, readValue(nodeId, "0:1,1,0:1").getValue().getValue());
+
+      assertNotNull(slice);
+      int[] dimensions = slice.getDimensions();
+      Object elements = slice.getElements();
+      assertNotNull(dimensions);
+      assertNotNull(elements);
+      assertArrayEquals(new int[] {2, 1, 2}, dimensions);
+      assertArrayEquals(shorts(2, 3, 6, 7), (Short[]) elements);
+    }
+
+    // A three-dimensional range write must preserve unselected values across every dimension.
+    @Test
+    void threeDimensionalRangeWritesPreserveUnselectedElements() throws Exception {
+      String address = "IR<int16[2][2][2]>" + ARRAY_OFFSET;
+      NodeId nodeId = nodeId(address);
+      assertGood(
+          writeValue(
+              nodeId,
+              new Matrix(
+                  shorts(0, 1, 2, 3, 4, 5, 6, 7),
+                  new int[] {2, 2, 2},
+                  OpcUaDataType.Int16)));
+      Matrix update =
+          new Matrix(shorts(50, 70), new int[] {1, 2, 1}, OpcUaDataType.Int16);
+
+      assertGood(writeValue(nodeId, "1,0:1,1", update));
+
+      Matrix fullValue =
+          assertInstanceOf(Matrix.class, readValue(nodeId).getValue().getValue());
+      assertNotNull(fullValue);
+      Object elements = fullValue.getElements();
+      assertNotNull(elements);
+      assertArrayEquals(
+          shorts(0, 1, 2, 3, 4, 50, 6, 70), (Short[]) elements);
+    }
+
+    // OPC UA Part 4 §7.27 treats a String NumericRange as a substring selection.
+    @ParameterizedTest(name = "{0} scalar String read")
+    @MethodSource("registerAreas")
+    void scalarStringRangeReadsReturnTheSelectedCharacters(String area) throws Exception {
+      NodeId nodeId = nodeId(area + "<string10>" + ARRAY_OFFSET);
+      assertGood(writeValue(nodeId, "HELLOWORLD"));
+
+      assertEquals("HELLO", readValue(nodeId, "0:4").getValue().getValue());
+    }
+
+    // A substring write replaces only the selected characters of the scalar String.
+    @ParameterizedTest(name = "{0} scalar String write")
+    @MethodSource("registerAreas")
+    void scalarStringRangeWritesPreserveUnselectedCharacters(String area) throws Exception {
+      NodeId nodeId = nodeId(area + "<string10>" + ARRAY_OFFSET);
+      assertGood(writeValue(nodeId, "HELLOWORLD"));
+
+      assertGood(writeValue(nodeId, "0:4", "WORLD"));
+
+      assertEquals("WORLDWORLD", readValue(nodeId).getValue().getValue());
+    }
+
+    // OPC UA Part 4 §7.27 treats String arrays as an additional substring dimension after the
+    // array dimensions.
+    @ParameterizedTest(name = "{0} String array read")
+    @MethodSource("registerAreas")
+    void stringArrayRangeReadsSelectElementsAndCharacters(String area) throws Exception {
+      NodeId nodeId = nodeId(area + "<string8[4]>" + (ARRAY_OFFSET + 16));
+      assertGood(writeValue(nodeId, new String[] {"alpha", "beta", "gamma", "delta"}));
+
+      assertArrayEquals(
+          new String[] {"bet"},
+          (String[]) readValue(nodeId, "1,0:2").getValue().getValue());
+    }
+
+    // A String-array range write must preserve both unselected array elements and unselected
+    // characters in the selected element.
+    @ParameterizedTest(name = "{0} String array write")
+    @MethodSource("registerAreas")
+    void stringArrayRangeWritesPreserveUnselectedValuesAndCharacters(String area)
+        throws Exception {
+
+      NodeId nodeId = nodeId(area + "<string8[4]>" + (ARRAY_OFFSET + 16));
+      assertGood(writeValue(nodeId, new String[] {"alpha", "beta", "gamma", "delta"}));
+
+      assertGood(writeValue(nodeId, "1,0:2", new String[] {"BET"}));
+
+      assertArrayEquals(
+          new String[] {"alpha", "BETa", "gamma", "delta"},
+          (String[]) readValue(nodeId).getValue().getValue());
+    }
+
+    // OPC UA Part 4 §7.27 distinguishes malformed NumericRange syntax from a valid range that has
+    // no data, and clients depend on that distinction for request correction.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidReadRangeCases")
+    void invalidRangeReadsReturnTheSpecifiedStatus(InvalidRangeCase testCase)
+        throws Exception {
+
+      NodeId nodeId = nodeId("HR<int16[6]>" + ARRAY_OFFSET);
+      assertGood(writeValue(nodeId, shorts(0, 1, 2, 3, 4, 5)));
+
+      assertStatus(
+          testCase.expectedStatus(), readValue(nodeId, testCase.indexRange()).getStatusCode());
+    }
+
+    // A rejected range write must be atomic; otherwise an error response could conceal a partial
+    // device update.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidWriteRangeCases")
+    void invalidRangeWritesDoNotMutateTheArray(InvalidRangeCase testCase)
+        throws Exception {
+
+      NodeId nodeId = nodeId("HR<int16[6]>" + ARRAY_OFFSET);
+      Short[] initial = shorts(0, 1, 2, 3, 4, 5);
+      assertGood(writeValue(nodeId, initial));
+
+      assertStatus(
+          testCase.expectedStatus(),
+          writeValue(nodeId, testCase.indexRange(), testCase.writeValue()));
+
+      assertArrayEquals(initial, (Short[]) readValue(nodeId).getValue().getValue());
+    }
+
+    // NumericRange applies only to indexed values; a scalar read must report that no indexed data
+    // exists instead of silently ignoring the range.
+    @Test
+    void scalarRangeReadsReturnBadIndexRangeNoData() throws Exception {
+      NodeId nodeId = nodeId("HR<int16>" + (ARRAY_OFFSET + 20));
+      assertGood(writeValue(nodeId, (short) 7));
+
+      assertStatus(StatusCodes.Bad_IndexRangeNoData, readValue(nodeId, "0").getStatusCode());
+    }
+
+    // A rejected scalar range write must leave the scalar value unchanged.
+    @Test
+    void scalarRangeWritesReturnBadIndexRangeNoDataWithoutMutation() throws Exception {
+      NodeId nodeId = nodeId("HR<int16>" + (ARRAY_OFFSET + 20));
+      assertGood(writeValue(nodeId, (short) 7));
+
+      assertStatus(StatusCodes.Bad_IndexRangeNoData, writeValue(nodeId, "0", (short) 8));
+
+      assertEquals((short) 7, readValue(nodeId).getValue().getValue());
+    }
+
+    // OPC UA Part 4 §5.11.2 returns one result per requested node; processing a ranged item must
+    // not skip later items in the batch.
+    @Test
+    void rangedItemsDoNotShortCircuitReadBatches() throws Exception {
+      NodeId first = nodeId("HR<int16>" + ARRAY_OFFSET);
+      NodeId ranged = nodeId("HR<int16[4]>" + (ARRAY_OFFSET + 10));
+      NodeId last = nodeId("C" + (ARRAY_OFFSET + 20));
+      assertGood(writeValue(first, (short) 11));
+      assertGood(writeValue(ranged, shorts(1, 2, 3, 4)));
+      assertGood(writeValue(last, true));
+
+      DataValue[] results =
+          opcUaClient
+              .read(
+                  0.0,
+                  TimestampsToReturn.Both,
+                  List.of(
+                      readValueId(first, AttributeId.Value, ""),
+                      readValueId(ranged, AttributeId.Value, "1:2"),
+                      readValueId(last, AttributeId.Value, "")))
+              .getResults();
+
+      assertNotNull(results);
+      assertEquals(3, results.length);
+      assertTrue(Arrays.stream(results).allMatch(value -> value.getStatusCode().isGood()));
+      assertArrayEquals(shorts(2, 3), (Short[]) results[1].getValue().getValue());
+    }
+
+    // OPC UA Part 4 §5.11.4 returns one result per requested write; a ranged write must not skip
+    // the scalar writes around it.
+    @Test
+    void rangedItemsDoNotShortCircuitWriteBatches() throws Exception {
+      NodeId first = nodeId("HR<int16>" + ARRAY_OFFSET);
+      NodeId ranged = nodeId("HR<int16[4]>" + (ARRAY_OFFSET + 10));
+      NodeId last = nodeId("C" + (ARRAY_OFFSET + 20));
+      assertGood(writeValue(first, (short) 11));
+      assertGood(writeValue(ranged, shorts(1, 2, 3, 4)));
+      assertGood(writeValue(last, true));
+
+      StatusCode[] results =
+          opcUaClient
+              .write(
+                  List.of(
+                      writeRequest(first, "", (short) 12),
+                      writeRequest(ranged, "1:2", shorts(20, 30)),
+                      writeRequest(last, "", false)))
+              .getResults();
+
+      assertNotNull(results);
+      assertEquals(3, results.length);
+      assertTrue(Arrays.stream(results).allMatch(StatusCode::isGood));
+      assertEquals((short) 12, readValue(first).getValue().getValue());
+      assertArrayEquals(
+          shorts(1, 20, 30, 4), (Short[]) readValue(ranged).getValue().getValue());
+      assertEquals(Boolean.FALSE, readValue(last).getValue().getValue());
+    }
+
+    static Stream<OneDimensionalRangeCase> oneDimensionalRangeCases() {
+      return ArrayModbusToOpcUaIT.oneDimensionalRangeCases();
+    }
+
+    static Stream<TwoDimensionalRangeCase> twoDimensionalRangeCases() {
+      return ArrayModbusToOpcUaIT.twoDimensionalRangeCases();
+    }
+
+    static Stream<String> registerAreas() {
+      return ArrayModbusToOpcUaIT.registerAreas();
+    }
+
+    static Stream<InvalidRangeCase> invalidReadRangeCases() {
+      return ArrayModbusToOpcUaIT.invalidReadRangeCases();
+    }
+
+    static Stream<InvalidRangeCase> invalidWriteRangeCases() {
+      return ArrayModbusToOpcUaIT.invalidWriteRangeCases();
+    }
+  }
+
+  @Nested
+  class ValidationAndBoundaries {
+
+    // Fixed-length OPC UA array Variables reject a shorter value so an incomplete device update
+    // cannot be reported as successful.
+    @Test
+    void oneDimensionalArrayLengthMismatchesAreRejectedWithoutMutation() throws Exception {
+      NodeId nodeId = nodeId("HR<int16[2]>" + ARRAY_OFFSET);
+      Short[] initial = shorts(11, 22);
+      assertGood(writeValue(nodeId, initial));
+
+      assertStatus(StatusCodes.Bad_TypeMismatch, writeValue(nodeId, new Short[] {1}));
+
+      assertArrayEquals(initial, (Short[]) readValue(nodeId).getValue().getValue());
+    }
+
+    // OPC UA Part 4 §5.11.4 requires Bad_TypeMismatch when the written element type does not match
+    // the Variable's DataType, and the failed write must not change device state.
+    @Test
+    void oneDimensionalArrayElementTypeMismatchesAreRejectedWithoutMutation() throws Exception {
+      NodeId nodeId = nodeId("HR<int16[2]>" + ARRAY_OFFSET);
+      Short[] initial = shorts(11, 22);
+      assertGood(writeValue(nodeId, initial));
+
+      assertStatus(StatusCodes.Bad_TypeMismatch, writeValue(nodeId, new Integer[] {1, 2}));
+
+      assertArrayEquals(initial, (Short[]) readValue(nodeId).getValue().getValue());
+    }
+
+    // A multi-dimensional Variable requires Matrix shape information; accepting a flat array would
+    // lose the rank contract advertised by ValueRank and ArrayDimensions.
+    @Test
+    void matrixWritesRejectFlatArraysWithoutMutation() throws Exception {
+      NodeId nodeId = nodeId("HR<int16[2][2]>" + (ARRAY_OFFSET + 10));
+      Matrix initial =
+          new Matrix(shorts(1, 2, 3, 4), new int[] {2, 2}, OpcUaDataType.Int16);
+      assertGood(writeValue(nodeId, initial));
+
+      assertStatus(StatusCodes.Bad_TypeMismatch, writeValue(nodeId, shorts(1, 2, 3, 4)));
+
+      Matrix actual =
+          assertInstanceOf(Matrix.class, readValue(nodeId).getValue().getValue());
+      assertNotNull(actual);
+      Object actualElements = actual.getElements();
+      assertNotNull(actualElements);
+      assertArrayEquals(shorts(1, 2, 3, 4), (Short[]) actualElements);
+    }
+
+    // Matrix dimensions are part of the Variable's type contract even when the flattened element
+    // count matches, so a reshaped payload must be rejected atomically.
+    @Test
+    void matrixWritesRejectDifferentDimensionsWithoutMutation() throws Exception {
+      NodeId nodeId = nodeId("HR<int16[2][2]>" + (ARRAY_OFFSET + 10));
+      Matrix initial =
+          new Matrix(shorts(1, 2, 3, 4), new int[] {2, 2}, OpcUaDataType.Int16);
+      assertGood(writeValue(nodeId, initial));
+
+      Matrix reshaped =
+          new Matrix(shorts(1, 2, 3, 4), new int[] {1, 4}, OpcUaDataType.Int16);
+      assertStatus(StatusCodes.Bad_TypeMismatch, writeValue(nodeId, reshaped));
+
+      Matrix actual =
+          assertInstanceOf(Matrix.class, readValue(nodeId).getValue().getValue());
+      assertNotNull(actual);
+      Object actualElements = actual.getElements();
+      assertNotNull(actualElements);
+      assertArrayEquals(shorts(1, 2, 3, 4), (Short[]) actualElements);
+    }
+
+    // OPC UA Part 4 §5.11.2 requires Bad_NodeIdUnknown for syntactically addressable nodes that the
+    // server cannot expose safely.
+    @ParameterizedTest(name = "invalid array read {0}")
+    @MethodSource("invalidArrayAddresses")
+    void invalidArrayAddressesAreNotReadableNodes(String address) throws Exception {
+      assertStatus(StatusCodes.Bad_NodeIdUnknown, readValue(nodeId(address)).getStatusCode());
+    }
+
+    // OPC UA Part 4 §5.11.4 applies the same unknown-node contract to writes, preventing invalid
+    // array extents or modifiers from reaching the Modbus server.
+    @ParameterizedTest(name = "invalid array write {0}")
+    @MethodSource("invalidArrayAddresses")
+    void invalidArrayAddressesAreNotWritableNodes(String address) throws Exception {
+      assertStatus(StatusCodes.Bad_NodeIdUnknown, writeValue(nodeId(address), (short) 1));
+    }
+
+    // An array ending exactly at register 65535 is valid; rejecting it would be an off-by-one loss
+    // of the final legal Modbus address.
+    @Test
+    void registerArraysMayEndAtTheAddressSpaceBoundary() throws Exception {
+      DataValue value = readValue(nodeId("HR<int16[36]>65500"));
+      Short[] expected = new Short[36];
+      Arrays.fill(expected, (short) 0);
+
+      assertGood(value.getStatusCode());
+      assertArrayEquals(expected, (Short[]) value.getValue().getValue());
+    }
+
+    // A one-element Boolean array beginning at coil 65535 proves the inclusive boundary for bit
+    // areas independently of register width calculations.
+    @Test
+    void booleanArraysMayEndAtTheAddressSpaceBoundary() throws Exception {
+      DataValue value = readValue(nodeId("C<bool[1]>65535"));
+
+      assertGood(value.getStatusCode());
+      assertArrayEquals(new Boolean[] {false}, (Boolean[]) value.getValue().getValue());
+    }
+
+    static Stream<String> invalidArrayAddresses() {
+      return ArrayModbusToOpcUaIT.invalidArrayAddresses();
+    }
+  }
+
+  private DataValue readValue(NodeId nodeId) throws Exception {
+    return readValue(nodeId, "");
+  }
+
+  private DataValue readValue(NodeId nodeId, String indexRange) throws Exception {
+    DataValue[] results =
+        opcUaClient
+            .read(
+                0.0,
+                TimestampsToReturn.Both,
+                List.of(readValueId(nodeId, AttributeId.Value, indexRange)))
+            .getResults();
+    assertNotNull(results);
+    assertEquals(1, results.length);
+    assertNotNull(results[0]);
+    return results[0];
+  }
+
+  private DataValue readAttribute(NodeId nodeId, AttributeId attributeId) throws Exception {
+    DataValue[] results =
+        opcUaClient
+            .read(
+                0.0,
+                TimestampsToReturn.Neither,
+                List.of(readValueId(nodeId, attributeId, "")))
+            .getResults();
+    assertNotNull(results);
+    assertEquals(1, results.length);
+    assertNotNull(results[0]);
+    return results[0];
+  }
+
+  private StatusCode writeValue(NodeId nodeId, Object value) throws Exception {
+    return writeValue(nodeId, "", value);
+  }
+
+  private StatusCode writeValue(NodeId nodeId, String indexRange, Object value) throws Exception {
+    StatusCode[] results =
+        opcUaClient.write(List.of(writeRequest(nodeId, indexRange, value))).getResults();
+    assertNotNull(results);
+    assertEquals(1, results.length);
+    assertNotNull(results[0]);
+    return results[0];
+  }
+
+  private static ReadValueId readValueId(
+      NodeId nodeId, AttributeId attributeId, String indexRange) {
+    return new ReadValueId(nodeId, attributeId.uid(), indexRange, QualifiedName.NULL_VALUE);
+  }
+
+  private static WriteValue writeRequest(NodeId nodeId, String indexRange, Object value) {
+    return new WriteValue(
+        nodeId,
+        AttributeId.Value.uid(),
+        indexRange,
+        DataValue.valueOnly(new Variant(value)));
+  }
+
+  private static NodeId nodeId(String address) {
+    return NodeId.parse("ns=1;s=[modbus-server]" + address);
+  }
+
+  private void assertArrayMetadata(
+      NodeId nodeId, OpcUaDataType dataType, int[] dimensions) throws Exception {
+    assertEquals(
+        dataType.getNodeId(),
+        readAttribute(nodeId, AttributeId.DataType).getValue().getValue());
+    assertEquals(
+        dimensions.length, readAttribute(nodeId, AttributeId.ValueRank).getValue().getValue());
+
+    UInteger[] expectedDimensions =
+        Arrays.stream(dimensions).mapToObj(Unsigned::uint).toArray(UInteger[]::new);
+    assertArrayEquals(
+        expectedDimensions,
+        (UInteger[])
+            readAttribute(nodeId, AttributeId.ArrayDimensions).getValue().getValue());
+  }
+
+  private void assertScalarMetadata(NodeId nodeId, OpcUaDataType dataType) throws Exception {
+    assertEquals(
+        dataType.getNodeId(),
+        readAttribute(nodeId, AttributeId.DataType).getValue().getValue());
+    assertEquals(-1, readAttribute(nodeId, AttributeId.ValueRank).getValue().getValue());
+    assertNull(readAttribute(nodeId, AttributeId.ArrayDimensions).getValue().getValue());
+  }
+
+  private static void assertValueShape(Object actual, Object expectedElements, int[] dimensions) {
+    if (dimensions.length == 1) {
+      assertEquals(expectedElements.getClass(), actual.getClass());
+      assertArrayEquals((Object[]) expectedElements, (Object[]) actual);
+    } else {
+      Matrix matrix = assertInstanceOf(Matrix.class, actual);
+      assertNotNull(matrix);
+      int[] actualDimensions = matrix.getDimensions();
+      Object actualElements = matrix.getElements();
+      assertNotNull(actualDimensions);
+      assertNotNull(actualElements);
+      assertArrayEquals(dimensions, actualDimensions);
+      assertEquals(expectedElements.getClass(), actualElements.getClass());
+      assertArrayEquals((Object[]) expectedElements, (Object[]) actualElements);
+    }
+  }
+
+  private static void assertGood(StatusCode statusCode) {
+    assertEquals(StatusCode.GOOD, statusCode);
+  }
+
+  private static void assertStatus(long expected, StatusCode actual) {
+    assertEquals(expected, actual.getValue());
+  }
+
+  private byte[] readRegisters(String area, int offset, int quantity) throws Exception {
+    if (area.equals("HR")) {
+      return modbusClient
+          .readHoldingRegisters(0, new ReadHoldingRegistersRequest(offset, quantity))
+          .registers();
+    }
+    if (area.equals("IR")) {
+      return modbusClient
+          .readInputRegisters(0, new ReadInputRegistersRequest(offset, quantity))
+          .registers();
+    }
+    throw new IllegalArgumentException("register area: " + area);
+  }
+
+  private byte[] readBits(String address, int quantity) throws Exception {
+    if (address.startsWith("C")) {
+      return modbusClient.readCoils(0, new ReadCoilsRequest(ARRAY_OFFSET, quantity)).coils();
+    }
+    if (address.startsWith("DI")) {
+      return modbusClient
+          .readDiscreteInputs(0, new ReadDiscreteInputsRequest(ARRAY_OFFSET, quantity))
+          .inputs();
+    }
+    throw new IllegalArgumentException("Boolean address: " + address);
+  }
+
+  private byte[] readModbusArray(String address, int elementCount) throws Exception {
+    if (address.startsWith("C") || address.startsWith("DI")) {
+      return readBits(address, elementCount);
+    }
+    return readRegisters(address.substring(0, 2), ARRAY_OFFSET, elementCount);
+  }
+
+  private static Stream<RegisterArrayCase> registerArrayCases() {
+    int[][] dimensions = {{2}, {2, 2}, {2, 1, 2}};
+    List<RegisterArrayCase> cases = new ArrayList<>();
+
+    for (String area : List.of("HR", "IR")) {
+      for (RegisterType type : registerTypes()) {
+        for (int[] shape : dimensions) {
+          int elementCount = Arrays.stream(shape).reduce(1, Math::multiplyExact);
+          Object elements = repeatElements(type.seedElements(), elementCount);
+          Object value =
+              shape.length == 1
+                  ? elements
+                  : new Matrix(elements, shape, type.dataType());
+          byte[] registers = repeatBytes(type.encodedSeed(), elementCount / 2);
+          String address =
+              area + "<" + type.syntax() + formatDimensions(shape) + ">" + ARRAY_OFFSET;
+          String caseName = area + " " + type.syntax() + " rank " + shape.length;
+
+          cases.add(
+              new RegisterArrayCase(
+                  caseName,
+                  address,
+                  type.dataType(),
+                  shape,
+                  value,
+                  elements,
+                  registers));
+        }
+      }
+    }
+
+    return cases.stream();
+  }
+
+  private static List<RegisterType> registerTypes() {
+    return List.of(
+        new RegisterType(
+            "int16",
+            OpcUaDataType.Int16,
+            shorts(0x1234, (short) 0xFEDC),
+            hex("1234 FEDC")),
+        new RegisterType(
+            "uint16",
+            OpcUaDataType.UInt16,
+            new UShort[] {ushort(0x1234), ushort(0xFEDC)},
+            hex("1234 FEDC")),
+        new RegisterType(
+            "int32",
+            OpcUaDataType.Int32,
+            new Integer[] {0x12345678, 0x90ABCDEF},
+            hex("12345678 90ABCDEF")),
+        new RegisterType(
+            "uint32",
+            OpcUaDataType.UInt32,
+            new UInteger[] {uint(0x12345678L), uint(0x90ABCDEFL)},
+            hex("12345678 90ABCDEF")),
+        new RegisterType(
+            "int64",
+            OpcUaDataType.Int64,
+            new Long[] {0x0123456789ABCDEFL, 0xFEDCBA9876543210L},
+            hex("0123456789ABCDEF FEDCBA9876543210")),
+        new RegisterType(
+            "uint64",
+            OpcUaDataType.UInt64,
+            new ULong[] {
+              ulong(0x0123456789ABCDEFL), ulong(0xFEDCBA9876543210L)
+            },
+            hex("0123456789ABCDEF FEDCBA9876543210")),
+        new RegisterType(
+            "float",
+            OpcUaDataType.Float,
+            new Float[] {1.25f, -2.5f},
+            hex("3FA00000 C0200000")),
+        new RegisterType(
+            "double",
+            OpcUaDataType.Double,
+            new Double[] {1.25, -2.5},
+            hex("3FF4000000000000 C004000000000000")),
+        new RegisterType(
+            "string8",
+            OpcUaDataType.String,
+            new String[] {"ABCD", "WXYZ"},
+            hex("4142434400000000 5758595A00000000")));
+  }
+
+  private static Stream<ArrayMetadataCase> arrayMetadataCases() {
+    return Stream.of(
+        metadataCase("HR int16 rank 1", "HR", "int16", OpcUaDataType.Int16, 2),
+        metadataCase("IR uint16 rank 2", "IR", "uint16", OpcUaDataType.UInt16, 2, 2),
+        metadataCase("HR int32 rank 3", "HR", "int32", OpcUaDataType.Int32, 2, 1, 2),
+        metadataCase("IR uint32 rank 1", "IR", "uint32", OpcUaDataType.UInt32, 2),
+        metadataCase("HR int64 rank 2", "HR", "int64", OpcUaDataType.Int64, 2, 2),
+        metadataCase("IR uint64 rank 3", "IR", "uint64", OpcUaDataType.UInt64, 2, 1, 2),
+        metadataCase("HR float rank 1", "HR", "float", OpcUaDataType.Float, 2),
+        metadataCase("IR double rank 2", "IR", "double", OpcUaDataType.Double, 2, 2),
+        metadataCase("HR string rank 3", "HR", "string8", OpcUaDataType.String, 2, 1, 2),
+        metadataCase("C Boolean rank 1", "C", "bool", OpcUaDataType.Boolean, 2),
+        metadataCase("DI Boolean rank 2", "DI", "bool", OpcUaDataType.Boolean, 2, 2),
+        metadataCase("C Boolean rank 3", "C", "bool", OpcUaDataType.Boolean, 2, 1, 2));
+  }
+
+  private static ArrayMetadataCase metadataCase(
+      String name,
+      String area,
+      String syntax,
+      OpcUaDataType dataType,
+      int... dimensions) {
+
+    String address = area + "<" + syntax + formatDimensions(dimensions) + ">" + ARRAY_OFFSET;
+    return new ArrayMetadataCase(name, address, dataType, dimensions);
+  }
+
+  private static Stream<BooleanArrayCase> booleanArrayCases() {
+    int[][] dimensions = {{2}, {2, 2}, {2, 1, 2}};
+    List<BooleanArrayCase> cases = new ArrayList<>();
+
+    for (String area : List.of("C", "DI")) {
+      for (int[] shape : dimensions) {
+        int elementCount = Arrays.stream(shape).reduce(1, Math::multiplyExact);
+        Boolean[] elements =
+            (Boolean[]) repeatElements(new Boolean[] {true, false}, elementCount);
+        Object value =
+            shape.length == 1
+                ? elements
+                : new Matrix(elements, shape, OpcUaDataType.Boolean);
+        String address = area + "<bool" + formatDimensions(shape) + ">" + ARRAY_OFFSET;
+        cases.add(
+            new BooleanArrayCase(
+                area + " bool rank " + shape.length,
+                address,
+                shape,
+                value,
+                elements,
+                packBooleans(elements)));
+      }
+    }
+
+    return cases.stream();
+  }
+
+  private static Stream<RegisterModifierCase> registerModifierCases() {
+    Integer[] values = {0x12345678, 0x90ABCDEF};
+    return Stream.of(
+        new RegisterModifierCase(
+            "HR @LE", "HR<int32[2]@LE>" + ARRAY_OFFSET, values, hex("78563412 EFCDAB90")),
+        new RegisterModifierCase(
+            "HR @LH", "HR<int32[2]@LH>" + ARRAY_OFFSET, values, hex("56781234 CDEF90AB")),
+        new RegisterModifierCase(
+            "HR @LE@LH",
+            "HR<int32[2]@LE@LH>" + ARRAY_OFFSET,
+            values,
+            hex("34127856 AB90EFCD")),
+        new RegisterModifierCase(
+            "IR @LE", "IR<int32[2]@LE>" + ARRAY_OFFSET, values, hex("78563412 EFCDAB90")),
+        new RegisterModifierCase(
+            "IR @LH", "IR<int32[2]@LH>" + ARRAY_OFFSET, values, hex("56781234 CDEF90AB")),
+        new RegisterModifierCase(
+            "IR @LE@LH",
+            "IR<int32[2]@LE@LH>" + ARRAY_OFFSET,
+            values,
+            hex("34127856 AB90EFCD")));
+  }
+
+  private static Stream<IndexedMetadataCase> indexedMetadataCases() {
+    return Stream.of(
+        new IndexedMetadataCase(
+            "indexed register element",
+            "HR<int32[2][3]>" + ARRAY_OFFSET + "[1][2]",
+            OpcUaDataType.Int32),
+        new IndexedMetadataCase(
+            "indexed Boolean element",
+            "C<bool[2][2][2]>" + ARRAY_OFFSET + "[1][0][1]",
+            OpcUaDataType.Boolean));
+  }
+
+  private static Stream<OneDimensionalRangeCase> oneDimensionalRangeCases() {
+    Boolean[] booleans = {true, false, true, false, true, false};
+    Boolean[] booleanSlice = {true, false, true};
+    Boolean[] booleanUpdate = {true, true};
+    Boolean[] expectedBooleans = {true, true, true, false, true, false};
+    Short[] registers = shorts(0, 1, 2, 3, 4, 5);
+    Short[] registerSlice = shorts(2, 3, 4);
+    Short[] registerUpdate = shorts(20, 30);
+    Short[] expectedRegisters = shorts(0, 20, 30, 3, 4, 5);
+
+    return Stream.of(
+        new OneDimensionalRangeCase(
+            "C range",
+            "C<bool[6]>" + ARRAY_OFFSET,
+            booleans,
+            booleanSlice,
+            booleanUpdate,
+            expectedBooleans,
+            packBooleans(expectedBooleans)),
+        new OneDimensionalRangeCase(
+            "DI range",
+            "DI<bool[6]>" + ARRAY_OFFSET,
+            booleans,
+            booleanSlice,
+            booleanUpdate,
+            expectedBooleans,
+            packBooleans(expectedBooleans)),
+        new OneDimensionalRangeCase(
+            "HR range",
+            "HR<int16[6]>" + ARRAY_OFFSET,
+            registers,
+            registerSlice,
+            registerUpdate,
+            expectedRegisters,
+            hex("0000 0014 001E 0003 0004 0005")),
+        new OneDimensionalRangeCase(
+            "IR range",
+            "IR<int16[6]>" + ARRAY_OFFSET,
+            registers,
+            registerSlice,
+            registerUpdate,
+            expectedRegisters,
+            hex("0000 0014 001E 0003 0004 0005")));
+  }
+
+  private static Stream<TwoDimensionalRangeCase> twoDimensionalRangeCases() {
+    Boolean[] booleans = {true, false, true, false, true, false, true, false, true};
+    Boolean[] booleanSlice = {false, true, true, false};
+    Boolean[] booleanUpdate = {true, true, false, false};
+    Boolean[] expectedBooleans = {true, true, true, false, false, false, true, false, true};
+    Short[] registers = shorts(0, 1, 2, 3, 4, 5, 6, 7, 8);
+    Short[] registerSlice = shorts(3, 4, 6, 7);
+    Short[] registerUpdate = shorts(20, 21, 30, 31);
+    Short[] expectedRegisters = shorts(0, 20, 21, 3, 30, 31, 6, 7, 8);
+
+    return Stream.of(
+        new TwoDimensionalRangeCase(
+            "C matrix range",
+            "C<bool[3][3]>" + ARRAY_OFFSET,
+            booleans,
+            OpcUaDataType.Boolean,
+            booleanSlice,
+            booleanUpdate,
+            expectedBooleans,
+            packBooleans(expectedBooleans)),
+        new TwoDimensionalRangeCase(
+            "DI matrix range",
+            "DI<bool[3][3]>" + ARRAY_OFFSET,
+            booleans,
+            OpcUaDataType.Boolean,
+            booleanSlice,
+            booleanUpdate,
+            expectedBooleans,
+            packBooleans(expectedBooleans)),
+        new TwoDimensionalRangeCase(
+            "HR matrix range",
+            "HR<int16[3][3]>" + ARRAY_OFFSET,
+            registers,
+            OpcUaDataType.Int16,
+            registerSlice,
+            registerUpdate,
+            expectedRegisters,
+            hex("0000 0014 0015 0003 001E 001F 0006 0007 0008")),
+        new TwoDimensionalRangeCase(
+            "IR matrix range",
+            "IR<int16[3][3]>" + ARRAY_OFFSET,
+            registers,
+            OpcUaDataType.Int16,
+            registerSlice,
+            registerUpdate,
+            expectedRegisters,
+            hex("0000 0014 0015 0003 001E 001F 0006 0007 0008")));
+  }
+
+  private static Stream<InvalidRangeCase> invalidReadRangeCases() {
+    return Stream.of(
+        new InvalidRangeCase(
+            "malformed read range", "1::2", null, StatusCodes.Bad_IndexRangeInvalid),
+        new InvalidRangeCase(
+            "out-of-bounds read range", "99", null, StatusCodes.Bad_IndexRangeNoData));
+  }
+
+  private static Stream<InvalidRangeCase> invalidWriteRangeCases() {
+    return Stream.of(
+        new InvalidRangeCase(
+            "malformed write range",
+            "1::2",
+            new Short[] {9, 9},
+            StatusCodes.Bad_IndexRangeInvalid),
+        new InvalidRangeCase(
+            "write value does not fill range",
+            "2:4",
+            new Short[] {9, 9},
+            StatusCodes.Bad_IndexRangeNoData));
+  }
+
+  private static Stream<String> registerAreas() {
+    return Stream.of("HR", "IR");
+  }
+
+  private static Stream<String> invalidArrayAddresses() {
+    return Stream.of(
+        "HR<int16[37]>65500",
+        "HR<int64[99999][99999][99999]>0",
+        "HR<int16[10]>0.5",
+        "HR0[5]",
+        "HR<int16[2]>0[2]",
+        "HR<int16@LE[2]>0");
+  }
+
+  private static Object repeatElements(Object seedElements, int elementCount) {
+    int seedLength = Array.getLength(seedElements);
+    Object elements =
+        Array.newInstance(seedElements.getClass().getComponentType(), elementCount);
+    for (int i = 0; i < elementCount; i++) {
+      Array.set(elements, i, Array.get(seedElements, i % seedLength));
+    }
+    return elements;
+  }
+
+  private static byte[] repeatBytes(byte[] seed, int repetitions) {
+    byte[] bytes = new byte[seed.length * repetitions];
+    for (int i = 0; i < repetitions; i++) {
+      System.arraycopy(seed, 0, bytes, i * seed.length, seed.length);
+    }
+    return bytes;
+  }
+
+  private static String formatDimensions(int[] dimensions) {
+    StringBuilder builder = new StringBuilder();
+    for (int dimension : dimensions) {
+      builder.append('[').append(dimension).append(']');
+    }
+    return builder.toString();
+  }
+
+  private static byte[] packBooleans(Boolean[] values) {
+    byte[] bytes = new byte[(values.length + 7) / 8];
+    for (int i = 0; i < values.length; i++) {
+      if (values[i]) {
+        bytes[i / 8] |= (byte) (1 << (i % 8));
+      }
+    }
+    return bytes;
+  }
+
+  private static Short[] shorts(int... values) {
+    Short[] shorts = new Short[values.length];
+    for (int i = 0; i < values.length; i++) {
+      shorts[i] = (short) values[i];
+    }
+    return shorts;
+  }
+
+  private static byte[] hex(String value) {
+    return HexFormat.of().parseHex(value.replace(" ", ""));
+  }
+
+  private record RegisterArrayCase(
+      String name,
+      String address,
+      OpcUaDataType dataType,
+      int[] dimensions,
+      Object value,
+      Object expectedElements,
+      byte[] expectedRegisters) {
+
+    @Override
+    @NotNull
+    public String toString() {
+      return name;
+    }
+  }
+
+  private record BooleanArrayCase(
+      String name,
+      String address,
+      int[] dimensions,
+      Object value,
+      Boolean[] expectedElements,
+      byte[] expectedBits) {
+
+    @Override
+    @NotNull
+    public String toString() {
+      return name;
+    }
+  }
+
+  private record ArrayMetadataCase(
+      String name, String address, OpcUaDataType dataType, int[] dimensions) {
+
+    @Override
+    @NotNull
+    public String toString() {
+      return name;
+    }
+  }
+
+  private record RegisterModifierCase(
+      String name, String address, Object value, byte[] expectedRegisters) {
+
+    @Override
+    @NotNull
+    public String toString() {
+      return name;
+    }
+  }
+
+  private record IndexedMetadataCase(String name, String address, OpcUaDataType dataType) {
+
+    @Override
+    @NotNull
+    public String toString() {
+      return name;
+    }
+  }
+
+  private record OneDimensionalRangeCase(
+      String name,
+      String address,
+      Object initial,
+      Object expectedSlice,
+      Object update,
+      Object expectedFullValue,
+      byte[] expectedModbusValue) {
+
+    @Override
+    @NotNull
+    public String toString() {
+      return name;
+    }
+  }
+
+  private record TwoDimensionalRangeCase(
+      String name,
+      String address,
+      Object initialElements,
+      OpcUaDataType dataType,
+      Object expectedSliceElements,
+      Object updateElements,
+      Object expectedFullElements,
+      byte[] expectedModbusValue) {
+
+    @Override
+    @NotNull
+    public String toString() {
+      return name;
+    }
+  }
+
+  private record InvalidRangeCase(
+      String name, String indexRange, Object writeValue, long expectedStatus) {
+
+    @Override
+    @NotNull
+    public String toString() {
+      return name;
+    }
+  }
+
+  private record RegisterType(
+      String syntax, OpcUaDataType dataType, Object seedElements, byte[] encodedSeed) {}
+}

--- a/msd-gateway/pom.xml
+++ b/msd-gateway/pom.xml
@@ -68,6 +68,12 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
@@ -207,14 +207,30 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
 
     return switch (area) {
       case COILS -> {
-        boolean value = device.processImage.get(tx -> readCoil(tx, address));
+        if (address instanceof ModbusAddress.ArrayAddress array) {
+          boolean[] values = device.processImage.get(tx -> readCoilArray(tx, array));
 
-        yield new Variant(value);
+          yield new Variant(values);
+        } else if (address instanceof ModbusAddress.ScalarAddress scalar) {
+          boolean value = device.processImage.get(tx -> readCoil(tx, scalar));
+
+          yield new Variant(value);
+        } else {
+          throw new IllegalArgumentException("address: " + address);
+        }
       }
       case DISCRETE_INPUTS -> {
-        boolean value = device.processImage.get(tx -> readDiscreteInput(tx, address));
+        if (address instanceof ModbusAddress.ArrayAddress array) {
+          boolean[] values = device.processImage.get(tx -> readDiscreteInputArray(tx, array));
 
-        yield new Variant(value);
+          yield new Variant(values);
+        } else if (address instanceof ModbusAddress.ScalarAddress scalar) {
+          boolean value = device.processImage.get(tx -> readDiscreteInput(tx, scalar));
+
+          yield new Variant(value);
+        } else {
+          throw new IllegalArgumentException("address: " + address);
+        }
       }
       case HOLDING_REGISTERS -> {
         byte[] bs = device.processImage.get(tx -> readHoldingRegisters(tx, address));
@@ -229,13 +245,37 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     };
   }
 
-  private static boolean readCoil(Transaction tx, ModbusAddress address) {
+  private static boolean readCoil(Transaction tx, ScalarAddress address) {
     return tx.readCoils(coilMap -> coilMap.getOrDefault(address.getOffset(), false));
   }
 
-  private static boolean readDiscreteInput(Transaction tx, ModbusAddress address) {
+  private static boolean readDiscreteInput(Transaction tx, ScalarAddress address) {
     return tx.readDiscreteInputs(
         discreteInputMap -> discreteInputMap.getOrDefault(address.getOffset(), false));
+  }
+
+  private static boolean[] readCoilArray(Transaction tx, ArrayAddress address) {
+    return tx.readCoils(coils -> readBooleans(coils, address));
+  }
+
+  private static boolean[] readDiscreteInputArray(Transaction tx, ArrayAddress address) {
+    return tx.readDiscreteInputs(inputs -> readBooleans(inputs, address));
+  }
+
+  static boolean[] readBooleans(Map<Integer, Boolean> booleans, ArrayAddress address) {
+    int totalElements = 1;
+    for (int dimension : address.getDimensions()) {
+      totalElements *= dimension;
+    }
+
+    boolean[] values = new boolean[totalElements];
+
+    for (int elementIndex = 0; elementIndex < totalElements; elementIndex++) {
+      int elementOffset = address.getOffset() + elementIndex;
+      values[elementIndex] = booleans.getOrDefault(elementOffset, false);
+    }
+
+    return values;
   }
 
   private static byte[] readHoldingRegisters(Transaction tx, ModbusAddress address) {

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
@@ -1043,13 +1043,7 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       id = id.substring(deviceName.length() + 2);
 
       logger.trace("checking {}", id);
-      try {
-        ModbusAddress address = ModbusAddressParser.parse(id);
-
-        return true;
-      } catch (Exception e) {
-        return false;
-      }
+      return ModbusAddressParser.isValidAddress(id);
     }
   }
 }

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
@@ -13,6 +13,7 @@ import com.digitalpetri.modbus.server.ProcessImage.Transaction;
 import com.inductiveautomation.ignition.gateway.opcua.server.api.OpcUa;
 import com.kevinherron.ignition.modbus.address.ModbusAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddress.ModbusArea;
+import com.kevinherron.ignition.modbus.address.ModbusAddress.ScalarAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddressParser;
 import com.kevinherron.ignition.modbus.address.ModbusDataType;
 import com.kevinherron.ignition.modbus.util.ModbusByteUtil;
@@ -890,8 +891,10 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
 
       logger.trace("checking {}", id);
       try {
-        ModbusAddressParser.parse(id);
-        return true;
+        ModbusAddress address = ModbusAddressParser.parse(id);
+
+        // TODO support array addresses
+        return address instanceof ScalarAddress;
       } catch (Exception e) {
         return false;
       }

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
@@ -435,21 +435,35 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
   private void writeValueAttribute(ModbusAddress address, Variant variant) throws UaException {
     switch (address.getArea()) {
       case COILS -> {
-        if (variant.getValue() instanceof Boolean b) {
-          device.processImage.with(
-              tx -> tx.writeCoils(coilMap -> coilMap.put(address.getOffset(), b)));
+        if (address instanceof ModbusAddress.ArrayAddress array) {
+          // TODO
+          throw new UaException(StatusCodes.Bad_NotImplemented);
+        } else if (address instanceof ModbusAddress.ScalarAddress scalar) {
+          if (variant.getValue() instanceof Boolean b) {
+            device.processImage.with(
+                tx -> tx.writeCoils(coilMap -> coilMap.put(scalar.getOffset(), b)));
+          } else {
+            throw new UaException(StatusCodes.Bad_TypeMismatch);
+          }
         } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
+          throw new IllegalArgumentException("address: " + address);
         }
       }
       case DISCRETE_INPUTS -> {
-        if (variant.getValue() instanceof Boolean b) {
-          device.processImage.with(
-              tx ->
-                  tx.writeDiscreteInputs(
-                      discreteInputMap -> discreteInputMap.put(address.getOffset(), b)));
+        if (address instanceof ModbusAddress.ArrayAddress array) {
+          // TODO
+          throw new UaException(StatusCodes.Bad_NotImplemented);
+        } else if (address instanceof ModbusAddress.ScalarAddress scalar) {
+          if (variant.getValue() instanceof Boolean b) {
+            device.processImage.with(
+                tx ->
+                    tx.writeDiscreteInputs(
+                        discreteInputMap -> discreteInputMap.put(scalar.getOffset(), b)));
+          } else {
+            throw new UaException(StatusCodes.Bad_TypeMismatch);
+          }
         } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
+          throw new IllegalArgumentException("address: " + address);
         }
       }
       case HOLDING_REGISTERS -> {
@@ -564,7 +578,7 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
           v &= ~mask;
         }
         byte[] newBytes =
-            ModbusByteUtil.getBytesForValue(
+            ModbusByteUtil.getBytesForScalarValue(
                 castToUnderlying(v, underlyingType),
                 underlyingType,
                 address.getDataTypeModifiers());

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
@@ -553,7 +553,7 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     }
   }
 
-  private static void writeBooleanArray(
+  static void writeBooleanArray(
       Map<Integer, Boolean> booleanMap, Variant variant, ArrayAddress array) throws UaException {
 
     int[] dimensions = array.getDimensions();

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
@@ -21,11 +21,13 @@ import java.io.IOException;
 import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -191,6 +193,17 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
         } else {
           try {
             Variant v = readNonValueAttribute(readValueId.getNodeId(), attributeId, address);
+            String indexRange = readValueId.getIndexRange();
+            if (indexRange != null && !indexRange.isEmpty()) {
+              // OPC UA Part 4: an IndexRange applies to any attribute; non-array attributes
+              // must return Bad_IndexRangeNoData rather than the full value.
+              NumericRange range = parseNumericRange(indexRange);
+              Object value = v.getValue();
+              if (value == null) {
+                throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+              }
+              v = new Variant(readValueAtRange(value, range));
+            }
             pending.value = new DataValue(v);
           } catch (UaException e) {
             pending.value = new DataValue(e.getStatusCode());
@@ -213,24 +226,48 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
   }
 
   static List<DataValue> readValueAttributes(ProcessImage processImage, List<ValueRead> reads) {
-
-    var values = new ArrayList<DataValue>(reads.size());
-    for (ValueRead read : reads) {
-      try {
-        values.add(
-            new DataValue(readValueAttribute(processImage, read.address(), read.indexRange())));
-      } catch (UaException e) {
-        values.add(new DataValue(e.getStatusCode()));
-      } catch (RuntimeException e) {
-        logger.error("Error reading value: address={}", read.address(), e);
-        values.add(new DataValue(StatusCodes.Bad_InternalError));
-      }
+    if (reads.isEmpty()) {
+      return List.of();
     }
-    return values;
+
+    // One transaction for the whole batch: a single lock acquisition and a consistent
+    // snapshot across items.
+    return processImage.get(
+        tx -> {
+          var values = new ArrayList<DataValue>(reads.size());
+          for (ValueRead read : reads) {
+            try {
+              values.add(new DataValue(readValueAttribute(tx, read.address(), read.indexRange())));
+            } catch (UaException e) {
+              values.add(new DataValue(e.getStatusCode()));
+            } catch (RuntimeException e) {
+              logger.error("Error reading value: address={}", read.address(), e);
+              values.add(new DataValue(StatusCodes.Bad_InternalError));
+            }
+          }
+          return values;
+        });
   }
 
   static Variant readValueAttribute(
       ProcessImage processImage, ModbusAddress address, String indexRange) throws UaException {
+
+    try {
+      return processImage.get(
+          tx -> {
+            try {
+              return readValueAttribute(tx, address, indexRange);
+            } catch (UaException e) {
+              throw new UaRuntimeException(e);
+            }
+          });
+    } catch (UaRuntimeException e) {
+      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_InternalError, e));
+    }
+  }
+
+  private static Variant readValueAttribute(
+      Transaction tx, ModbusAddress address, String indexRange) throws UaException {
 
     NumericRange range = null;
     if (indexRange != null && !indexRange.isEmpty()) {
@@ -240,21 +277,33 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
           && !(address.getDataType() instanceof ModbusDataType.String)) {
         throw new UaException(StatusCodes.Bad_IndexRangeNoData);
       }
+      if (address instanceof ArrayAddress array) {
+        // Read only the slices selected by the range's first dimension instead of decoding
+        // the whole array; the remaining dimensions are applied to the sub-array below.
+        NumericRange.Bounds bounds = range.getBounds()[0];
+        if (bounds.getHigh() >= array.getDimensions()[0]) {
+          throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+        }
+        address = subArrayAddress(array, bounds);
+        range = rebaseFirstDimension(indexRange, bounds);
+      }
     }
 
-    Variant fullValue =
-        switch (address.getArea()) {
-          case COILS -> readBooleanValue(processImage, address, false);
-          case DISCRETE_INPUTS -> readBooleanValue(processImage, address, true);
-          case HOLDING_REGISTERS -> {
-            byte[] bs = processImage.get(tx -> readHoldingRegisters(tx, address));
+    ModbusAddress readAddress = address;
 
-            yield new Variant(ModbusByteUtil.getValueForBytes(bs, address));
+    Variant fullValue =
+        switch (readAddress.getArea()) {
+          case COILS -> readBooleanValue(tx, readAddress, false);
+          case DISCRETE_INPUTS -> readBooleanValue(tx, readAddress, true);
+          case HOLDING_REGISTERS -> {
+            byte[] bs = readHoldingRegisters(tx, readAddress);
+
+            yield new Variant(ModbusByteUtil.getValueForBytes(bs, readAddress));
           }
           case INPUT_REGISTERS -> {
-            byte[] bs = processImage.get(tx -> readInputRegisters(tx, address));
+            byte[] bs = readInputRegisters(tx, readAddress);
 
-            yield new Variant(ModbusByteUtil.getValueForBytes(bs, address));
+            yield new Variant(ModbusByteUtil.getValueForBytes(bs, readAddress));
           }
         };
 
@@ -264,25 +313,67 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     return fullValue;
   }
 
+  /** Narrow {@code array} to the slices of its first dimension selected by {@code bounds}. */
+  private static ArrayAddress subArrayAddress(ArrayAddress array, NumericRange.Bounds bounds) {
+    int[] dimensions = array.getDimensions().clone();
+    dimensions[0] = bounds.getHigh() - bounds.getLow() + 1;
+
+    int offsetShift = bounds.getLow() * firstDimensionSliceSize(array) * entriesPerElement(array);
+
+    return new ArrayAddress(
+        array.getUnitId().orElse(null),
+        array.getArea(),
+        array.getOffset() + offsetShift,
+        array.getDataType(),
+        array.getDataTypeModifiers(),
+        dimensions);
+  }
+
+  /** Rewrite {@code indexRange} so its first dimension is relative to the sub-array read. */
+  private static NumericRange rebaseFirstDimension(String indexRange, NumericRange.Bounds bounds)
+      throws UaException {
+
+    String first =
+        bounds.getLow() == bounds.getHigh()
+            ? "0"
+            : "0:%d".formatted(bounds.getHigh() - bounds.getLow());
+    int comma = indexRange.indexOf(',');
+    return parseNumericRange(comma < 0 ? first : first + indexRange.substring(comma));
+  }
+
+  /** Number of elements in one slice of the array's first dimension. */
+  private static int firstDimensionSliceSize(ArrayAddress array) {
+    int[] dimensions = array.getDimensions();
+    int sliceSize = 1;
+    for (int i = 1; i < dimensions.length; i++) {
+      sliceSize *= dimensions[i];
+    }
+    return sliceSize;
+  }
+
+  /** Coils and discrete inputs store one entry per element; register areas store registers. */
+  private static int entriesPerElement(ModbusAddress address) {
+    return switch (address.getArea()) {
+      case COILS, DISCRETE_INPUTS -> 1;
+      case HOLDING_REGISTERS, INPUT_REGISTERS -> address.getDataType().getRegisterCount();
+    };
+  }
+
   private static Variant readBooleanValue(
-      ProcessImage processImage, ModbusAddress address, boolean discreteInputs) {
+      Transaction tx, ModbusAddress address, boolean discreteInputs) {
 
     if (address instanceof ArrayAddress array) {
       boolean[] values =
-          processImage.get(
-              tx ->
-                  discreteInputs
-                      ? tx.readDiscreteInputs(map -> readBooleans(map, array))
-                      : tx.readCoils(map -> readBooleans(map, array)));
+          discreteInputs
+              ? tx.readDiscreteInputs(map -> readBooleans(map, array))
+              : tx.readCoils(map -> readBooleans(map, array));
 
       return new Variant(shapeBooleanArray(values, array));
     } else if (address instanceof ScalarAddress scalar) {
       boolean value =
-          processImage.get(
-              tx ->
-                  discreteInputs
-                      ? tx.readDiscreteInputs(map -> map.getOrDefault(scalar.getOffset(), false))
-                      : tx.readCoils(map -> map.getOrDefault(scalar.getOffset(), false)));
+          discreteInputs
+              ? tx.readDiscreteInputs(map -> map.getOrDefault(scalar.getOffset(), false))
+              : tx.readCoils(map -> map.getOrDefault(scalar.getOffset(), false));
 
       return new Variant(value);
     } else {
@@ -472,21 +563,30 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
   }
 
   static List<StatusCode> writeValueAttributes(ProcessImage processImage, List<ValueWrite> writes) {
-
-    var statuses = new ArrayList<StatusCode>(writes.size());
-    for (ValueWrite write : writes) {
-      try {
-        writeValueAttribute(processImage, write.address(), write.variant(), write.indexRange());
-        statuses.add(StatusCode.GOOD);
-      } catch (UaException e) {
-        statuses.add(e.getStatusCode());
-      } catch (RuntimeException e) {
-        statuses.add(
-            UaException.extract(e)
-                .map(UaException::getStatusCode)
-                .orElse(new StatusCode(StatusCodes.Bad_InternalError)));
-      }
+    if (writes.isEmpty()) {
+      return List.of();
     }
+
+    // One transaction for the whole batch: a single lock acquisition instead of one per item.
+    var statuses = new ArrayList<StatusCode>(writes.size());
+    processImage.with(
+        tx -> {
+          for (ValueWrite write : writes) {
+            try {
+              writeValueAttribute(tx, write.address(), write.variant(), write.indexRange());
+              statuses.add(StatusCode.GOOD);
+            } catch (Exception e) {
+              statuses.add(
+                  UaException.extract(e)
+                      .map(UaException::getStatusCode)
+                      .orElseGet(
+                          () -> {
+                            logger.error("Error writing value: address={}", write.address(), e);
+                            return new StatusCode(StatusCodes.Bad_InternalError);
+                          }));
+            }
+          }
+        });
     return statuses;
   }
 
@@ -497,7 +597,12 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     try {
       processImage.with(tx -> writeValueAttribute(tx, address, variant, indexRange));
     } catch (Exception e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_InternalError));
+      throw UaException.extract(e)
+          .orElseGet(
+              () -> {
+                logger.error("Error writing value: address={}", address, e);
+                return new UaException(StatusCodes.Bad_InternalError, e);
+              });
     }
   }
 
@@ -527,14 +632,13 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
    * range is present.
    */
   private static Variant resolveWriteValue(
-      ModbusAddress address, Variant variant, String indexRange, CurrentValueReader currentValue)
+      ModbusAddress address, Variant variant, NumericRange range, CurrentValueReader currentValue)
       throws UaException {
 
-    if (indexRange == null || indexRange.isEmpty()) {
+    if (range == null) {
       return variant;
     }
 
-    NumericRange range = parseNumericRange(indexRange);
     // Arrays support element ranges; scalar String values support sub-string ranges.
     boolean rangeSupported =
         address instanceof ArrayAddress || address.getDataType() instanceof ModbusDataType.String;
@@ -554,20 +658,37 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       Map<Integer, Boolean> booleanMap, ModbusAddress address, Variant variant, String indexRange) {
 
     try {
+      NumericRange range =
+          indexRange == null || indexRange.isEmpty() ? null : parseNumericRange(indexRange);
+
       Variant fullVariant =
           resolveWriteValue(
               address,
               variant,
-              indexRange,
+              range,
               addr -> {
                 // Only ArrayAddress reaches here: scalar coils are Bool, so
                 // resolveWriteValue rejects their index-range writes.
                 ArrayAddress array = (ArrayAddress) addr;
-                return shapeBooleanArray(readBooleans(booleanMap, array), array);
+                // Copy the extent out of the transaction-scoped map first: its element
+                // lookups are O(map size).
+                Map<Integer, Boolean> current =
+                    copyRange(booleanMap, array.getOffset(), array.getElementCount());
+                return shapeBooleanArray(readBooleans(current, array), array);
               });
 
       if (address instanceof ArrayAddress array) {
-        writeBooleanArray(booleanMap, fullVariant, array);
+        int firstElement = 0;
+        int elementLimit = array.getElementCount();
+        if (range != null) {
+          // A ranged write must leave elements outside the selected first-dimension
+          // slices untouched.
+          int sliceSize = firstDimensionSliceSize(array);
+          NumericRange.Bounds bounds = range.getBounds()[0];
+          firstElement = bounds.getLow() * sliceSize;
+          elementLimit = Math.min((bounds.getHigh() + 1) * sliceSize, elementLimit);
+        }
+        writeBooleanArray(booleanMap, fullVariant, array, firstElement, elementLimit);
       } else if (address instanceof ScalarAddress scalar) {
         if (fullVariant.getValue() instanceof Boolean b) {
           booleanMap.put(scalar.getOffset(), b);
@@ -586,24 +707,109 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       Map<Integer, byte[]> registerMap, ModbusAddress address, Variant variant, String indexRange) {
 
     try {
+      NumericRange range =
+          indexRange == null || indexRange.isEmpty() ? null : parseNumericRange(indexRange);
+
       Variant fullVariant =
           resolveWriteValue(
               address,
               variant,
-              indexRange,
-              addr -> ModbusByteUtil.getValueForBytes(readRegisters(registerMap, addr), addr));
+              range,
+              addr -> {
+                // Copy the extent out of the transaction-scoped map first: its element
+                // lookups are O(map size).
+                Map<Integer, byte[]> current =
+                    copyRange(registerMap, addr.getOffset(), registerExtent(addr));
+                return ModbusByteUtil.getValueForBytes(readRegisters(current, addr), addr);
+              });
+
+      if (range != null
+          && address.getDataType() instanceof ModbusDataType.String
+          && isSubStringRange(address, range)) {
+        validateMergedStringByteCapacity(fullVariant.getValue(), address, range);
+      }
 
       if (address.getDataType() instanceof ModbusDataType.Bit dataType) {
         writeBitToRegister(address, fullVariant, dataType, registerMap);
       } else {
         byte[] registers = getRegisterWriteBytes(address, fullVariant);
-        for (int i = 0; i < registers.length / 2; i++) {
+        int firstRegister = 0;
+        int registerLimit = registers.length / 2;
+        if (range != null && address instanceof ArrayAddress array) {
+          // A ranged write must leave registers outside the selected first-dimension
+          // slices untouched: the merge round-trip is lossy for String and Bool elements.
+          int registersPerSlice =
+              firstDimensionSliceSize(array) * array.getDataType().getRegisterCount();
+          NumericRange.Bounds bounds = range.getBounds()[0];
+          firstRegister = bounds.getLow() * registersPerSlice;
+          registerLimit = Math.min((bounds.getHigh() + 1) * registersPerSlice, registerLimit);
+        }
+        for (int i = firstRegister; i < registerLimit; i++) {
           byte[] value = new byte[] {registers[i * 2], registers[i * 2 + 1]};
           registerMap.put(address.getOffset() + i, value);
         }
       }
     } catch (UaException e) {
       throw new UaRuntimeException(e);
+    }
+  }
+
+  /** Total number of registers spanned by {@code address}. */
+  private static int registerExtent(ModbusAddress address) {
+    int elementCount =
+        address instanceof ArrayAddress arrayAddress ? arrayAddress.getElementCount() : 1;
+    return elementCount * address.getDataType().getRegisterCount();
+  }
+
+  /** Copy the entries in {@code [offset, offset + count)} out of {@code map}. */
+  private static <V> Map<Integer, V> copyRange(Map<Integer, V> map, int offset, int count) {
+    var copy = new HashMap<Integer, V>();
+    for (Map.Entry<Integer, V> entry : map.entrySet()) {
+      int key = entry.getKey();
+      if (key >= offset && key - offset < count) {
+        copy.put(key, entry.getValue());
+      }
+    }
+    return copy;
+  }
+
+  /** An extra final range dimension selects characters within a String element. */
+  private static boolean isSubStringRange(ModbusAddress address, NumericRange range) {
+    int rank = address instanceof ArrayAddress array ? array.getDimensions().length : 0;
+    return range.getBounds().length == rank + 1;
+  }
+
+  /**
+   * Reject sub-string merges whose UTF-8 encoding no longer fits the element's registers;
+   * silently truncating would destroy characters outside the selected range.
+   */
+  private static void validateMergedStringByteCapacity(
+      Object merged, ModbusAddress address, NumericRange range) throws UaException {
+
+    int capacity = address.getDataType().getRegisterCount() * 2;
+
+    Object elements = merged instanceof Matrix matrix ? matrix.getElements() : merged;
+    if (elements instanceof String string) {
+      if (string.getBytes(StandardCharsets.UTF_8).length > capacity) {
+        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
+      }
+      return;
+    }
+
+    int first = 0;
+    int limit = Array.getLength(elements);
+    if (address instanceof ArrayAddress array) {
+      // Only elements in the selected first-dimension slices are written back.
+      int sliceSize = firstDimensionSliceSize(array);
+      NumericRange.Bounds bounds = range.getBounds()[0];
+      first = bounds.getLow() * sliceSize;
+      limit = Math.min((bounds.getHigh() + 1) * sliceSize, limit);
+    }
+    for (int i = first; i < limit; i++) {
+      if (Array.get(elements, i) instanceof String string
+          && string.getBytes(StandardCharsets.UTF_8).length > capacity) {
+        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
+      }
     }
   }
 
@@ -621,34 +827,46 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       currentValue = matrix.nestedArrayValue();
     }
     if (updateValue instanceof Matrix matrix) {
+      if (matrix.isNull()) {
+        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
+      }
       updateValue = matrix.nestedArrayValue();
     }
 
     validateRangeDimensionCount(currentValue, range);
+
+    int[] currentDimensions = ArrayUtil.getDimensions(currentValue);
+    NumericRange.Bounds[] bounds = range.getBounds();
+    // Bounds past the end of the current value select no data; check before the shape
+    // comparisons so the client sees Bad_IndexRangeNoData rather than a shape mismatch.
+    for (int i = 0; i < currentDimensions.length; i++) {
+      if (bounds[i].getHigh() >= currentDimensions[i]) {
+        throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+      }
+    }
 
     if (ArrayUtil.getBoxedType(currentValue) != ArrayUtil.getBoxedType(updateValue)) {
       throw new UaException(StatusCodes.Bad_TypeMismatch);
     }
 
     int[] updateDimensions = ArrayUtil.getDimensions(updateValue);
-    NumericRange.Bounds[] bounds = range.getBounds();
     // For String values an extra final range dimension selects characters within an
     // element, so the update value has one fewer dimension than the range has bounds.
     boolean subStringRange =
-        hasStringLeaf(currentValue)
-            && bounds.length == ArrayUtil.getDimensions(currentValue).length + 1;
-    if (!subStringRange && updateDimensions.length != bounds.length) {
+        hasStringLeaf(currentValue) && bounds.length == currentDimensions.length + 1;
+    int expectedUpdateRank = subStringRange ? bounds.length - 1 : bounds.length;
+    if (updateDimensions.length != expectedUpdateRank) {
       throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
     }
     for (int i = 0; i < updateDimensions.length; i++) {
-      int expectedLength = bounds[i].getHigh() - bounds[i].getLow() + 1;
+      long expectedLength = (long) bounds[i].getHigh() - bounds[i].getLow() + 1;
       if (updateDimensions[i] != expectedLength) {
         throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
       }
     }
     if (subStringRange) {
       NumericRange.Bounds stringBounds = bounds[bounds.length - 1];
-      int expectedLength = stringBounds.getHigh() - stringBounds.getLow() + 1;
+      long expectedLength = (long) stringBounds.getHigh() - stringBounds.getLow() + 1;
       validateStringLengths(updateValue, expectedLength);
     }
 
@@ -683,7 +901,7 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     }
   }
 
-  private static void validateStringLengths(Object value, int expectedLength) throws UaException {
+  private static void validateStringLengths(Object value, long expectedLength) throws UaException {
     if (value == null) {
       throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
     }
@@ -714,6 +932,17 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
   static void writeBooleanArray(
       Map<Integer, Boolean> booleanMap, Variant variant, ArrayAddress array) throws UaException {
 
+    writeBooleanArray(booleanMap, variant, array, 0, array.getElementCount());
+  }
+
+  private static void writeBooleanArray(
+      Map<Integer, Boolean> booleanMap,
+      Variant variant,
+      ArrayAddress array,
+      int firstElement,
+      int elementLimit)
+      throws UaException {
+
     Object value = variant.getValue();
 
     if (array.getDimensions().length > 1) {
@@ -725,13 +954,38 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       value = matrix.getElements();
     }
 
-    if (!(value instanceof Boolean[] booleans) || booleans.length != array.getElementCount()) {
-      throw new UaException(StatusCodes.Bad_TypeMismatch);
-    }
+    Boolean[] booleans = boxedBooleanArray(value, array.getElementCount());
 
-    for (int i = 0; i < booleans.length; i++) {
+    for (int i = firstElement; i < elementLimit; i++) {
       booleanMap.put(array.getOffset() + i, booleans[i]);
     }
+  }
+
+  /**
+   * Accepts boxed or primitive boolean arrays ({@link Matrix} supports both backings) and rejects
+   * null elements, which would poison the process image and NPE on later reads.
+   */
+  private static Boolean[] boxedBooleanArray(Object value, int expectedLength) throws UaException {
+    if (value instanceof boolean[] primitive) {
+      if (primitive.length != expectedLength) {
+        throw new UaException(StatusCodes.Bad_TypeMismatch);
+      }
+      Boolean[] boxed = new Boolean[primitive.length];
+      for (int i = 0; i < primitive.length; i++) {
+        boxed[i] = primitive[i];
+      }
+      return boxed;
+    }
+
+    if (!(value instanceof Boolean[] boxed) || boxed.length != expectedLength) {
+      throw new UaException(StatusCodes.Bad_TypeMismatch);
+    }
+    for (Boolean b : boxed) {
+      if (b == null) {
+        throw new UaException(StatusCodes.Bad_TypeMismatch);
+      }
+    }
+    return boxed;
   }
 
   private static void writeBitToRegister(

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
@@ -634,7 +634,8 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     }
 
     Object underlyingValue =
-        ModbusByteUtil.getValueForBytes(bytes, underlyingType, address.getDataTypeModifiers());
+        ModbusByteUtil.getScalarValueForBytes(
+            bytes, underlyingType, address.getDataTypeModifiers());
 
     if (underlyingValue instanceof Number n) {
       long mask = 1L << bitIndex;
@@ -1045,8 +1046,7 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       try {
         ModbusAddress address = ModbusAddressParser.parse(id);
 
-        // TODO support array addresses
-        return address instanceof ScalarAddress;
+        return true;
       } catch (Exception e) {
         return false;
       }

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
@@ -19,6 +19,7 @@ import com.kevinherron.ignition.modbus.address.ModbusAddressParser;
 import com.kevinherron.ignition.modbus.address.ModbusDataType;
 import com.kevinherron.ignition.modbus.util.ModbusByteUtil;
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -44,8 +45,10 @@ import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.UaRuntimeException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
@@ -436,8 +439,20 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     switch (address.getArea()) {
       case COILS -> {
         if (address instanceof ModbusAddress.ArrayAddress array) {
-          // TODO
-          throw new UaException(StatusCodes.Bad_NotImplemented);
+          try {
+            device.processImage.with(
+                tx ->
+                    tx.writeCoils(
+                        coilMap -> {
+                          try {
+                            writeBooleanArray(coilMap, variant, array);
+                          } catch (UaException e) {
+                            throw new UaRuntimeException(e);
+                          }
+                        }));
+          } catch (Exception e) {
+            throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_InternalError));
+          }
         } else if (address instanceof ModbusAddress.ScalarAddress scalar) {
           if (variant.getValue() instanceof Boolean b) {
             device.processImage.with(
@@ -451,8 +466,20 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       }
       case DISCRETE_INPUTS -> {
         if (address instanceof ModbusAddress.ArrayAddress array) {
-          // TODO
-          throw new UaException(StatusCodes.Bad_NotImplemented);
+          try {
+            device.processImage.with(
+                tx ->
+                    tx.writeDiscreteInputs(
+                        discreteInputMap -> {
+                          try {
+                            writeBooleanArray(discreteInputMap, variant, array);
+                          } catch (UaException e) {
+                            throw new UaRuntimeException(e);
+                          }
+                        }));
+          } catch (Exception e) {
+            throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_InternalError));
+          }
         } else if (address instanceof ModbusAddress.ScalarAddress scalar) {
           if (variant.getValue() instanceof Boolean b) {
             device.processImage.with(
@@ -523,6 +550,47 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
         }
       }
       default -> throw new IllegalArgumentException("area: " + address.getArea());
+    }
+  }
+
+  private static void writeBooleanArray(
+      Map<Integer, Boolean> booleanMap, Variant variant, ArrayAddress array) throws UaException {
+
+    int[] dimensions = array.getDimensions();
+
+    if (dimensions.length == 1) {
+      if (variant.getValue() instanceof Boolean[] booleans) {
+        if (booleans.length == dimensions[0]) {
+          for (int i = 0; i < booleans.length; i++) {
+            booleanMap.put(array.getOffset() + i, booleans[i]);
+          }
+        } else {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      } else {
+        throw new UaException(StatusCodes.Bad_TypeMismatch);
+      }
+    } else {
+      if (variant.getValue() instanceof Matrix matrix) {
+        int totalElements = 1;
+        for (int dimension : array.getDimensions()) {
+          totalElements *= dimension;
+        }
+        Object flatArray = matrix.getElements();
+        int arrayLength = Array.getLength(flatArray);
+
+        if (totalElements != arrayLength) {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+
+        for (int i = 0; i < totalElements; i++) {
+          int elementOffset = array.getOffset() + i;
+          Boolean b = (Boolean) Array.get(flatArray, i);
+          booleanMap.put(elementOffset, b);
+        }
+      } else {
+        throw new UaException(StatusCodes.Bad_TypeMismatch);
+      }
     }
   }
 

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
@@ -12,6 +12,7 @@ import com.digitalpetri.modbus.server.ProcessImage.Modification.InputRegisterMod
 import com.digitalpetri.modbus.server.ProcessImage.Transaction;
 import com.inductiveautomation.ignition.gateway.opcua.server.api.OpcUa;
 import com.kevinherron.ignition.modbus.address.ModbusAddress;
+import com.kevinherron.ignition.modbus.address.ModbusAddress.ArrayAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddress.ModbusArea;
 import com.kevinherron.ignition.modbus.address.ModbusAddress.ScalarAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddressParser;
@@ -163,7 +164,7 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
 
       if (readValueId.getIndexRange() != null && !readValueId.getIndexRange().isEmpty()) {
         // TODO support index ranges on array values
-        pending.value = new DataValue(StatusCodes.Bad_WriteNotSupported);
+        pending.value = new DataValue(StatusCodes.Bad_NotSupported);
         break;
       }
 
@@ -245,16 +246,45 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     return tx.readInputRegisters(registers -> readRegisters(registers, address));
   }
 
-  private static byte[] readRegisters(Map<Integer, byte[]> registers, ModbusAddress address) {
-    var value = new byte[address.getDataType().getRegisterCount() * 2];
+  static byte[] readRegisters(Map<Integer, byte[]> registers, ModbusAddress address) {
+    if (address instanceof ScalarAddress scalarAddress) {
+      var value = new byte[address.getDataType().getRegisterCount() * 2];
 
-    for (int i = 0; i < value.length / 2; i++) {
-      byte[] bs = registers.getOrDefault(address.getOffset() + i, new byte[2]);
-      value[i * 2] = bs[0];
-      value[i * 2 + 1] = bs[1];
+      for (int i = 0; i < value.length / 2; i++) {
+        byte[] bs = registers.getOrDefault(scalarAddress.getOffset() + i, new byte[2]);
+        value[i * 2] = bs[0];
+        value[i * 2 + 1] = bs[1];
+      }
+
+      return value;
+    } else if (address instanceof ArrayAddress arrayAddress) {
+      // Calculate the total number of elements in the array
+      int totalElements = 1;
+      for (int dimension : arrayAddress.getDimensions()) {
+        totalElements *= dimension;
+      }
+
+      // Allocate buffer for all array elements
+      int registerCount = arrayAddress.getDataType().getRegisterCount();
+      int bytesPerElement = registerCount * 2;
+      var value = new byte[totalElements * bytesPerElement];
+
+      // Read all register values for the entire array
+      for (int elementIndex = 0; elementIndex < totalElements; elementIndex++) {
+        int elementOffset = arrayAddress.getOffset() + (elementIndex * registerCount);
+
+        for (int i = 0; i < registerCount; i++) {
+          byte[] bs = registers.getOrDefault(elementOffset + i, new byte[2]);
+          int valueIndex = elementIndex * bytesPerElement + (i * 2);
+          value[valueIndex] = bs[0];
+          value[valueIndex + 1] = bs[1];
+        }
+      }
+
+      return value;
+    } else {
+      throw new IllegalArgumentException("address: " + address);
     }
-
-    return value;
   }
 
   private Variant readNonValueAttribute(

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
@@ -1,9 +1,5 @@
 package com.kevinherron.ignition.modbus;
 
-import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
-import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
-import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
-
 import com.digitalpetri.modbus.server.ProcessImage;
 import com.digitalpetri.modbus.server.ProcessImage.Modification.CoilModification;
 import com.digitalpetri.modbus.server.ProcessImage.Modification.DiscreteInputModification;
@@ -13,26 +9,17 @@ import com.digitalpetri.modbus.server.ProcessImage.Transaction;
 import com.inductiveautomation.ignition.gateway.opcua.server.api.OpcUa;
 import com.kevinherron.ignition.modbus.address.ModbusAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddress.ArrayAddress;
-import com.kevinherron.ignition.modbus.address.ModbusAddress.ScalarAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddressParser;
-import com.kevinherron.ignition.modbus.address.ModbusDataType;
-import com.kevinherron.ignition.modbus.util.ModbusByteUtil;
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
-import org.eclipse.milo.opcua.sdk.core.NumericRange;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.Reference.Direction;
 import org.eclipse.milo.opcua.sdk.core.ValueRank;
@@ -46,13 +33,11 @@ import org.eclipse.milo.opcua.sdk.server.items.MonitoredItem;
 import org.eclipse.milo.opcua.sdk.server.util.SubscriptionModel;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
-import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.UaRuntimeException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
-import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
@@ -63,18 +48,19 @@ import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.ViewDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteValue;
-import org.eclipse.milo.opcua.stack.core.util.ArrayUtil;
 import org.eclipse.milo.opcua.stack.core.util.ExecutionQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Presents a {@link ModbusServerDevice} process image as an OPC UA address-space fragment.
+ *
+ * <p>The fragment resolves Modbus address strings as variable nodes, exposes their value and
+ * metadata attributes, and supplies monitored values through the OPC UA subscription model. Its
+ * {@link Lifecycle} must be started before use and shut down with the owning device; startup also
+ * restores persisted process-image data when persistence is enabled.
+ */
 public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
-
-  /** Shared default for absent register entries; read-only, never mutated. */
-  private static final byte[] EMPTY_REGISTER = new byte[2];
-
-  private static final Pattern NUMERIC_RANGE_PATTERN =
-      Pattern.compile("[0-9]+(?::[0-9]+)?(?:,[0-9]+(?::[0-9]+)?)*");
 
   private static final Logger logger = LoggerFactory.getLogger(ModbusAddressSpace.class);
 
@@ -83,6 +69,11 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
 
   private final ModbusServerDevice device;
 
+  /**
+   * Creates an unstarted address space for a Modbus server device.
+   *
+   * @param device the device whose process image and OPC UA context back this address space.
+   */
   public ModbusAddressSpace(ModbusServerDevice device) {
     this.device = device;
 
@@ -197,12 +188,12 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
             if (indexRange != null && !indexRange.isEmpty()) {
               // OPC UA Part 4: an IndexRange applies to any attribute; non-array attributes
               // must return Bad_IndexRangeNoData rather than the full value.
-              NumericRange range = parseNumericRange(indexRange);
+              var range = ModbusValueAccess.parseNumericRange(indexRange);
               Object value = v.getValue();
               if (value == null) {
                 throw new UaException(StatusCodes.Bad_IndexRangeNoData);
               }
-              v = new Variant(readValueAtRange(value, range));
+              v = new Variant(ModbusValueAccess.readValueAtRange(value, range));
             }
             pending.value = new DataValue(v);
           } catch (UaException e) {
@@ -237,7 +228,10 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
           var values = new ArrayList<DataValue>(reads.size());
           for (ValueRead read : reads) {
             try {
-              values.add(new DataValue(readValueAttribute(tx, read.address(), read.indexRange())));
+              values.add(
+                  new DataValue(
+                      ModbusValueAccess.readValueAttribute(
+                          tx, read.address(), read.indexRange())));
             } catch (UaException e) {
               values.add(new DataValue(e.getStatusCode()));
             } catch (RuntimeException e) {
@@ -256,7 +250,7 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       return processImage.get(
           tx -> {
             try {
-              return readValueAttribute(tx, address, indexRange);
+              return ModbusValueAccess.readValueAttribute(tx, address, indexRange);
             } catch (UaException e) {
               throw new UaRuntimeException(e);
             }
@@ -264,188 +258,6 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     } catch (UaRuntimeException e) {
       throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_InternalError, e));
     }
-  }
-
-  private static Variant readValueAttribute(
-      Transaction tx, ModbusAddress address, String indexRange) throws UaException {
-
-    NumericRange range = null;
-    if (indexRange != null && !indexRange.isEmpty()) {
-      range = parseNumericRange(indexRange);
-      // OPC UA Part 4 defines IndexRange on scalar String values as sub-string selection.
-      if (address instanceof ScalarAddress
-          && !(address.getDataType() instanceof ModbusDataType.String)) {
-        throw new UaException(StatusCodes.Bad_IndexRangeNoData);
-      }
-      if (address instanceof ArrayAddress array) {
-        // Read only the slices selected by the range's first dimension instead of decoding
-        // the whole array; the remaining dimensions are applied to the sub-array below.
-        NumericRange.Bounds bounds = range.getBounds()[0];
-        if (bounds.getHigh() >= array.getDimensions()[0]) {
-          throw new UaException(StatusCodes.Bad_IndexRangeNoData);
-        }
-        address = subArrayAddress(array, bounds);
-        range = rebaseFirstDimension(indexRange, bounds);
-      }
-    }
-
-    ModbusAddress readAddress = address;
-
-    Variant fullValue =
-        switch (readAddress.getArea()) {
-          case COILS -> readBooleanValue(tx, readAddress, false);
-          case DISCRETE_INPUTS -> readBooleanValue(tx, readAddress, true);
-          case HOLDING_REGISTERS -> {
-            byte[] bs = readHoldingRegisters(tx, readAddress);
-
-            yield new Variant(ModbusByteUtil.getValueForBytes(bs, readAddress));
-          }
-          case INPUT_REGISTERS -> {
-            byte[] bs = readInputRegisters(tx, readAddress);
-
-            yield new Variant(ModbusByteUtil.getValueForBytes(bs, readAddress));
-          }
-        };
-
-    if (range != null) {
-      return new Variant(readValueAtRange(fullValue.getValue(), range));
-    }
-    return fullValue;
-  }
-
-  /** Narrow {@code array} to the slices of its first dimension selected by {@code bounds}. */
-  private static ArrayAddress subArrayAddress(ArrayAddress array, NumericRange.Bounds bounds) {
-    int[] dimensions = array.getDimensions().clone();
-    dimensions[0] = bounds.getHigh() - bounds.getLow() + 1;
-
-    int offsetShift = bounds.getLow() * firstDimensionSliceSize(array) * entriesPerElement(array);
-
-    return new ArrayAddress(
-        array.getUnitId().orElse(null),
-        array.getArea(),
-        array.getOffset() + offsetShift,
-        array.getDataType(),
-        array.getDataTypeModifiers(),
-        dimensions);
-  }
-
-  /** Rewrite {@code indexRange} so its first dimension is relative to the sub-array read. */
-  private static NumericRange rebaseFirstDimension(String indexRange, NumericRange.Bounds bounds)
-      throws UaException {
-
-    String first =
-        bounds.getLow() == bounds.getHigh()
-            ? "0"
-            : "0:%d".formatted(bounds.getHigh() - bounds.getLow());
-    int comma = indexRange.indexOf(',');
-    return parseNumericRange(comma < 0 ? first : first + indexRange.substring(comma));
-  }
-
-  /** Number of elements in one slice of the array's first dimension. */
-  private static int firstDimensionSliceSize(ArrayAddress array) {
-    int[] dimensions = array.getDimensions();
-    int sliceSize = 1;
-    for (int i = 1; i < dimensions.length; i++) {
-      sliceSize *= dimensions[i];
-    }
-    return sliceSize;
-  }
-
-  /** Coils and discrete inputs store one entry per element; register areas store registers. */
-  private static int entriesPerElement(ModbusAddress address) {
-    return switch (address.getArea()) {
-      case COILS, DISCRETE_INPUTS -> 1;
-      case HOLDING_REGISTERS, INPUT_REGISTERS -> address.getDataType().getRegisterCount();
-    };
-  }
-
-  private static Variant readBooleanValue(
-      Transaction tx, ModbusAddress address, boolean discreteInputs) {
-
-    if (address instanceof ArrayAddress array) {
-      boolean[] values =
-          discreteInputs
-              ? tx.readDiscreteInputs(map -> readBooleans(map, array))
-              : tx.readCoils(map -> readBooleans(map, array));
-
-      return new Variant(shapeBooleanArray(values, array));
-    } else if (address instanceof ScalarAddress scalar) {
-      boolean value =
-          discreteInputs
-              ? tx.readDiscreteInputs(map -> map.getOrDefault(scalar.getOffset(), false))
-              : tx.readCoils(map -> map.getOrDefault(scalar.getOffset(), false));
-
-      return new Variant(value);
-    } else {
-      throw new IllegalArgumentException("address: " + address);
-    }
-  }
-
-  static Object readValueAtRange(Object value, NumericRange range) throws UaException {
-    if (value instanceof Matrix matrix) {
-      value = matrix.nestedArrayValue();
-    }
-
-    validateRangeDimensionCount(value, range);
-
-    Object valueAtRange = NumericRange.readFromValueAtRange(value, range);
-    if (ArrayUtil.getValueRank(valueAtRange) > 1) {
-      valueAtRange = new Matrix(valueAtRange);
-    }
-
-    return valueAtRange;
-  }
-
-  static boolean[] readBooleans(Map<Integer, Boolean> booleans, ArrayAddress address) {
-    int totalElements = address.getElementCount();
-
-    boolean[] values = new boolean[totalElements];
-
-    for (int elementIndex = 0; elementIndex < totalElements; elementIndex++) {
-      int elementOffset = address.getOffset() + elementIndex;
-      values[elementIndex] = booleans.getOrDefault(elementOffset, false);
-    }
-
-    return values;
-  }
-
-  static Object shapeBooleanArray(boolean[] values, ArrayAddress address) {
-    Boolean[] boxedValues = new Boolean[values.length];
-    for (int i = 0; i < values.length; i++) {
-      boxedValues[i] = values[i];
-    }
-
-    int[] dimensions = address.getDimensions();
-
-    if (dimensions.length == 1) {
-      return boxedValues;
-    } else {
-      return new Matrix(boxedValues, dimensions, OpcUaDataType.Boolean);
-    }
-  }
-
-  private static byte[] readHoldingRegisters(Transaction tx, ModbusAddress address) {
-    return tx.readHoldingRegisters(registers -> readRegisters(registers, address));
-  }
-
-  private static byte[] readInputRegisters(Transaction tx, ModbusAddress address) {
-    return tx.readInputRegisters(registers -> readRegisters(registers, address));
-  }
-
-  static byte[] readRegisters(Map<Integer, byte[]> registers, ModbusAddress address) {
-    int elementCount =
-        address instanceof ArrayAddress arrayAddress ? arrayAddress.getElementCount() : 1;
-    int registerCount = address.getDataType().getRegisterCount();
-
-    var value = new byte[elementCount * registerCount * 2];
-
-    for (int i = 0; i < value.length / 2; i++) {
-      byte[] bs = registers.getOrDefault(address.getOffset() + i, EMPTY_REGISTER);
-      value[i * 2] = bs[0];
-      value[i * 2 + 1] = bs[1];
-    }
-
-    return value;
   }
 
   private Variant readNonValueAttribute(
@@ -573,7 +385,8 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
         tx -> {
           for (ValueWrite write : writes) {
             try {
-              writeValueAttribute(tx, write.address(), write.variant(), write.indexRange());
+              ModbusValueAccess.writeValueAttribute(
+                  tx, write.address(), write.variant(), write.indexRange());
               statuses.add(StatusCode.GOOD);
             } catch (Exception e) {
               statuses.add(
@@ -595,7 +408,8 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       throws UaException {
 
     try {
-      processImage.with(tx -> writeValueAttribute(tx, address, variant, indexRange));
+      processImage.with(
+          tx -> ModbusValueAccess.writeValueAttribute(tx, address, variant, indexRange));
     } catch (Exception e) {
       throw UaException.extract(e)
           .orElseGet(
@@ -603,455 +417,6 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
                 logger.error("Error writing value: address={}", address, e);
                 return new UaException(StatusCodes.Bad_InternalError, e);
               });
-    }
-  }
-
-  private static void writeValueAttribute(
-      Transaction tx, ModbusAddress address, Variant variant, String indexRange) {
-
-    switch (address.getArea()) {
-      case COILS ->
-          tx.writeCoils(coilMap -> writeBooleanValue(coilMap, address, variant, indexRange));
-      case DISCRETE_INPUTS ->
-          tx.writeDiscreteInputs(
-              discreteInputMap ->
-                  writeBooleanValue(discreteInputMap, address, variant, indexRange));
-      case HOLDING_REGISTERS ->
-          tx.writeHoldingRegisters(
-              holdingRegisterMap ->
-                  writeRegisterValue(holdingRegisterMap, address, variant, indexRange));
-      case INPUT_REGISTERS ->
-          tx.writeInputRegisters(
-              inputRegisterMap ->
-                  writeRegisterValue(inputRegisterMap, address, variant, indexRange));
-    }
-  }
-
-  /**
-   * Resolve the full value to write, merging {@code variant} into the current value when an index
-   * range is present.
-   */
-  private static Variant resolveWriteValue(
-      ModbusAddress address, Variant variant, NumericRange range, CurrentValueReader currentValue)
-      throws UaException {
-
-    if (range == null) {
-      return variant;
-    }
-
-    // Arrays support element ranges; scalar String values support sub-string ranges.
-    boolean rangeSupported =
-        address instanceof ArrayAddress || address.getDataType() instanceof ModbusDataType.String;
-    if (!rangeSupported) {
-      throw new UaException(StatusCodes.Bad_IndexRangeNoData);
-    }
-
-    return new Variant(writeValueAtRange(currentValue.read(address), variant.getValue(), range));
-  }
-
-  @FunctionalInterface
-  private interface CurrentValueReader {
-    Object read(ModbusAddress address) throws UaException;
-  }
-
-  private static void writeBooleanValue(
-      Map<Integer, Boolean> booleanMap, ModbusAddress address, Variant variant, String indexRange) {
-
-    try {
-      NumericRange range =
-          indexRange == null || indexRange.isEmpty() ? null : parseNumericRange(indexRange);
-
-      Variant fullVariant =
-          resolveWriteValue(
-              address,
-              variant,
-              range,
-              addr -> {
-                // Only ArrayAddress reaches here: scalar coils are Bool, so
-                // resolveWriteValue rejects their index-range writes.
-                ArrayAddress array = (ArrayAddress) addr;
-                // Copy the extent out of the transaction-scoped map first: its element
-                // lookups are O(map size).
-                Map<Integer, Boolean> current =
-                    copyRange(booleanMap, array.getOffset(), array.getElementCount());
-                return shapeBooleanArray(readBooleans(current, array), array);
-              });
-
-      if (address instanceof ArrayAddress array) {
-        int firstElement = 0;
-        int elementLimit = array.getElementCount();
-        if (range != null) {
-          // A ranged write must leave elements outside the selected first-dimension
-          // slices untouched.
-          int sliceSize = firstDimensionSliceSize(array);
-          NumericRange.Bounds bounds = range.getBounds()[0];
-          firstElement = bounds.getLow() * sliceSize;
-          elementLimit = Math.min((bounds.getHigh() + 1) * sliceSize, elementLimit);
-        }
-        writeBooleanArray(booleanMap, fullVariant, array, firstElement, elementLimit);
-      } else if (address instanceof ScalarAddress scalar) {
-        if (fullVariant.getValue() instanceof Boolean b) {
-          booleanMap.put(scalar.getOffset(), b);
-        } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
-      } else {
-        throw new IllegalArgumentException("address: " + address);
-      }
-    } catch (UaException e) {
-      throw new UaRuntimeException(e);
-    }
-  }
-
-  private static void writeRegisterValue(
-      Map<Integer, byte[]> registerMap, ModbusAddress address, Variant variant, String indexRange) {
-
-    try {
-      NumericRange range =
-          indexRange == null || indexRange.isEmpty() ? null : parseNumericRange(indexRange);
-
-      Variant fullVariant =
-          resolveWriteValue(
-              address,
-              variant,
-              range,
-              addr -> {
-                // Copy the extent out of the transaction-scoped map first: its element
-                // lookups are O(map size).
-                Map<Integer, byte[]> current =
-                    copyRange(registerMap, addr.getOffset(), registerExtent(addr));
-                return ModbusByteUtil.getValueForBytes(readRegisters(current, addr), addr);
-              });
-
-      if (range != null
-          && address.getDataType() instanceof ModbusDataType.String
-          && isSubStringRange(address, range)) {
-        validateMergedStringByteCapacity(fullVariant.getValue(), address, range);
-      }
-
-      if (address.getDataType() instanceof ModbusDataType.Bit dataType) {
-        writeBitToRegister(address, fullVariant, dataType, registerMap);
-      } else {
-        byte[] registers = getRegisterWriteBytes(address, fullVariant);
-        int firstRegister = 0;
-        int registerLimit = registers.length / 2;
-        if (range != null && address instanceof ArrayAddress array) {
-          // A ranged write must leave registers outside the selected first-dimension
-          // slices untouched: the merge round-trip is lossy for String and Bool elements.
-          int registersPerSlice =
-              firstDimensionSliceSize(array) * array.getDataType().getRegisterCount();
-          NumericRange.Bounds bounds = range.getBounds()[0];
-          firstRegister = bounds.getLow() * registersPerSlice;
-          registerLimit = Math.min((bounds.getHigh() + 1) * registersPerSlice, registerLimit);
-        }
-        for (int i = firstRegister; i < registerLimit; i++) {
-          byte[] value = new byte[] {registers[i * 2], registers[i * 2 + 1]};
-          registerMap.put(address.getOffset() + i, value);
-        }
-      }
-    } catch (UaException e) {
-      throw new UaRuntimeException(e);
-    }
-  }
-
-  /** Total number of registers spanned by {@code address}. */
-  private static int registerExtent(ModbusAddress address) {
-    int elementCount =
-        address instanceof ArrayAddress arrayAddress ? arrayAddress.getElementCount() : 1;
-    return elementCount * address.getDataType().getRegisterCount();
-  }
-
-  /** Copy the entries in {@code [offset, offset + count)} out of {@code map}. */
-  private static <V> Map<Integer, V> copyRange(Map<Integer, V> map, int offset, int count) {
-    var copy = new HashMap<Integer, V>();
-    for (Map.Entry<Integer, V> entry : map.entrySet()) {
-      int key = entry.getKey();
-      if (key >= offset && key - offset < count) {
-        copy.put(key, entry.getValue());
-      }
-    }
-    return copy;
-  }
-
-  /** An extra final range dimension selects characters within a String element. */
-  private static boolean isSubStringRange(ModbusAddress address, NumericRange range) {
-    int rank = address instanceof ArrayAddress array ? array.getDimensions().length : 0;
-    return range.getBounds().length == rank + 1;
-  }
-
-  /**
-   * Reject sub-string merges whose UTF-8 encoding no longer fits the element's registers;
-   * silently truncating would destroy characters outside the selected range.
-   */
-  private static void validateMergedStringByteCapacity(
-      Object merged, ModbusAddress address, NumericRange range) throws UaException {
-
-    int capacity = address.getDataType().getRegisterCount() * 2;
-
-    Object elements = merged instanceof Matrix matrix ? matrix.getElements() : merged;
-    if (elements instanceof String string) {
-      if (string.getBytes(StandardCharsets.UTF_8).length > capacity) {
-        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
-      }
-      return;
-    }
-
-    int first = 0;
-    int limit = Array.getLength(elements);
-    if (address instanceof ArrayAddress array) {
-      // Only elements in the selected first-dimension slices are written back.
-      int sliceSize = firstDimensionSliceSize(array);
-      NumericRange.Bounds bounds = range.getBounds()[0];
-      first = bounds.getLow() * sliceSize;
-      limit = Math.min((bounds.getHigh() + 1) * sliceSize, limit);
-    }
-    for (int i = first; i < limit; i++) {
-      if (Array.get(elements, i) instanceof String string
-          && string.getBytes(StandardCharsets.UTF_8).length > capacity) {
-        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
-      }
-    }
-  }
-
-  static Object writeValueAtRange(Object currentValue, Object updateValue, NumericRange range)
-      throws UaException {
-
-    if (currentValue == null) {
-      throw new UaException(StatusCodes.Bad_IndexRangeNoData);
-    }
-    if (updateValue == null) {
-      throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
-    }
-
-    if (currentValue instanceof Matrix matrix) {
-      currentValue = matrix.nestedArrayValue();
-    }
-    if (updateValue instanceof Matrix matrix) {
-      if (matrix.isNull()) {
-        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
-      }
-      updateValue = matrix.nestedArrayValue();
-    }
-
-    validateRangeDimensionCount(currentValue, range);
-
-    int[] currentDimensions = ArrayUtil.getDimensions(currentValue);
-    NumericRange.Bounds[] bounds = range.getBounds();
-    // Bounds past the end of the current value select no data; check before the shape
-    // comparisons so the client sees Bad_IndexRangeNoData rather than a shape mismatch.
-    for (int i = 0; i < currentDimensions.length; i++) {
-      if (bounds[i].getHigh() >= currentDimensions[i]) {
-        throw new UaException(StatusCodes.Bad_IndexRangeNoData);
-      }
-    }
-
-    if (ArrayUtil.getBoxedType(currentValue) != ArrayUtil.getBoxedType(updateValue)) {
-      throw new UaException(StatusCodes.Bad_TypeMismatch);
-    }
-
-    int[] updateDimensions = ArrayUtil.getDimensions(updateValue);
-    // For String values an extra final range dimension selects characters within an
-    // element, so the update value has one fewer dimension than the range has bounds.
-    boolean subStringRange =
-        hasStringLeaf(currentValue) && bounds.length == currentDimensions.length + 1;
-    int expectedUpdateRank = subStringRange ? bounds.length - 1 : bounds.length;
-    if (updateDimensions.length != expectedUpdateRank) {
-      throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
-    }
-    for (int i = 0; i < updateDimensions.length; i++) {
-      long expectedLength = (long) bounds[i].getHigh() - bounds[i].getLow() + 1;
-      if (updateDimensions[i] != expectedLength) {
-        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
-      }
-    }
-    if (subStringRange) {
-      NumericRange.Bounds stringBounds = bounds[bounds.length - 1];
-      long expectedLength = (long) stringBounds.getHigh() - stringBounds.getLow() + 1;
-      validateStringLengths(updateValue, expectedLength);
-    }
-
-    Object valueAtRange = NumericRange.writeToValueAtRange(currentValue, updateValue, range);
-    if (ArrayUtil.getValueRank(valueAtRange) > 1) {
-      valueAtRange = new Matrix(valueAtRange);
-    }
-
-    return valueAtRange;
-  }
-
-  private static NumericRange parseNumericRange(String indexRange) throws UaException {
-    if (!NUMERIC_RANGE_PATTERN.matcher(indexRange).matches()) {
-      throw new UaException(StatusCodes.Bad_IndexRangeInvalid);
-    }
-    return NumericRange.parse(indexRange);
-  }
-
-  private static void validateRangeDimensionCount(Object value, NumericRange range)
-      throws UaException {
-
-    int valueRank = ArrayUtil.getDimensions(value).length;
-    int rangeDimensions = range.getBounds().length;
-    boolean valid =
-        hasStringLeaf(value)
-            ? rangeDimensions > 0
-                && (rangeDimensions == valueRank || rangeDimensions == valueRank + 1)
-            : rangeDimensions == valueRank;
-
-    if (!valid) {
-      throw new UaException(StatusCodes.Bad_IndexRangeNoData);
-    }
-  }
-
-  private static void validateStringLengths(Object value, long expectedLength) throws UaException {
-    if (value == null) {
-      throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
-    }
-    if (value instanceof String string) {
-      if (string.length() != expectedLength) {
-        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
-      }
-      return;
-    }
-
-    for (int i = 0; i < Array.getLength(value); i++) {
-      validateStringLengths(Array.get(value, i), expectedLength);
-    }
-  }
-
-  private static boolean hasStringLeaf(Object value) {
-    Class<?> type = value.getClass();
-    while (type.isArray()) {
-      type = type.getComponentType();
-    }
-    return type == String.class;
-  }
-
-  static byte[] getRegisterWriteBytes(ModbusAddress address, Variant variant) throws UaException {
-    return ModbusByteUtil.getBytesForValue(variant.getValue(), address);
-  }
-
-  static void writeBooleanArray(
-      Map<Integer, Boolean> booleanMap, Variant variant, ArrayAddress array) throws UaException {
-
-    writeBooleanArray(booleanMap, variant, array, 0, array.getElementCount());
-  }
-
-  private static void writeBooleanArray(
-      Map<Integer, Boolean> booleanMap,
-      Variant variant,
-      ArrayAddress array,
-      int firstElement,
-      int elementLimit)
-      throws UaException {
-
-    Object value = variant.getValue();
-
-    if (array.getDimensions().length > 1) {
-      if (!(value instanceof Matrix matrix)
-          || matrix.isNull()
-          || !Arrays.equals(matrix.getDimensions(), array.getDimensions())) {
-        throw new UaException(StatusCodes.Bad_TypeMismatch);
-      }
-      value = matrix.getElements();
-    }
-
-    Boolean[] booleans = boxedBooleanArray(value, array.getElementCount());
-
-    for (int i = firstElement; i < elementLimit; i++) {
-      booleanMap.put(array.getOffset() + i, booleans[i]);
-    }
-  }
-
-  /**
-   * Accepts boxed or primitive boolean arrays ({@link Matrix} supports both backings) and rejects
-   * null elements, which would poison the process image and NPE on later reads.
-   */
-  private static Boolean[] boxedBooleanArray(Object value, int expectedLength) throws UaException {
-    if (value instanceof boolean[] primitive) {
-      if (primitive.length != expectedLength) {
-        throw new UaException(StatusCodes.Bad_TypeMismatch);
-      }
-      Boolean[] boxed = new Boolean[primitive.length];
-      for (int i = 0; i < primitive.length; i++) {
-        boxed[i] = primitive[i];
-      }
-      return boxed;
-    }
-
-    if (!(value instanceof Boolean[] boxed) || boxed.length != expectedLength) {
-      throw new UaException(StatusCodes.Bad_TypeMismatch);
-    }
-    for (Boolean b : boxed) {
-      if (b == null) {
-        throw new UaException(StatusCodes.Bad_TypeMismatch);
-      }
-    }
-    return boxed;
-  }
-
-  private static void writeBitToRegister(
-      ModbusAddress address,
-      Variant variant,
-      ModbusDataType.Bit dataType,
-      Map<Integer, byte[]> registerMap)
-      throws UaException {
-
-    int bitIndex = dataType.bit();
-    ModbusDataType underlyingType = dataType.underlyingType();
-
-    var bytes = new byte[underlyingType.getRegisterCount() * 2];
-
-    for (int i = 0; i < bytes.length / 2; i++) {
-      byte[] value = registerMap.getOrDefault(address.getOffset() + i, EMPTY_REGISTER);
-      bytes[i * 2] = value[0];
-      bytes[i * 2 + 1] = value[1];
-    }
-
-    Object underlyingValue =
-        ModbusByteUtil.getScalarValueForBytes(
-            bytes, underlyingType, address.getDataTypeModifiers());
-
-    if (underlyingValue instanceof Number n) {
-      long mask = 1L << bitIndex;
-      long v = n.longValue();
-      if (variant.getValue() instanceof Boolean b) {
-        if (b) {
-          v |= mask;
-        } else {
-          v &= ~mask;
-        }
-        byte[] newBytes =
-            ModbusByteUtil.getBytesForScalarValue(
-                castToUnderlying(v, underlyingType),
-                underlyingType,
-                address.getDataTypeModifiers());
-
-        for (int i = 0; i < newBytes.length / 2; i++) {
-          byte[] value = new byte[] {newBytes[i * 2], newBytes[i * 2 + 1]};
-          registerMap.put(address.getOffset() + i, value);
-        }
-      } else {
-        throw new UaException(StatusCodes.Bad_TypeMismatch);
-      }
-    } else {
-      throw new UaException(StatusCodes.Bad_InternalError);
-    }
-  }
-
-  private static Number castToUnderlying(long value, ModbusDataType dataType) {
-    if (dataType instanceof ModbusDataType.Int16) {
-      return (short) value;
-    } else if (dataType instanceof ModbusDataType.Int32) {
-      return (int) value;
-    } else if (dataType instanceof ModbusDataType.Int64) {
-      return value;
-    } else if (dataType instanceof ModbusDataType.UInt16) {
-      return ushort((int) value);
-    } else if (dataType instanceof ModbusDataType.UInt32) {
-      return uint(value);
-    } else if (dataType instanceof ModbusDataType.UInt64) {
-      return ulong(value);
-    } else {
-      throw new IllegalArgumentException("value=" + value + ", dataType=" + dataType);
     }
   }
 

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
@@ -13,13 +13,11 @@ import com.digitalpetri.modbus.server.ProcessImage.Transaction;
 import com.inductiveautomation.ignition.gateway.opcua.server.api.OpcUa;
 import com.kevinherron.ignition.modbus.address.ModbusAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddress.ArrayAddress;
-import com.kevinherron.ignition.modbus.address.ModbusAddress.ModbusArea;
 import com.kevinherron.ignition.modbus.address.ModbusAddress.ScalarAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddressParser;
 import com.kevinherron.ignition.modbus.address.ModbusDataType;
 import com.kevinherron.ignition.modbus.util.ModbusByteUtil;
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -30,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
+import org.eclipse.milo.opcua.sdk.core.NumericRange;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.Reference.Direction;
 import org.eclipse.milo.opcua.sdk.core.ValueRank;
@@ -43,6 +42,7 @@ import org.eclipse.milo.opcua.sdk.server.items.MonitoredItem;
 import org.eclipse.milo.opcua.sdk.server.util.SubscriptionModel;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.UaRuntimeException;
@@ -59,13 +59,17 @@ import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.ViewDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteValue;
+import org.eclipse.milo.opcua.stack.core.util.ArrayUtil;
 import org.eclipse.milo.opcua.stack.core.util.ExecutionQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  /** Shared default for absent register entries; read-only, never mutated. */
+  private static final byte[] EMPTY_REGISTER = new byte[2];
+
+  private static final Logger logger = LoggerFactory.getLogger(ModbusAddressSpace.class);
 
   private final AddressSpaceFilter filter;
   private final SubscriptionModel subscriptionModel;
@@ -161,15 +165,10 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       List<ReadValueId> readValueIds) {
 
     List<PendingRead> pendingReads = readValueIds.stream().map(PendingRead::new).toList();
+    var pendingValueReads = new ArrayList<PendingValueRead>();
 
     for (PendingRead pending : pendingReads) {
       ReadValueId readValueId = pending.readValueId;
-
-      if (readValueId.getIndexRange() != null && !readValueId.getIndexRange().isEmpty()) {
-        // TODO support index ranges on array values
-        pending.value = new DataValue(StatusCodes.Bad_NotSupported);
-        break;
-      }
 
       String id = readValueId.getNodeId().getIdentifier().toString();
       String name = "[%s]".formatted(device.deviceContext.getName());
@@ -182,12 +181,8 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
         if (attributeId == null) {
           pending.value = new DataValue(StatusCodes.Bad_AttributeIdInvalid);
         } else if (attributeId == AttributeId.Value) {
-          try {
-            Variant v = readValueAttribute(address);
-            pending.value = new DataValue(v);
-          } catch (UaException e) {
-            pending.value = new DataValue(e.getStatusCode());
-          }
+          pendingValueReads.add(
+              new PendingValueRead(pending, new ValueRead(address, readValueId.getIndexRange())));
         } else {
           try {
             Variant v = readNonValueAttribute(readValueId.getNodeId(), attributeId, address);
@@ -202,74 +197,110 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       }
     }
 
+    List<DataValue> values =
+        readValueAttributes(
+            device.processImage, pendingValueReads.stream().map(PendingValueRead::read).toList());
+    for (int i = 0; i < pendingValueReads.size(); i++) {
+      pendingValueReads.get(i).pending().value = values.get(i);
+    }
+
     return pendingReads.stream().map(p -> p.value).toList();
   }
 
-  private Variant readValueAttribute(ModbusAddress address) throws UaException {
-    ModbusArea area = address.getArea();
+  static List<DataValue> readValueAttributes(ProcessImage processImage, List<ValueRead> reads) {
 
-    return switch (area) {
-      case COILS -> {
-        if (address instanceof ModbusAddress.ArrayAddress array) {
-          boolean[] values = device.processImage.get(tx -> readCoilArray(tx, array));
-
-          yield new Variant(values);
-        } else if (address instanceof ModbusAddress.ScalarAddress scalar) {
-          boolean value = device.processImage.get(tx -> readCoil(tx, scalar));
-
-          yield new Variant(value);
-        } else {
-          throw new IllegalArgumentException("address: " + address);
-        }
+    var values = new ArrayList<DataValue>(reads.size());
+    for (ValueRead read : reads) {
+      try {
+        values.add(
+            new DataValue(readValueAttribute(processImage, read.address(), read.indexRange())));
+      } catch (UaException e) {
+        values.add(new DataValue(e.getStatusCode()));
+      } catch (RuntimeException e) {
+        logger.error("Error reading value: address={}", read.address(), e);
+        values.add(new DataValue(StatusCodes.Bad_InternalError));
       }
-      case DISCRETE_INPUTS -> {
-        if (address instanceof ModbusAddress.ArrayAddress array) {
-          boolean[] values = device.processImage.get(tx -> readDiscreteInputArray(tx, array));
-
-          yield new Variant(values);
-        } else if (address instanceof ModbusAddress.ScalarAddress scalar) {
-          boolean value = device.processImage.get(tx -> readDiscreteInput(tx, scalar));
-
-          yield new Variant(value);
-        } else {
-          throw new IllegalArgumentException("address: " + address);
-        }
-      }
-      case HOLDING_REGISTERS -> {
-        byte[] bs = device.processImage.get(tx -> readHoldingRegisters(tx, address));
-
-        yield new Variant(ModbusByteUtil.getValueForBytes(bs, address));
-      }
-      case INPUT_REGISTERS -> {
-        byte[] bs = device.processImage.get(tx -> readInputRegisters(tx, address));
-
-        yield new Variant(ModbusByteUtil.getValueForBytes(bs, address));
-      }
-    };
+    }
+    return values;
   }
 
-  private static boolean readCoil(Transaction tx, ScalarAddress address) {
-    return tx.readCoils(coilMap -> coilMap.getOrDefault(address.getOffset(), false));
+  static Variant readValueAttribute(
+      ProcessImage processImage, ModbusAddress address, String indexRange) throws UaException {
+
+    NumericRange range = null;
+    if (indexRange != null && !indexRange.isEmpty()) {
+      range = NumericRange.parse(indexRange);
+      // OPC UA Part 4 defines IndexRange on scalar String values as sub-string selection.
+      if (address instanceof ScalarAddress
+          && !(address.getDataType() instanceof ModbusDataType.String)) {
+        throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+      }
+    }
+
+    Variant fullValue =
+        switch (address.getArea()) {
+          case COILS -> readBooleanValue(processImage, address, false);
+          case DISCRETE_INPUTS -> readBooleanValue(processImage, address, true);
+          case HOLDING_REGISTERS -> {
+            byte[] bs = processImage.get(tx -> readHoldingRegisters(tx, address));
+
+            yield new Variant(ModbusByteUtil.getValueForBytes(bs, address));
+          }
+          case INPUT_REGISTERS -> {
+            byte[] bs = processImage.get(tx -> readInputRegisters(tx, address));
+
+            yield new Variant(ModbusByteUtil.getValueForBytes(bs, address));
+          }
+        };
+
+    if (range != null) {
+      return new Variant(readValueAtRange(fullValue.getValue(), range));
+    }
+    return fullValue;
   }
 
-  private static boolean readDiscreteInput(Transaction tx, ScalarAddress address) {
-    return tx.readDiscreteInputs(
-        discreteInputMap -> discreteInputMap.getOrDefault(address.getOffset(), false));
+  private static Variant readBooleanValue(
+      ProcessImage processImage, ModbusAddress address, boolean discreteInputs) {
+
+    if (address instanceof ArrayAddress array) {
+      boolean[] values =
+          processImage.get(
+              tx ->
+                  discreteInputs
+                      ? tx.readDiscreteInputs(map -> readBooleans(map, array))
+                      : tx.readCoils(map -> readBooleans(map, array)));
+
+      return new Variant(shapeBooleanArray(values, array));
+    } else if (address instanceof ScalarAddress scalar) {
+      boolean value =
+          processImage.get(
+              tx ->
+                  discreteInputs
+                      ? tx.readDiscreteInputs(map -> map.getOrDefault(scalar.getOffset(), false))
+                      : tx.readCoils(map -> map.getOrDefault(scalar.getOffset(), false)));
+
+      return new Variant(value);
+    } else {
+      throw new IllegalArgumentException("address: " + address);
+    }
   }
 
-  private static boolean[] readCoilArray(Transaction tx, ArrayAddress address) {
-    return tx.readCoils(coils -> readBooleans(coils, address));
-  }
+  static Object readValueAtRange(Object value, NumericRange range) throws UaException {
+    Object valueAtRange;
+    if (value instanceof Matrix matrix) {
+      valueAtRange = NumericRange.readFromValueAtRange(matrix.nestedArrayValue(), range);
+      if (ArrayUtil.getValueRank(valueAtRange) > 1) {
+        valueAtRange = new Matrix(valueAtRange);
+      }
+    } else {
+      valueAtRange = NumericRange.readFromValueAtRange(value, range);
+    }
 
-  private static boolean[] readDiscreteInputArray(Transaction tx, ArrayAddress address) {
-    return tx.readDiscreteInputs(inputs -> readBooleans(inputs, address));
+    return valueAtRange;
   }
 
   static boolean[] readBooleans(Map<Integer, Boolean> booleans, ArrayAddress address) {
-    int totalElements = 1;
-    for (int dimension : address.getDimensions()) {
-      totalElements *= dimension;
-    }
+    int totalElements = address.getElementCount();
 
     boolean[] values = new boolean[totalElements];
 
@@ -281,6 +312,21 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     return values;
   }
 
+  static Object shapeBooleanArray(boolean[] values, ArrayAddress address) {
+    Boolean[] boxedValues = new Boolean[values.length];
+    for (int i = 0; i < values.length; i++) {
+      boxedValues[i] = values[i];
+    }
+
+    int[] dimensions = address.getDimensions();
+
+    if (dimensions.length == 1) {
+      return boxedValues;
+    } else {
+      return new Matrix(boxedValues, dimensions, OpcUaDataType.Boolean);
+    }
+  }
+
   private static byte[] readHoldingRegisters(Transaction tx, ModbusAddress address) {
     return tx.readHoldingRegisters(registers -> readRegisters(registers, address));
   }
@@ -290,44 +336,19 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
   }
 
   static byte[] readRegisters(Map<Integer, byte[]> registers, ModbusAddress address) {
-    if (address instanceof ScalarAddress scalarAddress) {
-      var value = new byte[address.getDataType().getRegisterCount() * 2];
+    int elementCount =
+        address instanceof ArrayAddress arrayAddress ? arrayAddress.getElementCount() : 1;
+    int registerCount = address.getDataType().getRegisterCount();
 
-      for (int i = 0; i < value.length / 2; i++) {
-        byte[] bs = registers.getOrDefault(scalarAddress.getOffset() + i, new byte[2]);
-        value[i * 2] = bs[0];
-        value[i * 2 + 1] = bs[1];
-      }
+    var value = new byte[elementCount * registerCount * 2];
 
-      return value;
-    } else if (address instanceof ArrayAddress arrayAddress) {
-      // Calculate the total number of elements in the array
-      int totalElements = 1;
-      for (int dimension : arrayAddress.getDimensions()) {
-        totalElements *= dimension;
-      }
-
-      // Allocate buffer for all array elements
-      int registerCount = arrayAddress.getDataType().getRegisterCount();
-      int bytesPerElement = registerCount * 2;
-      var value = new byte[totalElements * bytesPerElement];
-
-      // Read all register values for the entire array
-      for (int elementIndex = 0; elementIndex < totalElements; elementIndex++) {
-        int elementOffset = arrayAddress.getOffset() + (elementIndex * registerCount);
-
-        for (int i = 0; i < registerCount; i++) {
-          byte[] bs = registers.getOrDefault(elementOffset + i, new byte[2]);
-          int valueIndex = elementIndex * bytesPerElement + (i * 2);
-          value[valueIndex] = bs[0];
-          value[valueIndex + 1] = bs[1];
-        }
-      }
-
-      return value;
-    } else {
-      throw new IllegalArgumentException("address: " + address);
+    for (int i = 0; i < value.length / 2; i++) {
+      byte[] bs = registers.getOrDefault(address.getOffset() + i, EMPTY_REGISTER);
+      value[i * 2] = bs[0];
+      value[i * 2 + 1] = bs[1];
     }
+
+    return value;
   }
 
   private Variant readNonValueAttribute(
@@ -348,25 +369,8 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
             yield LocalizedText.english(addr);
           }
           case WriteMask, UserWriteMask -> UInteger.valueOf(0);
-          case DataType -> address.getDataType().getOpcUaDataType().getNodeId();
-          case ValueRank -> {
-            if (address instanceof ModbusAddress.ArrayAddress a) {
-              yield a.getDimensions().length;
-            } else {
-              yield ValueRank.Scalar.getValue();
-            }
-          }
-          case ArrayDimensions -> {
-            if (address instanceof ModbusAddress.ArrayAddress a) {
-              yield Arrays.stream(a.getDimensions()).mapToObj(Unsigned::uint).toArray();
-            } else {
-              yield null;
-            }
-          }
-
-          // All areas are Read/Write from the OPC UA side, otherwise nothing would be able to
-          // update IR and DI values!
-          case AccessLevel, UserAccessLevel -> AccessLevel.toValue(AccessLevel.READ_WRITE);
+          case DataType, ValueRank, ArrayDimensions, AccessLevel, UserAccessLevel ->
+              readAddressAttribute(attributeId, address).getValue();
 
           case Value ->
               throw new UaException(StatusCodes.Bad_InternalError, "attributeId: " + attributeId);
@@ -377,6 +381,41 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
         };
 
     return new Variant(o);
+  }
+
+  static Variant readAddressAttribute(AttributeId attributeId, ModbusAddress address)
+      throws UaException {
+
+    Object value =
+        switch (attributeId) {
+          case DataType -> address.getDataType().getOpcUaDataType().getNodeId();
+          case ValueRank -> {
+            if (address instanceof ArrayAddress array) {
+              yield array.getDimensions().length;
+            } else {
+              yield ValueRank.Scalar.getValue();
+            }
+          }
+          case ArrayDimensions -> {
+            if (address instanceof ArrayAddress array) {
+              yield Arrays.stream(array.getDimensions())
+                  .mapToObj(Unsigned::uint)
+                  .toArray(UInteger[]::new);
+            } else {
+              yield null;
+            }
+          }
+
+          // All areas are Read/Write from the OPC UA side, otherwise nothing would be able to
+          // update IR and DI values!
+          case AccessLevel, UserAccessLevel -> AccessLevel.toValue(AccessLevel.READ_WRITE);
+
+          default ->
+              throw new UaException(
+                  StatusCodes.Bad_AttributeIdInvalid, "attributeId: " + attributeId);
+        };
+
+    return new Variant(value);
   }
 
   // endregion
@@ -392,12 +431,6 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     for (PendingWrite pending : pendingWrites) {
       WriteValue writeValue = pending.writeValue;
 
-      if (writeValue.getIndexRange() != null && !writeValue.getIndexRange().isEmpty()) {
-        // TODO support index ranges on array values
-        pending.statusCode = new StatusCode(StatusCodes.Bad_WriteNotSupported);
-        break;
-      }
-
       AttributeId attributeId = AttributeId.from(writeValue.getAttributeId()).orElse(null);
 
       if (attributeId == null) {
@@ -408,7 +441,11 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
         String addr = id.substring(id.indexOf(name) + name.length());
         try {
           ModbusAddress address = ModbusAddressParser.parse(addr);
-          pendingValueWrites.add(new PendingValueWrite(writeValue, address));
+          pendingValueWrites.add(
+              new PendingValueWrite(
+                  pending,
+                  new ValueWrite(
+                      address, writeValue.getValue().getValue(), writeValue.getIndexRange())));
         } catch (Exception e) {
           pending.statusCode = new StatusCode(StatusCodes.Bad_ConfigurationError);
         }
@@ -417,201 +454,223 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       }
     }
 
-    for (PendingValueWrite pvw : pendingValueWrites) {
-      try {
-        writeValueAttribute(pvw.address, pvw.writeValue.getValue().getValue());
-        pvw.statusCode = StatusCode.GOOD;
-      } catch (UaException e) {
-        pvw.statusCode = e.getStatusCode();
-      } catch (RuntimeException e) {
-        if (e.getCause() instanceof UaException uax) {
-          pvw.statusCode = uax.getStatusCode();
-        } else {
-          pvw.statusCode = new StatusCode(StatusCodes.Bad_InternalError);
-        }
-      }
+    List<StatusCode> statuses =
+        writeValueAttributes(
+            device.processImage,
+            pendingValueWrites.stream().map(PendingValueWrite::write).toList());
+    for (int i = 0; i < pendingValueWrites.size(); i++) {
+      pendingValueWrites.get(i).pending().statusCode = statuses.get(i);
     }
 
     return pendingWrites.stream().map(p -> p.statusCode).toList();
   }
 
-  private void writeValueAttribute(ModbusAddress address, Variant variant) throws UaException {
-    switch (address.getArea()) {
-      case COILS -> {
-        if (address instanceof ModbusAddress.ArrayAddress array) {
-          try {
-            device.processImage.with(
-                tx ->
-                    tx.writeCoils(
-                        coilMap -> {
-                          try {
-                            writeBooleanArray(coilMap, variant, array);
-                          } catch (UaException e) {
-                            throw new UaRuntimeException(e);
-                          }
-                        }));
-          } catch (Exception e) {
-            throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_InternalError));
-          }
-        } else if (address instanceof ModbusAddress.ScalarAddress scalar) {
-          if (variant.getValue() instanceof Boolean b) {
-            device.processImage.with(
-                tx -> tx.writeCoils(coilMap -> coilMap.put(scalar.getOffset(), b)));
-          } else {
-            throw new UaException(StatusCodes.Bad_TypeMismatch);
-          }
-        } else {
-          throw new IllegalArgumentException("address: " + address);
-        }
-      }
-      case DISCRETE_INPUTS -> {
-        if (address instanceof ModbusAddress.ArrayAddress array) {
-          try {
-            device.processImage.with(
-                tx ->
-                    tx.writeDiscreteInputs(
-                        discreteInputMap -> {
-                          try {
-                            writeBooleanArray(discreteInputMap, variant, array);
-                          } catch (UaException e) {
-                            throw new UaRuntimeException(e);
-                          }
-                        }));
-          } catch (Exception e) {
-            throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_InternalError));
-          }
-        } else if (address instanceof ModbusAddress.ScalarAddress scalar) {
-          if (variant.getValue() instanceof Boolean b) {
-            device.processImage.with(
-                tx ->
-                    tx.writeDiscreteInputs(
-                        discreteInputMap -> discreteInputMap.put(scalar.getOffset(), b)));
-          } else {
-            throw new UaException(StatusCodes.Bad_TypeMismatch);
-          }
-        } else {
-          throw new IllegalArgumentException("address: " + address);
-        }
-      }
-      case HOLDING_REGISTERS -> {
-        checkDataType(address.getDataType(), variant);
+  static List<StatusCode> writeValueAttributes(ProcessImage processImage, List<ValueWrite> writes) {
 
-        if (address.getDataType() instanceof ModbusDataType.Bit dataType) {
-          device.processImage.with(
-              tx ->
-                  tx.writeHoldingRegisters(
-                      holdingRegisterMap -> {
-                        try {
-                          writeBitToRegister(address, variant, dataType, holdingRegisterMap);
-                        } catch (UaException e) {
-                          throw new RuntimeException(e);
-                        }
-                      }));
-        } else {
-          byte[] registers = ModbusByteUtil.getBytesForValue(variant.getValue(), address);
-
-          device.processImage.with(
-              tx ->
-                  tx.writeHoldingRegisters(
-                      holdingRegisterMap -> {
-                        for (int i = 0; i < registers.length / 2; i++) {
-                          byte[] value = new byte[] {registers[i * 2], registers[i * 2 + 1]};
-                          holdingRegisterMap.put(address.getOffset() + i, value);
-                        }
-                      }));
-        }
+    var statuses = new ArrayList<StatusCode>(writes.size());
+    for (ValueWrite write : writes) {
+      try {
+        writeValueAttribute(processImage, write.address(), write.variant(), write.indexRange());
+        statuses.add(StatusCode.GOOD);
+      } catch (UaException e) {
+        statuses.add(e.getStatusCode());
+      } catch (RuntimeException e) {
+        statuses.add(
+            UaException.extract(e)
+                .map(UaException::getStatusCode)
+                .orElse(new StatusCode(StatusCodes.Bad_InternalError)));
       }
-      case INPUT_REGISTERS -> {
-        checkDataType(address.getDataType(), variant);
-
-        if (address.getDataType() instanceof ModbusDataType.Bit dataType) {
-          device.processImage.with(
-              tx ->
-                  tx.writeInputRegisters(
-                      inputRegisterMap -> {
-                        try {
-                          writeBitToRegister(address, variant, dataType, inputRegisterMap);
-                        } catch (UaException e) {
-                          throw new RuntimeException(e);
-                        }
-                      }));
-        } else {
-          byte[] registers = ModbusByteUtil.getBytesForValue(variant.getValue(), address);
-
-          device.processImage.with(
-              tx ->
-                  tx.writeInputRegisters(
-                      inputRegisterMap -> {
-                        for (int i = 0; i < registers.length / 2; i++) {
-                          byte[] value = new byte[] {registers[i * 2], registers[i * 2 + 1]};
-                          inputRegisterMap.put(address.getOffset() + i, value);
-                        }
-                      }));
-        }
-      }
-      default -> throw new IllegalArgumentException("area: " + address.getArea());
     }
+    return statuses;
+  }
+
+  static void writeValueAttribute(
+      ProcessImage processImage, ModbusAddress address, Variant variant, String indexRange)
+      throws UaException {
+
+    try {
+      processImage.with(tx -> writeValueAttribute(tx, address, variant, indexRange));
+    } catch (Exception e) {
+      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_InternalError));
+    }
+  }
+
+  private static void writeValueAttribute(
+      Transaction tx, ModbusAddress address, Variant variant, String indexRange) {
+
+    switch (address.getArea()) {
+      case COILS ->
+          tx.writeCoils(coilMap -> writeBooleanValue(coilMap, address, variant, indexRange));
+      case DISCRETE_INPUTS ->
+          tx.writeDiscreteInputs(
+              discreteInputMap ->
+                  writeBooleanValue(discreteInputMap, address, variant, indexRange));
+      case HOLDING_REGISTERS ->
+          tx.writeHoldingRegisters(
+              holdingRegisterMap ->
+                  writeRegisterValue(holdingRegisterMap, address, variant, indexRange));
+      case INPUT_REGISTERS ->
+          tx.writeInputRegisters(
+              inputRegisterMap ->
+                  writeRegisterValue(inputRegisterMap, address, variant, indexRange));
+    }
+  }
+
+  /**
+   * Resolve the full value to write, merging {@code variant} into the current value when an index
+   * range is present.
+   */
+  private static Variant resolveWriteValue(
+      ModbusAddress address, Variant variant, String indexRange, CurrentValueReader currentValue)
+      throws UaException {
+
+    if (indexRange == null || indexRange.isEmpty()) {
+      return variant;
+    }
+
+    NumericRange range = NumericRange.parse(indexRange);
+    // Arrays support element ranges; scalar String values support sub-string ranges.
+    boolean rangeSupported =
+        address instanceof ArrayAddress || address.getDataType() instanceof ModbusDataType.String;
+    if (!rangeSupported) {
+      throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+    }
+
+    return new Variant(writeValueAtRange(currentValue.read(address), variant.getValue(), range));
+  }
+
+  @FunctionalInterface
+  private interface CurrentValueReader {
+    Object read(ModbusAddress address) throws UaException;
+  }
+
+  private static void writeBooleanValue(
+      Map<Integer, Boolean> booleanMap, ModbusAddress address, Variant variant, String indexRange) {
+
+    try {
+      Variant fullVariant =
+          resolveWriteValue(
+              address,
+              variant,
+              indexRange,
+              addr -> {
+                // Only ArrayAddress reaches here: scalar coils are Bool, so
+                // resolveWriteValue rejects their index-range writes.
+                ArrayAddress array = (ArrayAddress) addr;
+                return shapeBooleanArray(readBooleans(booleanMap, array), array);
+              });
+
+      if (address instanceof ArrayAddress array) {
+        writeBooleanArray(booleanMap, fullVariant, array);
+      } else if (address instanceof ScalarAddress scalar) {
+        if (fullVariant.getValue() instanceof Boolean b) {
+          booleanMap.put(scalar.getOffset(), b);
+        } else {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      } else {
+        throw new IllegalArgumentException("address: " + address);
+      }
+    } catch (UaException e) {
+      throw new UaRuntimeException(e);
+    }
+  }
+
+  private static void writeRegisterValue(
+      Map<Integer, byte[]> registerMap, ModbusAddress address, Variant variant, String indexRange) {
+
+    try {
+      Variant fullVariant =
+          resolveWriteValue(
+              address,
+              variant,
+              indexRange,
+              addr -> ModbusByteUtil.getValueForBytes(readRegisters(registerMap, addr), addr));
+
+      if (address.getDataType() instanceof ModbusDataType.Bit dataType) {
+        writeBitToRegister(address, fullVariant, dataType, registerMap);
+      } else {
+        byte[] registers = getRegisterWriteBytes(address, fullVariant);
+        for (int i = 0; i < registers.length / 2; i++) {
+          byte[] value = new byte[] {registers[i * 2], registers[i * 2 + 1]};
+          registerMap.put(address.getOffset() + i, value);
+        }
+      }
+    } catch (UaException e) {
+      throw new UaRuntimeException(e);
+    }
+  }
+
+  static Object writeValueAtRange(Object currentValue, Object updateValue, NumericRange range)
+      throws UaException {
+
+    if (currentValue == null || updateValue == null) {
+      throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+    }
+
+    if (currentValue instanceof Matrix matrix) {
+      currentValue = matrix.nestedArrayValue();
+    }
+    if (updateValue instanceof Matrix matrix) {
+      updateValue = matrix.nestedArrayValue();
+    }
+
+    int[] updateDimensions = ArrayUtil.getDimensions(updateValue);
+    NumericRange.Bounds[] bounds = range.getBounds();
+    // For String values an extra final range dimension selects characters within an
+    // element, so the update value has one fewer dimension than the range has bounds.
+    boolean subStringRange =
+        updateDimensions.length == bounds.length - 1 && hasStringLeaf(updateValue);
+    if (!subStringRange && updateDimensions.length != bounds.length) {
+      throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+    }
+    for (int i = 0; i < updateDimensions.length; i++) {
+      int expectedLength = bounds[i].getHigh() - bounds[i].getLow() + 1;
+      if (updateDimensions[i] != expectedLength) {
+        throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+      }
+    }
+
+    Object valueAtRange = NumericRange.writeToValueAtRange(currentValue, updateValue, range);
+    if (ArrayUtil.getValueRank(valueAtRange) > 1) {
+      valueAtRange = new Matrix(valueAtRange);
+    }
+
+    return valueAtRange;
+  }
+
+  private static boolean hasStringLeaf(Object value) {
+    Class<?> type = value.getClass();
+    while (type.isArray()) {
+      type = type.getComponentType();
+    }
+    return type == String.class;
+  }
+
+  static byte[] getRegisterWriteBytes(ModbusAddress address, Variant variant) throws UaException {
+    return ModbusByteUtil.getBytesForValue(variant.getValue(), address);
   }
 
   static void writeBooleanArray(
       Map<Integer, Boolean> booleanMap, Variant variant, ArrayAddress array) throws UaException {
 
-    int[] dimensions = array.getDimensions();
-
-    if (dimensions.length == 1) {
-      if (variant.getValue() instanceof Boolean[] booleans) {
-        if (booleans.length == dimensions[0]) {
-          for (int i = 0; i < booleans.length; i++) {
-            booleanMap.put(array.getOffset() + i, booleans[i]);
-          }
-        } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
-      } else {
-        throw new UaException(StatusCodes.Bad_TypeMismatch);
-      }
-    } else {
-      if (variant.getValue() instanceof Matrix matrix) {
-        int totalElements = 1;
-        for (int dimension : array.getDimensions()) {
-          totalElements *= dimension;
-        }
-        Object flatArray = matrix.getElements();
-        int arrayLength = Array.getLength(flatArray);
-
-        if (totalElements != arrayLength) {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
-
-        for (int i = 0; i < totalElements; i++) {
-          int elementOffset = array.getOffset() + i;
-          Boolean b = (Boolean) Array.get(flatArray, i);
-          booleanMap.put(elementOffset, b);
-        }
-      } else {
-        throw new UaException(StatusCodes.Bad_TypeMismatch);
-      }
-    }
-  }
-
-  /**
-   * Check that a value is of the correct type for the given ModbusDataType.
-   *
-   * @param dataType the {@link ModbusDataType}.
-   * @param variant the {@link Variant} to check.
-   * @throws UaException if the value is {@code null}, or not of the correct type.
-   */
-  private static void checkDataType(ModbusDataType dataType, Variant variant) throws UaException {
     Object value = variant.getValue();
-    if (value == null) {
+
+    if (array.getDimensions().length > 1) {
+      if (!(value instanceof Matrix matrix)
+          || matrix.isNull()
+          || !Arrays.equals(matrix.getDimensions(), array.getDimensions())) {
+        throw new UaException(StatusCodes.Bad_TypeMismatch);
+      }
+      value = matrix.getElements();
+    }
+
+    if (!(value instanceof Boolean[] booleans) || booleans.length != array.getElementCount()) {
       throw new UaException(StatusCodes.Bad_TypeMismatch);
     }
 
-    Class<?> actualType = variant.getValue().getClass();
-    Class<?> expectedType = dataType.getOpcUaDataType().getBackingClass();
-
-    if (!expectedType.isAssignableFrom(actualType)) {
-      throw new UaException(StatusCodes.Bad_TypeMismatch);
+    for (int i = 0; i < booleans.length; i++) {
+      booleanMap.put(array.getOffset() + i, booleans[i]);
     }
   }
 
@@ -628,7 +687,7 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     var bytes = new byte[underlyingType.getRegisterCount() * 2];
 
     for (int i = 0; i < bytes.length / 2; i++) {
-      byte[] value = registerMap.getOrDefault(address.getOffset() + i, new byte[2]);
+      byte[] value = registerMap.getOrDefault(address.getOffset() + i, EMPTY_REGISTER);
       bytes[i * 2] = value[0];
       bytes[i * 2 + 1] = value[1];
     }
@@ -999,6 +1058,12 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     }
   }
 
+  record ValueRead(ModbusAddress address, String indexRange) {}
+
+  record ValueWrite(ModbusAddress address, Variant variant, String indexRange) {}
+
+  private record PendingValueRead(PendingRead pending, ValueRead read) {}
+
   private static class PendingWrite {
 
     volatile StatusCode statusCode;
@@ -1009,17 +1074,9 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     }
   }
 
-  private static class PendingValueWrite extends PendingWrite {
+  private record PendingValueWrite(PendingWrite pending, ValueWrite write) {}
 
-    final ModbusAddress address;
-
-    private PendingValueWrite(WriteValue writeValue, ModbusAddress address) {
-      super(writeValue);
-      this.address = address;
-    }
-  }
-
-  private class ModbusAddressFilter extends SimpleAddressSpaceFilter {
+  private static class ModbusAddressFilter extends SimpleAddressSpaceFilter {
 
     private final String deviceName;
 

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
@@ -18,6 +18,7 @@ import com.kevinherron.ignition.modbus.address.ModbusAddressParser;
 import com.kevinherron.ignition.modbus.address.ModbusDataType;
 import com.kevinherron.ignition.modbus.util.ModbusByteUtil;
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.NumericRange;
 import org.eclipse.milo.opcua.sdk.core.Reference;
@@ -68,6 +70,9 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
 
   /** Shared default for absent register entries; read-only, never mutated. */
   private static final byte[] EMPTY_REGISTER = new byte[2];
+
+  private static final Pattern NUMERIC_RANGE_PATTERN =
+      Pattern.compile("[0-9]+(?::[0-9]+)?(?:,[0-9]+(?::[0-9]+)?)*");
 
   private static final Logger logger = LoggerFactory.getLogger(ModbusAddressSpace.class);
 
@@ -229,7 +234,7 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
 
     NumericRange range = null;
     if (indexRange != null && !indexRange.isEmpty()) {
-      range = NumericRange.parse(indexRange);
+      range = parseNumericRange(indexRange);
       // OPC UA Part 4 defines IndexRange on scalar String values as sub-string selection.
       if (address instanceof ScalarAddress
           && !(address.getDataType() instanceof ModbusDataType.String)) {
@@ -286,14 +291,15 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
   }
 
   static Object readValueAtRange(Object value, NumericRange range) throws UaException {
-    Object valueAtRange;
     if (value instanceof Matrix matrix) {
-      valueAtRange = NumericRange.readFromValueAtRange(matrix.nestedArrayValue(), range);
-      if (ArrayUtil.getValueRank(valueAtRange) > 1) {
-        valueAtRange = new Matrix(valueAtRange);
-      }
-    } else {
-      valueAtRange = NumericRange.readFromValueAtRange(value, range);
+      value = matrix.nestedArrayValue();
+    }
+
+    validateRangeDimensionCount(value, range);
+
+    Object valueAtRange = NumericRange.readFromValueAtRange(value, range);
+    if (ArrayUtil.getValueRank(valueAtRange) > 1) {
+      valueAtRange = new Matrix(valueAtRange);
     }
 
     return valueAtRange;
@@ -528,7 +534,7 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       return variant;
     }
 
-    NumericRange range = NumericRange.parse(indexRange);
+    NumericRange range = parseNumericRange(indexRange);
     // Arrays support element ranges; scalar String values support sub-string ranges.
     boolean rangeSupported =
         address instanceof ArrayAddress || address.getDataType() instanceof ModbusDataType.String;
@@ -604,8 +610,11 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
   static Object writeValueAtRange(Object currentValue, Object updateValue, NumericRange range)
       throws UaException {
 
-    if (currentValue == null || updateValue == null) {
+    if (currentValue == null) {
       throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+    }
+    if (updateValue == null) {
+      throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
     }
 
     if (currentValue instanceof Matrix matrix) {
@@ -615,20 +624,32 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       updateValue = matrix.nestedArrayValue();
     }
 
+    validateRangeDimensionCount(currentValue, range);
+
+    if (ArrayUtil.getBoxedType(currentValue) != ArrayUtil.getBoxedType(updateValue)) {
+      throw new UaException(StatusCodes.Bad_TypeMismatch);
+    }
+
     int[] updateDimensions = ArrayUtil.getDimensions(updateValue);
     NumericRange.Bounds[] bounds = range.getBounds();
     // For String values an extra final range dimension selects characters within an
     // element, so the update value has one fewer dimension than the range has bounds.
     boolean subStringRange =
-        updateDimensions.length == bounds.length - 1 && hasStringLeaf(updateValue);
+        hasStringLeaf(currentValue)
+            && bounds.length == ArrayUtil.getDimensions(currentValue).length + 1;
     if (!subStringRange && updateDimensions.length != bounds.length) {
-      throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+      throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
     }
     for (int i = 0; i < updateDimensions.length; i++) {
       int expectedLength = bounds[i].getHigh() - bounds[i].getLow() + 1;
       if (updateDimensions[i] != expectedLength) {
-        throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
       }
+    }
+    if (subStringRange) {
+      NumericRange.Bounds stringBounds = bounds[bounds.length - 1];
+      int expectedLength = stringBounds.getHigh() - stringBounds.getLow() + 1;
+      validateStringLengths(updateValue, expectedLength);
     }
 
     Object valueAtRange = NumericRange.writeToValueAtRange(currentValue, updateValue, range);
@@ -637,6 +658,45 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
     }
 
     return valueAtRange;
+  }
+
+  private static NumericRange parseNumericRange(String indexRange) throws UaException {
+    if (!NUMERIC_RANGE_PATTERN.matcher(indexRange).matches()) {
+      throw new UaException(StatusCodes.Bad_IndexRangeInvalid);
+    }
+    return NumericRange.parse(indexRange);
+  }
+
+  private static void validateRangeDimensionCount(Object value, NumericRange range)
+      throws UaException {
+
+    int valueRank = ArrayUtil.getDimensions(value).length;
+    int rangeDimensions = range.getBounds().length;
+    boolean valid =
+        hasStringLeaf(value)
+            ? rangeDimensions > 0
+                && (rangeDimensions == valueRank || rangeDimensions == valueRank + 1)
+            : rangeDimensions == valueRank;
+
+    if (!valid) {
+      throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+    }
+  }
+
+  private static void validateStringLengths(Object value, int expectedLength) throws UaException {
+    if (value == null) {
+      throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
+    }
+    if (value instanceof String string) {
+      if (string.length() != expectedLength) {
+        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
+      }
+      return;
+    }
+
+    for (int i = 0; i < Array.getLength(value); i++) {
+      validateStringLengths(Array.get(value, i), expectedLength);
+    }
   }
 
   private static boolean hasStringLeaf(Object value) {

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusValueAccess.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusValueAccess.java
@@ -1,0 +1,771 @@
+package com.kevinherron.ignition.modbus;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+
+import com.digitalpetri.modbus.server.ProcessImage.Transaction;
+import com.kevinherron.ignition.modbus.address.ModbusAddress;
+import com.kevinherron.ignition.modbus.address.ModbusAddress.ArrayAddress;
+import com.kevinherron.ignition.modbus.address.ModbusAddress.ScalarAddress;
+import com.kevinherron.ignition.modbus.address.ModbusDataType;
+import com.kevinherron.ignition.modbus.util.ModbusByteUtil;
+import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.eclipse.milo.opcua.sdk.core.NumericRange;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.UaRuntimeException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.util.ArrayUtil;
+
+/**
+ * Reads and writes OPC UA values backed by entries in a Modbus process image.
+ *
+ * <p>This class is the value-access boundary between {@link ModbusAddressSpace} and a process-image
+ * {@link Transaction}. Callers own the transaction scope; this class applies the address's data
+ * type and array dimensions, interprets OPC UA index ranges, and reads or mutates entries through
+ * the supplied transaction.
+ */
+final class ModbusValueAccess {
+
+  /** Shared default for absent register entries; read-only, never mutated. */
+  private static final byte[] EMPTY_REGISTER = new byte[2];
+
+  private static final Pattern NUMERIC_RANGE_PATTERN =
+      Pattern.compile("[0-9]+(?::[0-9]+)?(?:,[0-9]+(?::[0-9]+)?)*");
+
+  private ModbusValueAccess() {}
+
+  /**
+   * Reads the value identified by {@code address} from an existing process-image transaction.
+   *
+   * <p>An absent or empty {@code indexRange} returns the complete value. A non-empty range returns
+   * only the selected array elements or, for String values, the selected characters. Arrays with
+   * more than one dimension are returned as a {@link Matrix}.
+   *
+   * @param tx the transaction that supplies the process-image snapshot.
+   * @param address the Modbus address and value representation to read.
+   * @param indexRange the OPC UA numeric range to apply, or {@code null} for the complete value.
+   * @return the value represented as an OPC UA {@link Variant}.
+   * @throws UaException if the range is invalid, selects no data, or the stored value cannot be
+   *     decoded.
+   */
+  static Variant readValueAttribute(Transaction tx, ModbusAddress address, String indexRange)
+      throws UaException {
+
+    NumericRange range = null;
+    if (indexRange != null && !indexRange.isEmpty()) {
+      range = parseNumericRange(indexRange);
+      // OPC UA Part 4 defines IndexRange on scalar String values as sub-string selection.
+      if (address instanceof ScalarAddress
+          && !(address.getDataType() instanceof ModbusDataType.String)) {
+        throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+      }
+      if (address instanceof ArrayAddress array) {
+        // Read only the slices selected by the range's first dimension instead of decoding
+        // the whole array; the remaining dimensions are applied to the sub-array below.
+        NumericRange.Bounds bounds = range.getBounds()[0];
+        if (bounds.getHigh() >= array.getDimensions()[0]) {
+          throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+        }
+        address = subArrayAddress(array, bounds);
+        range = rebaseFirstDimension(indexRange, bounds);
+      }
+    }
+
+    ModbusAddress readAddress = address;
+
+    Variant fullValue =
+        switch (readAddress.getArea()) {
+          case COILS -> readBooleanValue(tx, readAddress, false);
+          case DISCRETE_INPUTS -> readBooleanValue(tx, readAddress, true);
+          case HOLDING_REGISTERS -> {
+            byte[] bs = readHoldingRegisters(tx, readAddress);
+
+            yield new Variant(ModbusByteUtil.getValueForBytes(bs, readAddress));
+          }
+          case INPUT_REGISTERS -> {
+            byte[] bs = readInputRegisters(tx, readAddress);
+
+            yield new Variant(ModbusByteUtil.getValueForBytes(bs, readAddress));
+          }
+        };
+
+    if (range != null) {
+      return new Variant(readValueAtRange(fullValue.getValue(), range));
+    }
+    return fullValue;
+  }
+
+  /** Narrow {@code array} to the slices of its first dimension selected by {@code bounds}. */
+  private static ArrayAddress subArrayAddress(ArrayAddress array, NumericRange.Bounds bounds) {
+    int[] dimensions = array.getDimensions().clone();
+    dimensions[0] = bounds.getHigh() - bounds.getLow() + 1;
+
+    int offsetShift = bounds.getLow() * firstDimensionSliceSize(array) * entriesPerElement(array);
+
+    return new ArrayAddress(
+        array.getUnitId().orElse(null),
+        array.getArea(),
+        array.getOffset() + offsetShift,
+        array.getDataType(),
+        array.getDataTypeModifiers(),
+        dimensions);
+  }
+
+  /** Rewrite {@code indexRange} so its first dimension is relative to the sub-array read. */
+  private static NumericRange rebaseFirstDimension(String indexRange, NumericRange.Bounds bounds)
+      throws UaException {
+
+    String first =
+        bounds.getLow() == bounds.getHigh()
+            ? "0"
+            : "0:%d".formatted(bounds.getHigh() - bounds.getLow());
+    int comma = indexRange.indexOf(',');
+    return parseNumericRange(comma < 0 ? first : first + indexRange.substring(comma));
+  }
+
+  /** Number of elements in one slice of the array's first dimension. */
+  private static int firstDimensionSliceSize(ArrayAddress array) {
+    int[] dimensions = array.getDimensions();
+    int sliceSize = 1;
+    for (int i = 1; i < dimensions.length; i++) {
+      sliceSize *= dimensions[i];
+    }
+    return sliceSize;
+  }
+
+  /** Coils and discrete inputs store one entry per element; register areas store registers. */
+  private static int entriesPerElement(ModbusAddress address) {
+    return switch (address.getArea()) {
+      case COILS, DISCRETE_INPUTS -> 1;
+      case HOLDING_REGISTERS, INPUT_REGISTERS -> address.getDataType().getRegisterCount();
+    };
+  }
+
+  private static Variant readBooleanValue(
+      Transaction tx, ModbusAddress address, boolean discreteInputs) {
+
+    if (address instanceof ArrayAddress array) {
+      boolean[] values =
+          discreteInputs
+              ? tx.readDiscreteInputs(map -> readBooleans(map, array))
+              : tx.readCoils(map -> readBooleans(map, array));
+
+      return new Variant(shapeBooleanArray(array, values));
+    } else if (address instanceof ScalarAddress scalar) {
+      boolean value =
+          discreteInputs
+              ? tx.readDiscreteInputs(map -> map.getOrDefault(scalar.getOffset(), false))
+              : tx.readCoils(map -> map.getOrDefault(scalar.getOffset(), false));
+
+      return new Variant(value);
+    } else {
+      throw new IllegalArgumentException("address: " + address);
+    }
+  }
+
+  /**
+   * Returns the portion of an OPC UA value selected by a numeric range.
+   *
+   * @param value the scalar String, array, or matrix value to read from.
+   * @param range the range whose dimensions apply to {@code value}.
+   * @return the selected value, using a {@link Matrix} when its rank is greater than one.
+   * @throws UaException if the range's rank does not match the value or the range selects no data.
+   */
+  static Object readValueAtRange(Object value, NumericRange range) throws UaException {
+    if (value instanceof Matrix matrix) {
+      value = matrix.nestedArrayValue();
+    }
+
+    validateRangeDimensionCount(value, range);
+
+    Object valueAtRange = NumericRange.readFromValueAtRange(value, range);
+    if (ArrayUtil.getValueRank(valueAtRange) > 1) {
+      valueAtRange = new Matrix(valueAtRange);
+    }
+
+    return valueAtRange;
+  }
+
+  /**
+   * Reads the Boolean elements spanned by an array address.
+   *
+   * @param booleans the process-image entries keyed by Modbus offset.
+   * @param address the array extent to read.
+   * @return the flattened values in Modbus offset order; absent entries are {@code false}.
+   */
+  static boolean[] readBooleans(Map<Integer, Boolean> booleans, ArrayAddress address) {
+    int totalElements = address.getElementCount();
+
+    boolean[] values = new boolean[totalElements];
+
+    for (int elementIndex = 0; elementIndex < totalElements; elementIndex++) {
+      int elementOffset = address.getOffset() + elementIndex;
+      values[elementIndex] = booleans.getOrDefault(elementOffset, false);
+    }
+
+    return values;
+  }
+
+  /**
+   * Shapes flattened Boolean elements for the OPC UA value described by an array address.
+   *
+   * @param address the array dimensions to apply.
+   * @param values the Boolean elements in Modbus offset order.
+   * @return a boxed array for a one-dimensional address, or a {@link Matrix} for a higher rank.
+   */
+  static Object shapeBooleanArray(ArrayAddress address, boolean[] values) {
+    Boolean[] boxedValues = new Boolean[values.length];
+    for (int i = 0; i < values.length; i++) {
+      boxedValues[i] = values[i];
+    }
+
+    int[] dimensions = address.getDimensions();
+
+    if (dimensions.length == 1) {
+      return boxedValues;
+    } else {
+      return new Matrix(boxedValues, dimensions, OpcUaDataType.Boolean);
+    }
+  }
+
+  private static byte[] readHoldingRegisters(Transaction tx, ModbusAddress address) {
+    return tx.readHoldingRegisters(registers -> readRegisters(registers, address));
+  }
+
+  private static byte[] readInputRegisters(Transaction tx, ModbusAddress address) {
+    return tx.readInputRegisters(registers -> readRegisters(registers, address));
+  }
+
+  /**
+   * Reads the register bytes spanned by a scalar or array address.
+   *
+   * @param registers the process-image entries keyed by Modbus register offset.
+   * @param address the address whose complete register extent should be read.
+   * @return the concatenated register bytes in ascending offset order; absent registers contribute
+   *     two zero bytes.
+   */
+  static byte[] readRegisters(Map<Integer, byte[]> registers, ModbusAddress address) {
+    int elementCount =
+        address instanceof ArrayAddress arrayAddress ? arrayAddress.getElementCount() : 1;
+    int registerCount = address.getDataType().getRegisterCount();
+
+    var value = new byte[elementCount * registerCount * 2];
+
+    for (int i = 0; i < value.length / 2; i++) {
+      byte[] bs = registers.getOrDefault(address.getOffset() + i, EMPTY_REGISTER);
+      value[i * 2] = bs[0];
+      value[i * 2 + 1] = bs[1];
+    }
+
+    return value;
+  }
+
+  /**
+   * Writes an OPC UA value through an existing process-image transaction.
+   *
+   * <p>An absent or empty {@code indexRange} replaces the complete value. A non-empty range merges
+   * the selected array elements or String characters into the current value so unselected OPC UA
+   * value components are preserved.
+   *
+   * @param tx the transaction through which process-image entries are mutated.
+   * @param address the Modbus address and value representation to write.
+   * @param variant the OPC UA value to encode.
+   * @param indexRange the OPC UA numeric range to update, or {@code null} for the complete value.
+   * @throws UaRuntimeException if the range is invalid, the value does not match the selected shape
+   *     or data type, or the value cannot be encoded.
+   */
+  static void writeValueAttribute(
+      Transaction tx, ModbusAddress address, Variant variant, String indexRange) {
+
+    switch (address.getArea()) {
+      case COILS ->
+          tx.writeCoils(coilMap -> writeBooleanValue(coilMap, address, variant, indexRange));
+      case DISCRETE_INPUTS ->
+          tx.writeDiscreteInputs(
+              discreteInputMap ->
+                  writeBooleanValue(discreteInputMap, address, variant, indexRange));
+      case HOLDING_REGISTERS ->
+          tx.writeHoldingRegisters(
+              holdingRegisterMap ->
+                  writeRegisterValue(holdingRegisterMap, address, variant, indexRange));
+      case INPUT_REGISTERS ->
+          tx.writeInputRegisters(
+              inputRegisterMap ->
+                  writeRegisterValue(inputRegisterMap, address, variant, indexRange));
+    }
+  }
+
+  /**
+   * Resolve the full value to write, merging {@code variant} into the current value when an index
+   * range is present.
+   */
+  private static Variant resolveWriteValue(
+      ModbusAddress address, Variant variant, NumericRange range, CurrentValueReader currentValue)
+      throws UaException {
+
+    if (range == null) {
+      return variant;
+    }
+
+    // Arrays support element ranges; scalar String values support sub-string ranges.
+    boolean rangeSupported =
+        address instanceof ArrayAddress || address.getDataType() instanceof ModbusDataType.String;
+    if (!rangeSupported) {
+      throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+    }
+
+    return new Variant(writeValueAtRange(currentValue.read(address), variant.getValue(), range));
+  }
+
+  @FunctionalInterface
+  private interface CurrentValueReader {
+    Object read(ModbusAddress address) throws UaException;
+  }
+
+  private static void writeBooleanValue(
+      Map<Integer, Boolean> booleanMap, ModbusAddress address, Variant variant, String indexRange) {
+
+    try {
+      NumericRange range =
+          indexRange == null || indexRange.isEmpty() ? null : parseNumericRange(indexRange);
+
+      Variant fullVariant =
+          resolveWriteValue(
+              address,
+              variant,
+              range,
+              addr -> {
+                // Only ArrayAddress reaches here: scalar coils are Bool, so
+                // resolveWriteValue rejects their index-range writes.
+                ArrayAddress array = (ArrayAddress) addr;
+                // Copy the extent out of the transaction-scoped map first: its element
+                // lookups are O(map size).
+                Map<Integer, Boolean> current =
+                    copyRange(booleanMap, array.getOffset(), array.getElementCount());
+                return shapeBooleanArray(array, readBooleans(current, array));
+              });
+
+      if (address instanceof ArrayAddress array) {
+        int firstElement = 0;
+        int elementLimit = array.getElementCount();
+        if (range != null) {
+          // A ranged write must leave elements outside the selected first-dimension
+          // slices untouched.
+          int sliceSize = firstDimensionSliceSize(array);
+          NumericRange.Bounds bounds = range.getBounds()[0];
+          firstElement = bounds.getLow() * sliceSize;
+          elementLimit = Math.min((bounds.getHigh() + 1) * sliceSize, elementLimit);
+        }
+        writeBooleanArray(booleanMap, array, fullVariant, firstElement, elementLimit);
+      } else if (address instanceof ScalarAddress scalar) {
+        if (fullVariant.getValue() instanceof Boolean b) {
+          booleanMap.put(scalar.getOffset(), b);
+        } else {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      } else {
+        throw new IllegalArgumentException("address: " + address);
+      }
+    } catch (UaException e) {
+      throw new UaRuntimeException(e);
+    }
+  }
+
+  private static void writeRegisterValue(
+      Map<Integer, byte[]> registerMap, ModbusAddress address, Variant variant, String indexRange) {
+
+    try {
+      NumericRange range =
+          indexRange == null || indexRange.isEmpty() ? null : parseNumericRange(indexRange);
+
+      Variant fullVariant =
+          resolveWriteValue(
+              address,
+              variant,
+              range,
+              addr -> {
+                // Copy the extent out of the transaction-scoped map first: its element
+                // lookups are O(map size).
+                Map<Integer, byte[]> current =
+                    copyRange(registerMap, addr.getOffset(), registerExtent(addr));
+                return ModbusByteUtil.getValueForBytes(readRegisters(current, addr), addr);
+              });
+
+      if (range != null
+          && address.getDataType() instanceof ModbusDataType.String
+          && isSubStringRange(address, range)) {
+        validateMergedStringByteCapacity(address, fullVariant.getValue(), range);
+      }
+
+      if (address.getDataType() instanceof ModbusDataType.Bit dataType) {
+        writeBitToRegister(registerMap, address, fullVariant, dataType);
+      } else {
+        byte[] registers = getRegisterWriteBytes(address, fullVariant);
+        int firstRegister = 0;
+        int registerLimit = registers.length / 2;
+        if (range != null && address instanceof ArrayAddress array) {
+          // A ranged write must leave registers outside the selected first-dimension
+          // slices untouched: the merge round-trip is lossy for String and Bool elements.
+          int registersPerSlice =
+              firstDimensionSliceSize(array) * array.getDataType().getRegisterCount();
+          NumericRange.Bounds bounds = range.getBounds()[0];
+          firstRegister = bounds.getLow() * registersPerSlice;
+          registerLimit = Math.min((bounds.getHigh() + 1) * registersPerSlice, registerLimit);
+        }
+        for (int i = firstRegister; i < registerLimit; i++) {
+          byte[] value = new byte[] {registers[i * 2], registers[i * 2 + 1]};
+          registerMap.put(address.getOffset() + i, value);
+        }
+      }
+    } catch (UaException e) {
+      throw new UaRuntimeException(e);
+    }
+  }
+
+  /** Total number of registers spanned by {@code address}. */
+  private static int registerExtent(ModbusAddress address) {
+    int elementCount =
+        address instanceof ArrayAddress arrayAddress ? arrayAddress.getElementCount() : 1;
+    return elementCount * address.getDataType().getRegisterCount();
+  }
+
+  /** Copy the entries in {@code [offset, offset + count)} out of {@code map}. */
+  private static <V> Map<Integer, V> copyRange(Map<Integer, V> map, int offset, int count) {
+    var copy = new HashMap<Integer, V>();
+    for (Map.Entry<Integer, V> entry : map.entrySet()) {
+      int key = entry.getKey();
+      if (key >= offset && key - offset < count) {
+        copy.put(key, entry.getValue());
+      }
+    }
+    return copy;
+  }
+
+  /** An extra final range dimension selects characters within a String element. */
+  private static boolean isSubStringRange(ModbusAddress address, NumericRange range) {
+    int rank = address instanceof ArrayAddress array ? array.getDimensions().length : 0;
+    return range.getBounds().length == rank + 1;
+  }
+
+  /**
+   * Reject sub-string merges whose UTF-8 encoding no longer fits the element's registers; silently
+   * truncating would destroy characters outside the selected range.
+   */
+  private static void validateMergedStringByteCapacity(
+      ModbusAddress address, Object merged, NumericRange range) throws UaException {
+
+    int capacity = address.getDataType().getRegisterCount() * 2;
+
+    Object elements = merged instanceof Matrix matrix ? matrix.getElements() : merged;
+    if (elements instanceof String string) {
+      if (string.getBytes(StandardCharsets.UTF_8).length > capacity) {
+        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
+      }
+      return;
+    }
+
+    int first = 0;
+    int limit = Array.getLength(elements);
+    if (address instanceof ArrayAddress array) {
+      // Only elements in the selected first-dimension slices are written back.
+      int sliceSize = firstDimensionSliceSize(array);
+      NumericRange.Bounds bounds = range.getBounds()[0];
+      first = bounds.getLow() * sliceSize;
+      limit = Math.min((bounds.getHigh() + 1) * sliceSize, limit);
+    }
+    for (int i = first; i < limit; i++) {
+      if (Array.get(elements, i) instanceof String string
+          && string.getBytes(StandardCharsets.UTF_8).length > capacity) {
+        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
+      }
+    }
+  }
+
+  /**
+   * Merges an update into the portion of an OPC UA value selected by a numeric range.
+   *
+   * @param currentValue the complete scalar String, array, or matrix value to update.
+   * @param updateValue the replacement value whose shape must match the selected range.
+   * @param range the range identifying the portion to replace.
+   * @return the merged value, using a {@link Matrix} when its rank is greater than one.
+   * @throws UaException if either value is absent, the range selects no data, or the update's type
+   *     or shape is incompatible with the selected range.
+   */
+  static Object writeValueAtRange(Object currentValue, Object updateValue, NumericRange range)
+      throws UaException {
+
+    if (currentValue == null) {
+      throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+    }
+    if (updateValue == null) {
+      throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
+    }
+
+    if (currentValue instanceof Matrix matrix) {
+      currentValue = matrix.nestedArrayValue();
+    }
+    if (updateValue instanceof Matrix matrix) {
+      if (matrix.isNull()) {
+        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
+      }
+      updateValue = matrix.nestedArrayValue();
+    }
+
+    validateRangeDimensionCount(currentValue, range);
+
+    int[] currentDimensions = ArrayUtil.getDimensions(currentValue);
+    NumericRange.Bounds[] bounds = range.getBounds();
+    // Bounds past the end of the current value select no data; check before the shape
+    // comparisons so the client sees Bad_IndexRangeNoData rather than a shape mismatch.
+    for (int i = 0; i < currentDimensions.length; i++) {
+      if (bounds[i].getHigh() >= currentDimensions[i]) {
+        throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+      }
+    }
+
+    if (ArrayUtil.getBoxedType(currentValue) != ArrayUtil.getBoxedType(updateValue)) {
+      throw new UaException(StatusCodes.Bad_TypeMismatch);
+    }
+
+    int[] updateDimensions = ArrayUtil.getDimensions(updateValue);
+    // For String values an extra final range dimension selects characters within an
+    // element, so the update value has one fewer dimension than the range has bounds.
+    boolean subStringRange =
+        hasStringLeaf(currentValue) && bounds.length == currentDimensions.length + 1;
+    int expectedUpdateRank = subStringRange ? bounds.length - 1 : bounds.length;
+    if (updateDimensions.length != expectedUpdateRank) {
+      throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
+    }
+    for (int i = 0; i < updateDimensions.length; i++) {
+      long expectedLength = (long) bounds[i].getHigh() - bounds[i].getLow() + 1;
+      if (updateDimensions[i] != expectedLength) {
+        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
+      }
+    }
+    if (subStringRange) {
+      NumericRange.Bounds stringBounds = bounds[bounds.length - 1];
+      long expectedLength = (long) stringBounds.getHigh() - stringBounds.getLow() + 1;
+      validateStringLengths(updateValue, expectedLength);
+    }
+
+    Object valueAtRange = NumericRange.writeToValueAtRange(currentValue, updateValue, range);
+    if (ArrayUtil.getValueRank(valueAtRange) > 1) {
+      valueAtRange = new Matrix(valueAtRange);
+    }
+
+    return valueAtRange;
+  }
+
+  /**
+   * Parses the OPC UA numeric-range syntax accepted by this address space.
+   *
+   * @param indexRange the non-empty range text to parse.
+   * @return the parsed numeric range.
+   * @throws UaException if the text is not a well-formed numeric range.
+   */
+  static NumericRange parseNumericRange(String indexRange) throws UaException {
+    if (!NUMERIC_RANGE_PATTERN.matcher(indexRange).matches()) {
+      throw new UaException(StatusCodes.Bad_IndexRangeInvalid);
+    }
+    return NumericRange.parse(indexRange);
+  }
+
+  private static void validateRangeDimensionCount(Object value, NumericRange range)
+      throws UaException {
+
+    int valueRank = ArrayUtil.getDimensions(value).length;
+    int rangeDimensions = range.getBounds().length;
+    boolean valid =
+        hasStringLeaf(value)
+            ? rangeDimensions > 0
+                && (rangeDimensions == valueRank || rangeDimensions == valueRank + 1)
+            : rangeDimensions == valueRank;
+
+    if (!valid) {
+      throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+    }
+  }
+
+  private static void validateStringLengths(Object value, long expectedLength) throws UaException {
+    if (value == null) {
+      throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
+    }
+    if (value instanceof String string) {
+      if (string.length() != expectedLength) {
+        throw new UaException(StatusCodes.Bad_IndexRangeDataMismatch);
+      }
+      return;
+    }
+
+    for (int i = 0; i < Array.getLength(value); i++) {
+      validateStringLengths(Array.get(value, i), expectedLength);
+    }
+  }
+
+  private static boolean hasStringLeaf(Object value) {
+    Class<?> type = value.getClass();
+    while (type.isArray()) {
+      type = type.getComponentType();
+    }
+    return type == String.class;
+  }
+
+  /**
+   * Encodes an OPC UA value into the complete register extent described by an address.
+   *
+   * @param address the address whose data type, modifiers, and dimensions control encoding.
+   * @param variant the value to encode.
+   * @return the encoded bytes in Modbus register order.
+   * @throws UaException if the value does not match the address's data type or dimensions.
+   */
+  static byte[] getRegisterWriteBytes(ModbusAddress address, Variant variant) throws UaException {
+    return ModbusByteUtil.getBytesForValue(variant.getValue(), address);
+  }
+
+  /**
+   * Replaces the complete Boolean array represented by an address.
+   *
+   * <p>The value is validated before the map is mutated. One-dimensional addresses accept a boxed
+   * {@code Boolean[]} or primitive {@code boolean[]}; higher-rank addresses require a {@link
+   * Matrix} with matching dimensions.
+   *
+   * @param booleanMap the process-image entries to mutate.
+   * @param array the destination offset and dimensions.
+   * @param variant the complete array value to write.
+   * @throws UaException if the value has the wrong type or shape, or contains a null element.
+   */
+  static void writeBooleanArray(
+      Map<Integer, Boolean> booleanMap, ArrayAddress array, Variant variant) throws UaException {
+
+    writeBooleanArray(booleanMap, array, variant, 0, array.getElementCount());
+  }
+
+  private static void writeBooleanArray(
+      Map<Integer, Boolean> booleanMap,
+      ArrayAddress array,
+      Variant variant,
+      int firstElement,
+      int elementLimit)
+      throws UaException {
+
+    Object value = variant.getValue();
+
+    if (array.getDimensions().length > 1) {
+      if (!(value instanceof Matrix matrix)
+          || matrix.isNull()
+          || !Arrays.equals(matrix.getDimensions(), array.getDimensions())) {
+        throw new UaException(StatusCodes.Bad_TypeMismatch);
+      }
+      value = matrix.getElements();
+    }
+
+    Boolean[] booleans = boxedBooleanArray(value, array.getElementCount());
+
+    for (int i = firstElement; i < elementLimit; i++) {
+      booleanMap.put(array.getOffset() + i, booleans[i]);
+    }
+  }
+
+  /**
+   * Accepts boxed or primitive boolean arrays ({@link Matrix} supports both backings) and rejects
+   * null elements, which would poison the process image and NPE on later reads.
+   */
+  private static Boolean[] boxedBooleanArray(Object value, int expectedLength) throws UaException {
+    if (value instanceof boolean[] primitive) {
+      if (primitive.length != expectedLength) {
+        throw new UaException(StatusCodes.Bad_TypeMismatch);
+      }
+      Boolean[] boxed = new Boolean[primitive.length];
+      for (int i = 0; i < primitive.length; i++) {
+        boxed[i] = primitive[i];
+      }
+      return boxed;
+    }
+
+    if (!(value instanceof Boolean[] boxed) || boxed.length != expectedLength) {
+      throw new UaException(StatusCodes.Bad_TypeMismatch);
+    }
+    for (Boolean b : boxed) {
+      if (b == null) {
+        throw new UaException(StatusCodes.Bad_TypeMismatch);
+      }
+    }
+    return boxed;
+  }
+
+  private static void writeBitToRegister(
+      Map<Integer, byte[]> registerMap,
+      ModbusAddress address,
+      Variant variant,
+      ModbusDataType.Bit dataType)
+      throws UaException {
+
+    int bitIndex = dataType.bit();
+    ModbusDataType underlyingType = dataType.underlyingType();
+
+    var bytes = new byte[underlyingType.getRegisterCount() * 2];
+
+    for (int i = 0; i < bytes.length / 2; i++) {
+      byte[] value = registerMap.getOrDefault(address.getOffset() + i, EMPTY_REGISTER);
+      bytes[i * 2] = value[0];
+      bytes[i * 2 + 1] = value[1];
+    }
+
+    Object underlyingValue =
+        ModbusByteUtil.getScalarValueForBytes(
+            bytes, underlyingType, address.getDataTypeModifiers());
+
+    if (underlyingValue instanceof Number n) {
+      long mask = 1L << bitIndex;
+      long v = n.longValue();
+      if (variant.getValue() instanceof Boolean b) {
+        if (b) {
+          v |= mask;
+        } else {
+          v &= ~mask;
+        }
+        byte[] newBytes =
+            ModbusByteUtil.getBytesForScalarValue(
+                castToUnderlying(v, underlyingType),
+                underlyingType,
+                address.getDataTypeModifiers());
+
+        for (int i = 0; i < newBytes.length / 2; i++) {
+          byte[] value = new byte[] {newBytes[i * 2], newBytes[i * 2 + 1]};
+          registerMap.put(address.getOffset() + i, value);
+        }
+      } else {
+        throw new UaException(StatusCodes.Bad_TypeMismatch);
+      }
+    } else {
+      throw new UaException(StatusCodes.Bad_InternalError);
+    }
+  }
+
+  private static Number castToUnderlying(long value, ModbusDataType dataType) {
+    if (dataType instanceof ModbusDataType.Int16) {
+      return (short) value;
+    } else if (dataType instanceof ModbusDataType.Int32) {
+      return (int) value;
+    } else if (dataType instanceof ModbusDataType.Int64) {
+      return value;
+    } else if (dataType instanceof ModbusDataType.UInt16) {
+      return ushort((int) value);
+    } else if (dataType instanceof ModbusDataType.UInt32) {
+      return uint(value);
+    } else if (dataType instanceof ModbusDataType.UInt64) {
+      return ulong(value);
+    } else {
+      throw new IllegalArgumentException("value=" + value + ", dataType=" + dataType);
+    }
+  }
+}

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/address/ModbusAddress.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/address/ModbusAddress.java
@@ -66,6 +66,19 @@ public abstract sealed class ModbusAddress {
     public int[] getDimensions() {
       return dimensions;
     }
+
+    /**
+     * Get the total number of elements in the array: the product of all dimensions.
+     *
+     * @return the total number of elements in the array.
+     */
+    public int getElementCount() {
+      int elementCount = 1;
+      for (int dimension : dimensions) {
+        elementCount *= dimension;
+      }
+      return elementCount;
+    }
   }
 
   public static final class ScalarAddress extends ModbusAddress {

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/address/ModbusAddressParser.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/address/ModbusAddressParser.java
@@ -5,6 +5,7 @@ import com.kevinherron.ignition.modbus.address.DataTypeModifier.ByteOrderModifie
 import com.kevinherron.ignition.modbus.address.DataTypeModifier.WordOrder;
 import com.kevinherron.ignition.modbus.address.DataTypeModifier.WordOrderModifier;
 import com.kevinherron.ignition.modbus.address.ModbusAddress.ModbusArea;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -14,11 +15,14 @@ import org.jetbrains.annotations.Nullable;
 
 public class ModbusAddressParser {
 
+  private static final long ADDRESS_SPACE_SIZE = 65536L;
   private static final String AREAS = "C|DI|HR|IR";
   private static final String DATA_TYPES =
       "BOOL|INT16|UINT16|INT32|UINT32|INT64|UINT64|FLOAT|DOUBLE|STRING[1-9][0-9]*";
-  private static final String DATA_TYPE_MODIFIERS = "[@BE|@LE|@HL|@LH]+";
+  private static final String DATA_TYPE_MODIFIERS = "(?:@BE|@LE|@HL|@LH)+";
   private static final String SUBSCRIPTS = "\\[\\d+]";
+
+  private static final Pattern SUBSCRIPT_PATTERN = Pattern.compile("\\[(\\d+)]");
 
   static final Pattern ADDRESS_PATTERN =
       Pattern.compile(
@@ -38,17 +42,6 @@ public class ModbusAddressParser {
     if (!matcher.matches()) {
       throw new Exception("invalid address: " + address);
     }
-
-    // System.out.println("0: " + matcher.group(0));
-    // System.out.println("1: " + matcher.group(1));
-    // System.out.println("2: " + matcher.group(2));
-    // System.out.println("3: " + matcher.group(3));
-    // System.out.println("4: " + matcher.group(4));
-    // System.out.println("5: " + matcher.group(5));
-    // System.out.println("6: " + matcher.group(6));
-    // System.out.println("7: " + matcher.group(7));
-    // System.out.println("8: " + matcher.group(8));
-    // System.out.println("9: " + matcher.group(9));
 
     Integer unitId = parseUnitId(matcher.group(2));
 
@@ -76,19 +69,32 @@ public class ModbusAddressParser {
 
     if (matcher.group(9) != null) {
       int bit = Integer.parseInt(matcher.group(9));
+      validateBit(dataType, bit);
       dataType = new ModbusDataType.Bit(dataType, bit);
+    }
+
+    if (!dimensions.isEmpty()) {
+      if (indices.isEmpty() && dataType instanceof ModbusDataType.Bit) {
+        throw new Exception("bit specifiers are not allowed on array addresses");
+      }
+
+      validateExtent(area, offset, calculateElementCount(dimensions), dataType);
     }
 
     if (!indices.isEmpty()) {
       // element within an array
 
-      if (!dimensions.isEmpty() && dimensions.size() != indices.size()) {
+      if (dimensions.isEmpty()) {
+        throw new Exception("indices require array dimensions");
+      }
+
+      if (dimensions.size() != indices.size()) {
         throw new Exception(
             "number of indices (%d) doesn't match number of dimensions (%d)"
                 .formatted(indices.size(), dimensions.size()));
       }
 
-      int calculatedOffset = offset;
+      long linearIndex = 0;
       for (int i = 0; i < indices.size(); i++) {
         int index = indices.get(i);
         int dimension = dimensions.get(i);
@@ -97,17 +103,30 @@ public class ModbusAddressParser {
           throw new Exception("index " + index + " out of bounds for dimension " + dimension);
         }
 
-        int multiplier = 1;
-        for (int j = i + 1; j < dimensions.size(); j++) {
-          multiplier *= dimensions.get(j);
+        try {
+          linearIndex = Math.addExact(Math.multiplyExact(linearIndex, dimension), index);
+        } catch (ArithmeticException e) {
+          throw new Exception("indexed address extent exceeds the Modbus address space", e);
         }
-        calculatedOffset += index * multiplier * dataType.getRegisterCount();
       }
 
+      long calculatedOffset;
+      try {
+        calculatedOffset =
+            Math.addExact(
+                offset, Math.multiplyExact(linearIndex, entriesPerElement(area, dataType)));
+      } catch (ArithmeticException e) {
+        throw new Exception("indexed address extent exceeds the Modbus address space", e);
+      }
+
+      validateExtent(area, calculatedOffset, 1, dataType);
+
       return new ModbusAddress.ScalarAddress(
-          unitId, area, calculatedOffset, dataType, dataTypeModifiers);
+          unitId, area, (int) calculatedOffset, dataType, dataTypeModifiers);
     } else if (dimensions.isEmpty()) {
       // scalar address, no indices or dimensions
+
+      validateExtent(area, offset, 1, dataType);
 
       return new ModbusAddress.ScalarAddress(unitId, area, offset, dataType, dataTypeModifiers);
     } else {
@@ -118,6 +137,70 @@ public class ModbusAddressParser {
       return new ModbusAddress.ArrayAddress(
           unitId, area, offset, dataType, dataTypeModifiers, dimensionsArray);
     }
+  }
+
+  private static long calculateElementCount(List<Integer> dimensions) throws Exception {
+    long elementCount = 1;
+    try {
+      for (int dimension : dimensions) {
+        elementCount = Math.multiplyExact(elementCount, dimension);
+      }
+      return elementCount;
+    } catch (ArithmeticException e) {
+      throw new Exception("array extent exceeds the Modbus address space", e);
+    }
+  }
+
+  private static void validateExtent(
+      ModbusArea area, long offset, long elementCount, ModbusDataType dataType) throws Exception {
+    if (offset < 0 || offset >= ADDRESS_SPACE_SIZE) {
+      throw new Exception("offset %d is outside the Modbus address space".formatted(offset));
+    }
+
+    long entriesPerElement = entriesPerElement(area, dataType);
+    if (entriesPerElement <= 0) {
+      throw new Exception("entries per element must be positive");
+    }
+
+    long extent;
+    try {
+      extent =
+          Math.addExact(offset, Math.multiplyExact(elementCount, entriesPerElement));
+    } catch (ArithmeticException e) {
+      throw new Exception("address extent exceeds the Modbus address space", e);
+    }
+
+    if (extent > ADDRESS_SPACE_SIZE) {
+      throw new Exception(
+          "address extent %d exceeds the Modbus address space".formatted(extent));
+    }
+  }
+
+  private static void validateBit(ModbusDataType underlyingType, int bit) throws Exception {
+    boolean integerType =
+        underlyingType instanceof ModbusDataType.Int16
+            || underlyingType instanceof ModbusDataType.UInt16
+            || underlyingType instanceof ModbusDataType.Int32
+            || underlyingType instanceof ModbusDataType.UInt32
+            || underlyingType instanceof ModbusDataType.Int64
+            || underlyingType instanceof ModbusDataType.UInt64;
+
+    if (!integerType) {
+      throw new Exception("bit selection requires an integer data type: " + underlyingType);
+    }
+
+    int bitWidth = underlyingType.getRegisterCount() * 16;
+    if (bit < 0 || bit >= bitWidth) {
+      throw new Exception(
+          "bit index %d out of range for %d-bit data type".formatted(bit, bitWidth));
+    }
+  }
+
+  private static int entriesPerElement(ModbusArea area, ModbusDataType dataType) {
+    return switch (area) {
+      case COILS, DISCRETE_INPUTS -> 1;
+      case HOLDING_REGISTERS, INPUT_REGISTERS -> dataType.getRegisterCount();
+    };
   }
 
   public static boolean isValidAddress(String address) {
@@ -191,6 +274,13 @@ public class ModbusAddressParser {
       }
     }
 
+    // Coil and discrete input entries are single bits; register-only data types would
+    // advertise an OPC UA DataType the boolean read/write paths can never satisfy.
+    if ((area == ModbusArea.COILS || area == ModbusArea.DISCRETE_INPUTS)
+        && !(mdt instanceof ModbusDataType.Bool)) {
+      return Optional.empty();
+    }
+
     return Optional.ofNullable(mdt);
   }
 
@@ -208,9 +298,8 @@ public class ModbusAddressParser {
     }
 
     try {
-      var dimensionList = new java.util.ArrayList<Integer>();
-      var pattern = Pattern.compile("\\[(\\d+)]");
-      var matcher = pattern.matcher(subscripts);
+      var dimensionList = new ArrayList<Integer>();
+      var matcher = SUBSCRIPT_PATTERN.matcher(subscripts);
 
       while (matcher.find()) {
         int dimension = Integer.parseInt(matcher.group(1));
@@ -218,10 +307,6 @@ public class ModbusAddressParser {
           return Optional.empty();
         }
         dimensionList.add(dimension);
-      }
-
-      if (dimensionList.isEmpty()) {
-        return Optional.empty();
       }
 
       return Optional.of(dimensionList);
@@ -235,11 +320,13 @@ public class ModbusAddressParser {
       return Optional.of(Set.of());
     }
 
-    // TODO this ignores invalid modifiers instead of returning empty
-
     var set = new HashSet<DataTypeModifier>();
 
-    for (String s : modifiers.split("@")) {
+    if (!modifiers.startsWith("@")) {
+      return Optional.empty();
+    }
+
+    for (String s : modifiers.substring(1).split("@", -1)) {
       DataTypeModifier m =
           switch (s.toUpperCase()) {
             case "BE" -> new ByteOrderModifier(ByteOrder.BIG_ENDIAN);
@@ -249,9 +336,20 @@ public class ModbusAddressParser {
             default -> null;
           };
 
-      if (m != null) {
-        set.add(m);
+      if (m == null) {
+        return Optional.empty();
       }
+
+      boolean conflictsWithExisting =
+          set.stream()
+              .anyMatch(
+                  existing ->
+                      existing.getClass() == m.getClass() && !existing.equals(m));
+      if (conflictsWithExisting) {
+        return Optional.empty();
+      }
+
+      set.add(m);
     }
 
     return Optional.of(set);

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/address/ModbusAddressParser.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/address/ModbusAddressParser.java
@@ -120,6 +120,15 @@ public class ModbusAddressParser {
     }
   }
 
+  public static boolean isValidAddress(String address) {
+    try {
+      parse(address);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
   private static @Nullable Integer parseUnitId(String unitId) throws Exception {
     if (unitId != null) {
       try {

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/address/ModbusAddressParser.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/address/ModbusAddressParser.java
@@ -18,7 +18,7 @@ public class ModbusAddressParser {
   private static final String DATA_TYPES =
       "BOOL|INT16|UINT16|INT32|UINT32|INT64|UINT64|FLOAT|DOUBLE|STRING[1-9][0-9]*";
   private static final String DATA_TYPE_MODIFIERS = "[@BE|@LE|@HL|@LH]+";
-  private static final String ARRAY_DIMENSIONS = "\\[\\d+]";
+  private static final String SUBSCRIPTS = "\\[\\d+]";
 
   static final Pattern ADDRESS_PATTERN =
       Pattern.compile(
@@ -30,8 +30,7 @@ public class ModbusAddressParser {
           ((?:%s){0,3})?\
           (?:\\.(\\d+))?\
           """
-              .formatted(
-                  AREAS, DATA_TYPES, ARRAY_DIMENSIONS, DATA_TYPE_MODIFIERS, ARRAY_DIMENSIONS),
+              .formatted(AREAS, DATA_TYPES, SUBSCRIPTS, DATA_TYPE_MODIFIERS, SUBSCRIPTS),
           Pattern.CASE_INSENSITIVE);
 
   public static ModbusAddress parse(String address) throws Exception {
@@ -62,7 +61,7 @@ public class ModbusAddressParser {
             .orElseThrow(() -> new Exception("invalid DataType: " + matcher.group(4)));
 
     List<Integer> dimensions =
-        parseArrayDimensions(matcher.group(5))
+        parseDimensions(matcher.group(5))
             .orElseThrow(() -> new Exception("invalid dimensions: " + matcher.group(5)));
 
     Set<DataTypeModifier> dataTypeModifiers =
@@ -71,16 +70,53 @@ public class ModbusAddressParser {
 
     int offset = Integer.parseInt(matcher.group(7));
 
+    List<Integer> indices =
+        parseIndices(matcher.group(8))
+            .orElseThrow(() -> new Exception("invalid indices: " + matcher.group(8)));
+
     if (matcher.group(9) != null) {
       int bit = Integer.parseInt(matcher.group(9));
       dataType = new ModbusDataType.Bit(dataType, bit);
     }
 
-    if (dimensions.isEmpty()) {
+    if (!indices.isEmpty()) {
+      // element within an array
+
+      if (!dimensions.isEmpty() && dimensions.size() != indices.size()) {
+        throw new Exception(
+            "number of indices (%d) doesn't match number of dimensions (%d)"
+                .formatted(indices.size(), dimensions.size()));
+      }
+
+      int calculatedOffset = offset;
+      for (int i = 0; i < indices.size(); i++) {
+        int index = indices.get(i);
+        int dimension = dimensions.get(i);
+
+        if (index < 0 || index >= dimension) {
+          throw new Exception("index " + index + " out of bounds for dimension " + dimension);
+        }
+
+        int multiplier = 1;
+        for (int j = i + 1; j < dimensions.size(); j++) {
+          multiplier *= dimensions.get(j);
+        }
+        calculatedOffset += index * multiplier * dataType.getRegisterCount();
+      }
+
+      return new ModbusAddress.ScalarAddress(
+          unitId, area, calculatedOffset, dataType, dataTypeModifiers);
+    } else if (dimensions.isEmpty()) {
+      // scalar address, no indices or dimensions
+
       return new ModbusAddress.ScalarAddress(unitId, area, offset, dataType, dataTypeModifiers);
     } else {
-      // TODO arrays
-      throw new Exception("array address not implemented");
+      // array address, no indices but dimensions are present
+
+      int[] dimensionsArray = dimensions.stream().mapToInt(Integer::intValue).toArray();
+
+      return new ModbusAddress.ArrayAddress(
+          unitId, area, offset, dataType, dataTypeModifiers, dimensionsArray);
     }
   }
 
@@ -149,12 +185,40 @@ public class ModbusAddressParser {
     return Optional.ofNullable(mdt);
   }
 
-  private static Optional<List<Integer>> parseArrayDimensions(String dimensions) {
-    if (dimensions == null || dimensions.isEmpty()) {
+  private static Optional<List<Integer>> parseDimensions(String dimensions) {
+    return parseSubscripts(dimensions, 1);
+  }
+
+  private static Optional<List<Integer>> parseIndices(String indices) {
+    return parseSubscripts(indices, 0);
+  }
+
+  private static Optional<List<Integer>> parseSubscripts(String subscripts, int minAllowed) {
+    if (subscripts == null || subscripts.isEmpty()) {
       return Optional.of(List.of());
     }
-    // TODO
-    return Optional.empty();
+
+    try {
+      var dimensionList = new java.util.ArrayList<Integer>();
+      var pattern = Pattern.compile("\\[(\\d+)]");
+      var matcher = pattern.matcher(subscripts);
+
+      while (matcher.find()) {
+        int dimension = Integer.parseInt(matcher.group(1));
+        if (dimension < minAllowed) {
+          return Optional.empty();
+        }
+        dimensionList.add(dimension);
+      }
+
+      if (dimensionList.isEmpty()) {
+        return Optional.empty();
+      }
+
+      return Optional.of(dimensionList);
+    } catch (NumberFormatException e) {
+      return Optional.empty();
+    }
   }
 
   private static Optional<Set<DataTypeModifier>> parseDataTypeModifiers(String modifiers) {

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/address/ModbusDataType.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/address/ModbusDataType.java
@@ -147,7 +147,7 @@ public sealed interface ModbusDataType
 
     @Override
     public int getRegisterCount() {
-      return (length + 1) / 2;
+      return (int) ((length + 1L) / 2L);
     }
   }
 }

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
@@ -27,7 +28,7 @@ public final class ModbusByteUtil {
       throws UaException {
 
     if (dataType instanceof ModbusDataType.Bit d) {
-      // read underlying value, check and return specified bit
+      // read the underlying value, check and return the specified bit
       Object value = getValueForBytes(registerBytes, d.underlyingType(), modifiers);
       if (value instanceof Number n) {
         return (n.longValue() & (1L << d.bit())) != 0L;
@@ -70,10 +71,23 @@ public final class ModbusByteUtil {
   }
 
   public static byte[] getBytesForValue(Object value, ModbusAddress address) throws UaException {
-    return getBytesForValue(value, address.getDataType(), address.getDataTypeModifiers());
+    if (address instanceof ModbusAddress.ArrayAddress array) {
+      if (array.getDimensions().length == 1) {
+        return getBytesForArrayValue(
+            value, array.getDataType(), array.getDataTypeModifiers(), array.getDimensions());
+      } else {
+        assert array.getDimensions().length > 1;
+        return getBytesForMatrixValue(
+            value, array.getDataType(), array.getDataTypeModifiers(), array.getDimensions());
+      }
+    } else if (address instanceof ModbusAddress.ScalarAddress) {
+      return getBytesForScalarValue(value, address.getDataType(), address.getDataTypeModifiers());
+    } else {
+      throw new IllegalArgumentException("address: " + address);
+    }
   }
 
-  public static byte[] getBytesForValue(
+  public static byte[] getBytesForScalarValue(
       Object value, ModbusDataType dataType, Set<DataTypeModifier> modifiers) throws UaException {
 
     byte[] valueBytes = new byte[dataType.getRegisterCount() * 2];
@@ -145,6 +159,28 @@ public final class ModbusByteUtil {
     }
 
     return valueBytes;
+  }
+
+  private static byte[] getBytesForArrayValue(
+      Object value, ModbusDataType dataType, Set<DataTypeModifier> modifiers, int[] dimensions)
+      throws UaException {
+
+    // TODO
+    throw new UaException(StatusCodes.Bad_NotImplemented);
+  }
+
+  private static byte[] getBytesForMatrixValue(
+      Object value, ModbusDataType dataType, Set<DataTypeModifier> modifiers, int[] dimensions)
+      throws UaException {
+
+    if (!(value instanceof Matrix)) {
+      throw new UaException(StatusCodes.Bad_TypeMismatch);
+    }
+
+    Matrix matrix = (Matrix) value;
+
+    // TODO
+    throw new UaException(StatusCodes.Bad_NotImplemented);
   }
 
   static ByteArrayByteOps getByteOps(Set<DataTypeModifier> modifiers) {

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
@@ -4,6 +4,7 @@ import com.digitalpetri.util.ByteArrayByteOps;
 import com.kevinherron.ignition.modbus.address.DataTypeModifier;
 import com.kevinherron.ignition.modbus.address.ModbusAddress;
 import com.kevinherron.ignition.modbus.address.ModbusDataType;
+import java.lang.reflect.Array;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
@@ -98,8 +99,92 @@ public final class ModbusByteUtil {
       int[] dimensions)
       throws UaException {
 
-    // TODO
-    throw new UaException(StatusCodes.Bad_NotImplemented);
+    if (dimensions.length != 1) {
+      throw new UaException(StatusCodes.Bad_TypeMismatch, "expected 1-dimensional array");
+    }
+
+    int arrayLength = dimensions[0];
+    int bytesPerElement = dataType.getRegisterCount() * 2;
+    int totalBytes = arrayLength * bytesPerElement;
+
+    if (registerBytes.length < totalBytes) {
+      throw new UaException(StatusCodes.Bad_InternalError, "registerBytes.length < " + totalBytes);
+    }
+
+    ByteArrayByteOps byteOps = getByteOps(modifiers);
+
+    Class<?> componentType;
+    if (dataType instanceof ModbusDataType.Bool) {
+      componentType = Boolean.class;
+    } else if (dataType instanceof ModbusDataType.Int16) {
+      componentType = Short.class;
+    } else if (dataType instanceof ModbusDataType.UInt16) {
+      componentType = UShort.class;
+    } else if (dataType instanceof ModbusDataType.Int32) {
+      componentType = Integer.class;
+    } else if (dataType instanceof ModbusDataType.UInt32) {
+      componentType = UInteger.class;
+    } else if (dataType instanceof ModbusDataType.Int64) {
+      componentType = Long.class;
+    } else if (dataType instanceof ModbusDataType.UInt64) {
+      componentType = ULong.class;
+    } else if (dataType instanceof ModbusDataType.Float32) {
+      componentType = Float.class;
+    } else if (dataType instanceof ModbusDataType.Double64) {
+      componentType = Double.class;
+    } else if (dataType instanceof ModbusDataType.String) {
+      componentType = String.class;
+    } else if (dataType instanceof ModbusDataType.Bit) {
+      throw new UaException(StatusCodes.Bad_InternalError, "Bit arrays are not allowed");
+    } else {
+      throw new UaException(StatusCodes.Bad_InternalError, "dataType: " + dataType);
+    }
+
+    Object array = Array.newInstance(componentType, arrayLength);
+
+    // Iterate and parse
+    for (int i = 0; i < arrayLength; i++) {
+      int offset = i * bytesPerElement;
+
+      Object value;
+      if (dataType instanceof ModbusDataType.Bool) {
+        value = byteOps.getBoolean(registerBytes, offset);
+      } else if (dataType instanceof ModbusDataType.Int16) {
+        value = byteOps.getShort(registerBytes, offset);
+      } else if (dataType instanceof ModbusDataType.UInt16) {
+        short v = byteOps.getShort(registerBytes, offset);
+        value = UShort.valueOf(v);
+      } else if (dataType instanceof ModbusDataType.Int32) {
+        value = byteOps.getInt(registerBytes, offset);
+      } else if (dataType instanceof ModbusDataType.UInt32) {
+        int v = byteOps.getInt(registerBytes, offset);
+        value = UInteger.valueOf(v);
+      } else if (dataType instanceof ModbusDataType.Int64) {
+        value = byteOps.getLong(registerBytes, offset);
+      } else if (dataType instanceof ModbusDataType.UInt64) {
+        long v = byteOps.getLong(registerBytes, offset);
+        value = ULong.valueOf(v);
+      } else if (dataType instanceof ModbusDataType.Float32) {
+        value = byteOps.getFloat(registerBytes, offset);
+      } else if (dataType instanceof ModbusDataType.Double64) {
+        value = byteOps.getDouble(registerBytes, offset);
+      } else if (dataType instanceof ModbusDataType.String str) {
+        int length = str.length();
+        for (int j = 0; j < length; j++) {
+          if (registerBytes[offset + j] == 0) {
+            length = j;
+            break;
+          }
+        }
+        value = new String(registerBytes, offset, length, StandardCharsets.UTF_8);
+      } else {
+        throw new UaException(StatusCodes.Bad_InternalError, "dataType: " + dataType);
+      }
+
+      Array.set(array, i, value);
+    }
+
+    return array;
   }
 
   public static Object getMatrixValueForBytes(
@@ -228,7 +313,7 @@ public final class ModbusByteUtil {
     ByteArrayByteOps byteOps = getByteOps(modifiers);
 
     for (int i = 0; i < arrayLength; i++) {
-      Object element = java.lang.reflect.Array.get(value, i);
+      Object element = Array.get(value, i);
       int offset = i * bytesPerElement;
 
       if (dataType instanceof ModbusDataType.Bool) {

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
@@ -194,8 +194,21 @@ public final class ModbusByteUtil {
       int[] dimensions)
       throws UaException {
 
-    // TODO
-    throw new UaException(StatusCodes.Bad_NotImplemented);
+    if (dimensions.length <= 1) {
+      throw new UaException(
+          StatusCodes.Bad_InternalError,
+          "expected multi-dimensional array (dimensions.length > 1)");
+    }
+
+    int totalElementCount = 1;
+    for (int dimension : dimensions) {
+      totalElementCount *= dimension;
+    }
+
+    Object flatArray =
+        getArrayValueForBytes(registerBytes, dataType, modifiers, new int[] {totalElementCount});
+
+    return new Matrix(flatArray, dimensions, dataType.getOpcUaDataType());
   }
 
   public static byte[] getBytesForValue(Object value, ModbusAddress address) throws UaException {

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
@@ -161,12 +161,102 @@ public final class ModbusByteUtil {
     return valueBytes;
   }
 
-  private static byte[] getBytesForArrayValue(
+  static byte[] getBytesForArrayValue(
       Object value, ModbusDataType dataType, Set<DataTypeModifier> modifiers, int[] dimensions)
       throws UaException {
 
-    // TODO
-    throw new UaException(StatusCodes.Bad_NotImplemented);
+    // Check if the input value is actually a Java array
+    if (!value.getClass().isArray()) {
+      throw new UaException(StatusCodes.Bad_TypeMismatch, "expected array");
+    }
+
+    // Validate dimensions array
+    if (dimensions.length != 1) {
+      throw new UaException(StatusCodes.Bad_TypeMismatch, "expected 1-dimensional array");
+    }
+
+    int arrayLength = dimensions[0];
+
+    int bytesPerElement = dataType.getRegisterCount() * 2;
+    int totalBytes = arrayLength * bytesPerElement;
+    byte[] valueBytes = new byte[totalBytes];
+
+    ByteArrayByteOps byteOps = getByteOps(modifiers);
+
+    for (int i = 0; i < arrayLength; i++) {
+      Object element = java.lang.reflect.Array.get(value, i);
+      int offset = i * bytesPerElement;
+
+      if (dataType instanceof ModbusDataType.Bool) {
+        if (element instanceof Boolean v) {
+          byteOps.setBoolean(valueBytes, offset, v);
+        } else {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      } else if (dataType instanceof ModbusDataType.Int16) {
+        if (element instanceof Short v) {
+          byteOps.setShort(valueBytes, offset, v);
+        } else {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      } else if (dataType instanceof ModbusDataType.UInt16) {
+        if (element instanceof UShort v) {
+          byteOps.setShort(valueBytes, offset, v.shortValue());
+        } else {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      } else if (dataType instanceof ModbusDataType.Int32) {
+        if (element instanceof Integer v) {
+          byteOps.setInt(valueBytes, offset, v);
+        } else {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      } else if (dataType instanceof ModbusDataType.UInt32) {
+        if (element instanceof UInteger v) {
+          byteOps.setInt(valueBytes, offset, v.intValue());
+        } else {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      } else if (dataType instanceof ModbusDataType.Int64) {
+        if (element instanceof Long v) {
+          byteOps.setLong(valueBytes, offset, v);
+        } else {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      } else if (dataType instanceof ModbusDataType.UInt64) {
+        if (element instanceof ULong v) {
+          byteOps.setLong(valueBytes, offset, v.longValue());
+        } else {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      } else if (dataType instanceof ModbusDataType.Float32) {
+        if (element instanceof Float v) {
+          byteOps.setFloat(valueBytes, offset, v);
+        } else {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      } else if (dataType instanceof ModbusDataType.Double64) {
+        if (element instanceof Double v) {
+          byteOps.setDouble(valueBytes, offset, v);
+        } else {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      } else if (dataType instanceof ModbusDataType.String) {
+        if (element instanceof String v) {
+          // note: padding with null bytes happens automatically
+          // since valueBytes is initialized with zeros
+          byte[] stringBytes = v.getBytes(StandardCharsets.UTF_8);
+          int lengthToCopy = Math.min(stringBytes.length, bytesPerElement);
+          System.arraycopy(stringBytes, 0, valueBytes, offset, lengthToCopy);
+        } else {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      } else {
+        throw new UaException(StatusCodes.Bad_InternalError, "dataType: " + dataType);
+      }
+    }
+
+    return valueBytes;
   }
 
   private static byte[] getBytesForMatrixValue(
@@ -197,16 +287,14 @@ public final class ModbusByteUtil {
     }
 
     return switch (byteOrder) {
-      case BIG_ENDIAN ->
-          switch (wordOrder) {
-            case HIGH_LOW -> ByteArrayByteOps.BIG_ENDIAN;
-            case LOW_HIGH -> ByteArrayByteOps.BIG_ENDIAN_LOW_HIGH;
-          };
-      case LITTLE_ENDIAN ->
-          switch (wordOrder) {
-            case HIGH_LOW -> ByteArrayByteOps.LITTLE_ENDIAN;
-            case LOW_HIGH -> ByteArrayByteOps.LITTLE_ENDIAN_LOW_HIGH;
-          };
+      case BIG_ENDIAN -> switch (wordOrder) {
+        case HIGH_LOW -> ByteArrayByteOps.BIG_ENDIAN;
+        case LOW_HIGH -> ByteArrayByteOps.BIG_ENDIAN_LOW_HIGH;
+      };
+      case LITTLE_ENDIAN -> switch (wordOrder) {
+        case HIGH_LOW -> ByteArrayByteOps.LITTLE_ENDIAN;
+        case LOW_HIGH -> ByteArrayByteOps.LITTLE_ENDIAN_LOW_HIGH;
+      };
     };
   }
 }

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
@@ -259,18 +259,37 @@ public final class ModbusByteUtil {
     return valueBytes;
   }
 
-  private static byte[] getBytesForMatrixValue(
+  static byte[] getBytesForMatrixValue(
       Object value, ModbusDataType dataType, Set<DataTypeModifier> modifiers, int[] dimensions)
       throws UaException {
 
-    if (!(value instanceof Matrix)) {
+    if (value instanceof Matrix matrix) {
+      if (matrix.isNull()) {
+        throw new UaException(StatusCodes.Bad_TypeMismatch);
+      }
+
+      if (matrix.getDimensions().length != dimensions.length) {
+        throw new UaException(StatusCodes.Bad_TypeMismatch);
+      }
+
+      for (int i = 0; i < dimensions.length; i++) {
+        if (matrix.getDimensions()[i] != dimensions[i]) {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      }
+
+      Object flatArrayValue = matrix.getElements();
+      assert flatArrayValue != null;
+
+      int elementCount = 1;
+      for (int dimension : dimensions) {
+        elementCount *= dimension;
+      }
+
+      return getBytesForArrayValue(flatArrayValue, dataType, modifiers, new int[] {elementCount});
+    } else {
       throw new UaException(StatusCodes.Bad_TypeMismatch);
     }
-
-    Matrix matrix = (Matrix) value;
-
-    // TODO
-    throw new UaException(StatusCodes.Bad_NotImplemented);
   }
 
   static ByteArrayByteOps getByteOps(Set<DataTypeModifier> modifiers) {
@@ -287,14 +306,16 @@ public final class ModbusByteUtil {
     }
 
     return switch (byteOrder) {
-      case BIG_ENDIAN -> switch (wordOrder) {
-        case HIGH_LOW -> ByteArrayByteOps.BIG_ENDIAN;
-        case LOW_HIGH -> ByteArrayByteOps.BIG_ENDIAN_LOW_HIGH;
-      };
-      case LITTLE_ENDIAN -> switch (wordOrder) {
-        case HIGH_LOW -> ByteArrayByteOps.LITTLE_ENDIAN;
-        case LOW_HIGH -> ByteArrayByteOps.LITTLE_ENDIAN_LOW_HIGH;
-      };
+      case BIG_ENDIAN ->
+          switch (wordOrder) {
+            case HIGH_LOW -> ByteArrayByteOps.BIG_ENDIAN;
+            case LOW_HIGH -> ByteArrayByteOps.BIG_ENDIAN_LOW_HIGH;
+          };
+      case LITTLE_ENDIAN ->
+          switch (wordOrder) {
+            case HIGH_LOW -> ByteArrayByteOps.LITTLE_ENDIAN;
+            case LOW_HIGH -> ByteArrayByteOps.LITTLE_ENDIAN_LOW_HIGH;
+          };
     };
   }
 }

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
@@ -20,16 +20,37 @@ public final class ModbusByteUtil {
   public static Object getValueForBytes(byte[] registerBytes, ModbusAddress address)
       throws UaException {
 
-    return getValueForBytes(registerBytes, address.getDataType(), address.getDataTypeModifiers());
+    if (address instanceof ModbusAddress.ArrayAddress array) {
+      if (array.getDimensions().length == 1) {
+        return getArrayValueForBytes(
+            registerBytes,
+            array.getDataType(),
+            array.getDataTypeModifiers(),
+            array.getDimensions());
+      } else {
+        assert array.getDimensions().length > 1;
+
+        return getMatrixValueForBytes(
+            registerBytes,
+            array.getDataType(),
+            array.getDataTypeModifiers(),
+            array.getDimensions());
+      }
+    } else if (address instanceof ModbusAddress.ScalarAddress) {
+      return getScalarValueForBytes(
+          registerBytes, address.getDataType(), address.getDataTypeModifiers());
+    } else {
+      throw new IllegalArgumentException("address: " + address);
+    }
   }
 
-  public static Object getValueForBytes(
+  public static Object getScalarValueForBytes(
       byte[] registerBytes, ModbusDataType dataType, Set<DataTypeModifier> modifiers)
       throws UaException {
 
     if (dataType instanceof ModbusDataType.Bit d) {
       // read the underlying value, check and return the specified bit
-      Object value = getValueForBytes(registerBytes, d.underlyingType(), modifiers);
+      Object value = getScalarValueForBytes(registerBytes, d.underlyingType(), modifiers);
       if (value instanceof Number n) {
         return (n.longValue() & (1L << d.bit())) != 0L;
       } else {
@@ -70,6 +91,28 @@ public final class ModbusByteUtil {
     }
   }
 
+  public static Object getArrayValueForBytes(
+      byte[] registerBytes,
+      ModbusDataType dataType,
+      Set<DataTypeModifier> modifiers,
+      int[] dimensions)
+      throws UaException {
+
+    // TODO
+    throw new UaException(StatusCodes.Bad_NotImplemented);
+  }
+
+  public static Object getMatrixValueForBytes(
+      byte[] registerBytes,
+      ModbusDataType dataType,
+      Set<DataTypeModifier> modifiers,
+      int[] dimensions)
+      throws UaException {
+
+    // TODO
+    throw new UaException(StatusCodes.Bad_NotImplemented);
+  }
+
   public static byte[] getBytesForValue(Object value, ModbusAddress address) throws UaException {
     if (address instanceof ModbusAddress.ArrayAddress array) {
       if (array.getDimensions().length == 1) {
@@ -77,6 +120,7 @@ public final class ModbusByteUtil {
             value, array.getDataType(), array.getDataTypeModifiers(), array.getDimensions());
       } else {
         assert array.getDimensions().length > 1;
+
         return getBytesForMatrixValue(
             value, array.getDataType(), array.getDataTypeModifiers(), array.getDimensions());
       }

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
@@ -6,6 +6,7 @@ import com.kevinherron.ignition.modbus.address.ModbusAddress;
 import com.kevinherron.ignition.modbus.address.ModbusDataType;
 import java.lang.reflect.Array;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Set;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -49,44 +50,51 @@ public final class ModbusByteUtil {
       byte[] registerBytes, ModbusDataType dataType, Set<DataTypeModifier> modifiers)
       throws UaException {
 
+    return getScalarValueForBytes(registerBytes, 0, dataType, modifiers);
+  }
+
+  static Object getScalarValueForBytes(
+      byte[] registerBytes, int offset, ModbusDataType dataType, Set<DataTypeModifier> modifiers)
+      throws UaException {
+
     if (dataType instanceof ModbusDataType.Bit d) {
       // read the underlying value, check and return the specified bit
-      Object value = getScalarValueForBytes(registerBytes, d.underlyingType(), modifiers);
+      Object value = getScalarValueForBytes(registerBytes, offset, d.underlyingType(), modifiers);
       if (value instanceof Number n) {
         return (n.longValue() & (1L << d.bit())) != 0L;
       } else {
         throw new UaException(StatusCodes.Bad_InternalError, "underlying: " + d.underlyingType());
       }
     } else if (dataType instanceof ModbusDataType.Bool) {
-      return getByteOps(modifiers).getBoolean(registerBytes, 0);
+      return getByteOps(modifiers).getBoolean(registerBytes, offset);
     } else if (dataType instanceof ModbusDataType.Int16) {
-      return getByteOps(modifiers).getShort(registerBytes, 0);
+      return getByteOps(modifiers).getShort(registerBytes, offset);
     } else if (dataType instanceof ModbusDataType.UInt16) {
-      short v = getByteOps(modifiers).getShort(registerBytes, 0);
+      short v = getByteOps(modifiers).getShort(registerBytes, offset);
       return UShort.valueOf(v);
     } else if (dataType instanceof ModbusDataType.Int32) {
-      return getByteOps(modifiers).getInt(registerBytes, 0);
+      return getByteOps(modifiers).getInt(registerBytes, offset);
     } else if (dataType instanceof ModbusDataType.UInt32) {
-      int v = getByteOps(modifiers).getInt(registerBytes, 0);
+      int v = getByteOps(modifiers).getInt(registerBytes, offset);
       return UInteger.valueOf(v);
     } else if (dataType instanceof ModbusDataType.Int64) {
-      return getByteOps(modifiers).getLong(registerBytes, 0);
+      return getByteOps(modifiers).getLong(registerBytes, offset);
     } else if (dataType instanceof ModbusDataType.UInt64) {
-      long v = getByteOps(modifiers).getLong(registerBytes, 0);
+      long v = getByteOps(modifiers).getLong(registerBytes, offset);
       return ULong.valueOf(v);
     } else if (dataType instanceof ModbusDataType.Float32) {
-      return getByteOps(modifiers).getFloat(registerBytes, 0);
+      return getByteOps(modifiers).getFloat(registerBytes, offset);
     } else if (dataType instanceof ModbusDataType.Double64) {
-      return getByteOps(modifiers).getDouble(registerBytes, 0);
+      return getByteOps(modifiers).getDouble(registerBytes, offset);
     } else if (dataType instanceof ModbusDataType.String d) {
       int length = d.length();
       for (int i = 0; i < length; i++) {
-        if (registerBytes[i] == 0) {
+        if (registerBytes[offset + i] == 0) {
           length = i;
           break;
         }
       }
-      return new String(registerBytes, 0, length, StandardCharsets.UTF_8);
+      return new String(registerBytes, offset, length, StandardCharsets.UTF_8);
     } else {
       throw new UaException(StatusCodes.Bad_InternalError, "dataType: " + dataType);
     }
@@ -103,6 +111,10 @@ public final class ModbusByteUtil {
       throw new UaException(StatusCodes.Bad_TypeMismatch, "expected 1-dimensional array");
     }
 
+    if (dataType instanceof ModbusDataType.Bit) {
+      throw new UaException(StatusCodes.Bad_InternalError, "Bit arrays are not allowed");
+    }
+
     int arrayLength = dimensions[0];
     int bytesPerElement = dataType.getRegisterCount() * 2;
     int totalBytes = arrayLength * bytesPerElement;
@@ -111,77 +123,12 @@ public final class ModbusByteUtil {
       throw new UaException(StatusCodes.Bad_InternalError, "registerBytes.length < " + totalBytes);
     }
 
-    ByteArrayByteOps byteOps = getByteOps(modifiers);
-
-    Class<?> componentType;
-    if (dataType instanceof ModbusDataType.Bool) {
-      componentType = Boolean.class;
-    } else if (dataType instanceof ModbusDataType.Int16) {
-      componentType = Short.class;
-    } else if (dataType instanceof ModbusDataType.UInt16) {
-      componentType = UShort.class;
-    } else if (dataType instanceof ModbusDataType.Int32) {
-      componentType = Integer.class;
-    } else if (dataType instanceof ModbusDataType.UInt32) {
-      componentType = UInteger.class;
-    } else if (dataType instanceof ModbusDataType.Int64) {
-      componentType = Long.class;
-    } else if (dataType instanceof ModbusDataType.UInt64) {
-      componentType = ULong.class;
-    } else if (dataType instanceof ModbusDataType.Float32) {
-      componentType = Float.class;
-    } else if (dataType instanceof ModbusDataType.Double64) {
-      componentType = Double.class;
-    } else if (dataType instanceof ModbusDataType.String) {
-      componentType = String.class;
-    } else if (dataType instanceof ModbusDataType.Bit) {
-      throw new UaException(StatusCodes.Bad_InternalError, "Bit arrays are not allowed");
-    } else {
-      throw new UaException(StatusCodes.Bad_InternalError, "dataType: " + dataType);
-    }
-
+    Class<?> componentType = dataType.getOpcUaDataType().getBackingClass();
     Object array = Array.newInstance(componentType, arrayLength);
 
-    // Iterate and parse
     for (int i = 0; i < arrayLength; i++) {
-      int offset = i * bytesPerElement;
-
-      Object value;
-      if (dataType instanceof ModbusDataType.Bool) {
-        value = byteOps.getBoolean(registerBytes, offset);
-      } else if (dataType instanceof ModbusDataType.Int16) {
-        value = byteOps.getShort(registerBytes, offset);
-      } else if (dataType instanceof ModbusDataType.UInt16) {
-        short v = byteOps.getShort(registerBytes, offset);
-        value = UShort.valueOf(v);
-      } else if (dataType instanceof ModbusDataType.Int32) {
-        value = byteOps.getInt(registerBytes, offset);
-      } else if (dataType instanceof ModbusDataType.UInt32) {
-        int v = byteOps.getInt(registerBytes, offset);
-        value = UInteger.valueOf(v);
-      } else if (dataType instanceof ModbusDataType.Int64) {
-        value = byteOps.getLong(registerBytes, offset);
-      } else if (dataType instanceof ModbusDataType.UInt64) {
-        long v = byteOps.getLong(registerBytes, offset);
-        value = ULong.valueOf(v);
-      } else if (dataType instanceof ModbusDataType.Float32) {
-        value = byteOps.getFloat(registerBytes, offset);
-      } else if (dataType instanceof ModbusDataType.Double64) {
-        value = byteOps.getDouble(registerBytes, offset);
-      } else if (dataType instanceof ModbusDataType.String str) {
-        int length = str.length();
-        for (int j = 0; j < length; j++) {
-          if (registerBytes[offset + j] == 0) {
-            length = j;
-            break;
-          }
-        }
-        value = new String(registerBytes, offset, length, StandardCharsets.UTF_8);
-      } else {
-        throw new UaException(StatusCodes.Bad_InternalError, "dataType: " + dataType);
-      }
-
-      Array.set(array, i, value);
+      Array.set(
+          array, i, getScalarValueForBytes(registerBytes, i * bytesPerElement, dataType, modifiers));
     }
 
     return array;
@@ -200,13 +147,9 @@ public final class ModbusByteUtil {
           "expected multi-dimensional array (dimensions.length > 1)");
     }
 
-    int totalElementCount = 1;
-    for (int dimension : dimensions) {
-      totalElementCount *= dimension;
-    }
-
     Object flatArray =
-        getArrayValueForBytes(registerBytes, dataType, modifiers, new int[] {totalElementCount});
+        getArrayValueForBytes(
+            registerBytes, dataType, modifiers, new int[] {elementCount(dimensions)});
 
     return new Matrix(flatArray, dimensions, dataType.getOpcUaDataType());
   }
@@ -233,74 +176,83 @@ public final class ModbusByteUtil {
       Object value, ModbusDataType dataType, Set<DataTypeModifier> modifiers) throws UaException {
 
     byte[] valueBytes = new byte[dataType.getRegisterCount() * 2];
+    setBytesForScalarValue(value, valueBytes, 0, dataType, modifiers);
+    return valueBytes;
+  }
+
+  static void setBytesForScalarValue(
+      Object value,
+      byte[] valueBytes,
+      int offset,
+      ModbusDataType dataType,
+      Set<DataTypeModifier> modifiers)
+      throws UaException {
 
     if (dataType instanceof ModbusDataType.Bool) {
       if (value instanceof Boolean v) {
-        getByteOps(modifiers).setBoolean(valueBytes, 0, v);
+        getByteOps(modifiers).setBoolean(valueBytes, offset, v);
       } else {
         throw new UaException(StatusCodes.Bad_TypeMismatch);
       }
     } else if (dataType instanceof ModbusDataType.Int16) {
       if (value instanceof Short v) {
-        getByteOps(modifiers).setShort(valueBytes, 0, v);
+        getByteOps(modifiers).setShort(valueBytes, offset, v);
       } else {
         throw new UaException(StatusCodes.Bad_TypeMismatch);
       }
     } else if (dataType instanceof ModbusDataType.UInt16) {
       if (value instanceof UShort v) {
-        getByteOps(modifiers).setShort(valueBytes, 0, v.shortValue());
+        getByteOps(modifiers).setShort(valueBytes, offset, v.shortValue());
       } else {
         throw new UaException(StatusCodes.Bad_TypeMismatch);
       }
     } else if (dataType instanceof ModbusDataType.Int32) {
       if (value instanceof Integer v) {
-        getByteOps(modifiers).setInt(valueBytes, 0, v);
+        getByteOps(modifiers).setInt(valueBytes, offset, v);
       } else {
         throw new UaException(StatusCodes.Bad_TypeMismatch);
       }
     } else if (dataType instanceof ModbusDataType.UInt32) {
       if (value instanceof UInteger v) {
-        getByteOps(modifiers).setInt(valueBytes, 0, v.intValue());
+        getByteOps(modifiers).setInt(valueBytes, offset, v.intValue());
       } else {
         throw new UaException(StatusCodes.Bad_TypeMismatch);
       }
     } else if (dataType instanceof ModbusDataType.Int64) {
       if (value instanceof Long v) {
-        getByteOps(modifiers).setLong(valueBytes, 0, v);
+        getByteOps(modifiers).setLong(valueBytes, offset, v);
       } else {
         throw new UaException(StatusCodes.Bad_TypeMismatch);
       }
     } else if (dataType instanceof ModbusDataType.UInt64) {
       if (value instanceof ULong v) {
-        getByteOps(modifiers).setLong(valueBytes, 0, v.longValue());
+        getByteOps(modifiers).setLong(valueBytes, offset, v.longValue());
       } else {
         throw new UaException(StatusCodes.Bad_TypeMismatch);
       }
     } else if (dataType instanceof ModbusDataType.Float32) {
       if (value instanceof Float v) {
-        getByteOps(modifiers).setFloat(valueBytes, 0, v);
+        getByteOps(modifiers).setFloat(valueBytes, offset, v);
       } else {
         throw new UaException(StatusCodes.Bad_TypeMismatch);
       }
     } else if (dataType instanceof ModbusDataType.Double64) {
       if (value instanceof Double v) {
-        getByteOps(modifiers).setDouble(valueBytes, 0, v);
+        getByteOps(modifiers).setDouble(valueBytes, offset, v);
       } else {
         throw new UaException(StatusCodes.Bad_TypeMismatch);
       }
     } else if (dataType instanceof ModbusDataType.String) {
       if (value instanceof String v) {
         byte[] stringBytes = v.getBytes(StandardCharsets.UTF_8);
-        int length = Math.min(stringBytes.length, valueBytes.length);
-        System.arraycopy(stringBytes, 0, valueBytes, 0, length);
+        int length = Math.min(stringBytes.length, dataType.getRegisterCount() * 2);
+        System.arraycopy(stringBytes, 0, valueBytes, offset, length);
       } else {
         throw new UaException(StatusCodes.Bad_TypeMismatch);
       }
     } else {
       throw new UaException(StatusCodes.Bad_InternalError, "dataType: " + dataType);
     }
-
-    return valueBytes;
   }
 
   static byte[] getBytesForArrayValue(
@@ -308,7 +260,7 @@ public final class ModbusByteUtil {
       throws UaException {
 
     // Check if the input value is actually a Java array
-    if (!value.getClass().isArray()) {
+    if (value == null || !value.getClass().isArray()) {
       throw new UaException(StatusCodes.Bad_TypeMismatch, "expected array");
     }
 
@@ -318,84 +270,16 @@ public final class ModbusByteUtil {
     }
 
     int arrayLength = dimensions[0];
+    if (Array.getLength(value) != arrayLength) {
+      throw new UaException(StatusCodes.Bad_TypeMismatch, "array length does not match dimensions");
+    }
 
     int bytesPerElement = dataType.getRegisterCount() * 2;
-    int totalBytes = arrayLength * bytesPerElement;
-    byte[] valueBytes = new byte[totalBytes];
-
-    ByteArrayByteOps byteOps = getByteOps(modifiers);
+    byte[] valueBytes = new byte[arrayLength * bytesPerElement];
 
     for (int i = 0; i < arrayLength; i++) {
-      Object element = Array.get(value, i);
-      int offset = i * bytesPerElement;
-
-      if (dataType instanceof ModbusDataType.Bool) {
-        if (element instanceof Boolean v) {
-          byteOps.setBoolean(valueBytes, offset, v);
-        } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
-      } else if (dataType instanceof ModbusDataType.Int16) {
-        if (element instanceof Short v) {
-          byteOps.setShort(valueBytes, offset, v);
-        } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
-      } else if (dataType instanceof ModbusDataType.UInt16) {
-        if (element instanceof UShort v) {
-          byteOps.setShort(valueBytes, offset, v.shortValue());
-        } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
-      } else if (dataType instanceof ModbusDataType.Int32) {
-        if (element instanceof Integer v) {
-          byteOps.setInt(valueBytes, offset, v);
-        } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
-      } else if (dataType instanceof ModbusDataType.UInt32) {
-        if (element instanceof UInteger v) {
-          byteOps.setInt(valueBytes, offset, v.intValue());
-        } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
-      } else if (dataType instanceof ModbusDataType.Int64) {
-        if (element instanceof Long v) {
-          byteOps.setLong(valueBytes, offset, v);
-        } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
-      } else if (dataType instanceof ModbusDataType.UInt64) {
-        if (element instanceof ULong v) {
-          byteOps.setLong(valueBytes, offset, v.longValue());
-        } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
-      } else if (dataType instanceof ModbusDataType.Float32) {
-        if (element instanceof Float v) {
-          byteOps.setFloat(valueBytes, offset, v);
-        } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
-      } else if (dataType instanceof ModbusDataType.Double64) {
-        if (element instanceof Double v) {
-          byteOps.setDouble(valueBytes, offset, v);
-        } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
-      } else if (dataType instanceof ModbusDataType.String) {
-        if (element instanceof String v) {
-          // note: padding with null bytes happens automatically
-          // since valueBytes is initialized with zeros
-          byte[] stringBytes = v.getBytes(StandardCharsets.UTF_8);
-          int lengthToCopy = Math.min(stringBytes.length, bytesPerElement);
-          System.arraycopy(stringBytes, 0, valueBytes, offset, lengthToCopy);
-        } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
-      } else {
-        throw new UaException(StatusCodes.Bad_InternalError, "dataType: " + dataType);
-      }
+      setBytesForScalarValue(
+          Array.get(value, i), valueBytes, i * bytesPerElement, dataType, modifiers);
     }
 
     return valueBytes;
@@ -410,28 +294,26 @@ public final class ModbusByteUtil {
         throw new UaException(StatusCodes.Bad_TypeMismatch);
       }
 
-      if (matrix.getDimensions().length != dimensions.length) {
+      if (!Arrays.equals(matrix.getDimensions(), dimensions)) {
         throw new UaException(StatusCodes.Bad_TypeMismatch);
-      }
-
-      for (int i = 0; i < dimensions.length; i++) {
-        if (matrix.getDimensions()[i] != dimensions[i]) {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
       }
 
       Object flatArrayValue = matrix.getElements();
       assert flatArrayValue != null;
 
-      int elementCount = 1;
-      for (int dimension : dimensions) {
-        elementCount *= dimension;
-      }
-
-      return getBytesForArrayValue(flatArrayValue, dataType, modifiers, new int[] {elementCount});
+      return getBytesForArrayValue(
+          flatArrayValue, dataType, modifiers, new int[] {elementCount(dimensions)});
     } else {
       throw new UaException(StatusCodes.Bad_TypeMismatch);
     }
+  }
+
+  private static int elementCount(int[] dimensions) {
+    int elementCount = 1;
+    for (int dimension : dimensions) {
+      elementCount *= dimension;
+    }
+    return elementCount;
   }
 
   static ByteArrayByteOps getByteOps(Set<DataTypeModifier> modifiers) {

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
@@ -37,7 +37,7 @@ class ModbusAddressSpaceTest {
 
     ModbusAddress address = ModbusAddressParser.parse(addressString);
     assertInstanceOf(ArrayAddress.class, address, "Address must be an array address");
-    boolean[] values = ModbusAddressSpace.readBooleans(booleans, (ArrayAddress) address);
+    boolean[] values = ModbusValueAccess.readBooleans(booleans, (ArrayAddress) address);
     assertArrayEquals(expectedValues, values);
   }
 
@@ -47,7 +47,7 @@ class ModbusAddressSpaceTest {
       throws Exception {
 
     ModbusAddress address = ModbusAddressParser.parse(addressString);
-    byte[] bytes = ModbusAddressSpace.readRegisters(registers, address);
+    byte[] bytes = ModbusValueAccess.readRegisters(registers, address);
     assertArrayEquals(expectedBytes, bytes);
   }
 
@@ -62,7 +62,7 @@ class ModbusAddressSpaceTest {
     Map<Integer, Boolean> booleanMap = new java.util.HashMap<>();
     Variant variant = new Variant(value);
 
-    ModbusAddressSpace.writeBooleanArray(booleanMap, variant, (ArrayAddress) address);
+    ModbusValueAccess.writeBooleanArray(booleanMap, (ArrayAddress) address, variant);
 
     assertEquals(expectedMap.size(), booleanMap.size(), "Map size should match");
     for (Map.Entry<Integer, Boolean> entry : expectedMap.entrySet()) {
@@ -80,7 +80,7 @@ class ModbusAddressSpaceTest {
 
     ModbusAddress address = ModbusAddressParser.parse(addressString);
 
-    byte[] bytes = ModbusAddressSpace.getRegisterWriteBytes(address, new Variant(value));
+    byte[] bytes = ModbusValueAccess.getRegisterWriteBytes(address, new Variant(value));
 
     assertArrayEquals(expectedBytes, bytes);
   }
@@ -118,14 +118,14 @@ class ModbusAddressSpaceTest {
     ModbusAddress address = ModbusAddressParser.parse("HR<int16[10]>0");
     Short[] value = new Short[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     byte[] writtenBytes =
-        ModbusAddressSpace.getRegisterWriteBytes(address, new Variant(value));
+        ModbusValueAccess.getRegisterWriteBytes(address, new Variant(value));
     Map<Integer, byte[]> registers = new java.util.HashMap<>();
 
     for (int i = 0; i < writtenBytes.length / 2; i++) {
       registers.put(i, new byte[] {writtenBytes[i * 2], writtenBytes[i * 2 + 1]});
     }
 
-    assertArrayEquals(writtenBytes, ModbusAddressSpace.readRegisters(registers, address));
+    assertArrayEquals(writtenBytes, ModbusValueAccess.readRegisters(registers, address));
   }
 
   @Test
@@ -133,8 +133,8 @@ class ModbusAddressSpaceTest {
     ArrayAddress address = arrayAddress("C<bool[2][2]>0");
 
     Object value =
-        ModbusAddressSpace.shapeBooleanArray(
-            new boolean[] {true, false, false, true}, address);
+        ModbusValueAccess.shapeBooleanArray(
+            address, new boolean[] {true, false, false, true});
 
     Matrix matrix = assertInstanceOf(Matrix.class, value);
     assertArrayEquals(new int[] {2, 2}, matrix.getDimensions());
@@ -148,8 +148,8 @@ class ModbusAddressSpaceTest {
     ArrayAddress address = arrayAddress("DI<bool[2][3]>0");
 
     Object value =
-        ModbusAddressSpace.shapeBooleanArray(
-            new boolean[] {true, false, true, false, true, false}, address);
+        ModbusValueAccess.shapeBooleanArray(
+            address, new boolean[] {true, false, true, false, true, false});
 
     Matrix matrix = assertInstanceOf(Matrix.class, value);
     assertArrayEquals(new int[] {2, 3}, matrix.getDimensions());
@@ -165,7 +165,7 @@ class ModbusAddressSpaceTest {
     ArrayAddress address = arrayAddress("C<bool[3]>0");
 
     Object value =
-        ModbusAddressSpace.shapeBooleanArray(new boolean[] {true, false, true}, address);
+        ModbusValueAccess.shapeBooleanArray(address, new boolean[] {true, false, true});
 
     assertArrayEquals(
         new Boolean[] {true, false, true}, assertInstanceOf(Boolean[].class, value));
@@ -177,8 +177,8 @@ class ModbusAddressSpaceTest {
     Matrix matrix =
         assertInstanceOf(
             Matrix.class,
-            ModbusAddressSpace.shapeBooleanArray(
-                new boolean[] {true, false, false, true}, address));
+            ModbusValueAccess.shapeBooleanArray(
+                address, new boolean[] {true, false, false, true}));
 
     Variant valueRank = ModbusAddressSpace.readAddressAttribute(AttributeId.ValueRank, address);
     Variant arrayDimensions =
@@ -194,11 +194,11 @@ class ModbusAddressSpaceTest {
   void shapedCoilMatrixCanBeWrittenBackToSameAddress() throws Exception {
     ArrayAddress address = arrayAddress("C<bool[2][2]>0");
     Object value =
-        ModbusAddressSpace.shapeBooleanArray(
-            new boolean[] {true, false, false, true}, address);
+        ModbusValueAccess.shapeBooleanArray(
+            address, new boolean[] {true, false, false, true});
     Map<Integer, Boolean> booleans = new HashMap<>();
 
-    ModbusAddressSpace.writeBooleanArray(booleans, new Variant(value), address);
+    ModbusValueAccess.writeBooleanArray(booleans, address, new Variant(value));
 
     assertEquals(
         Map.of(
@@ -660,8 +660,8 @@ class ModbusAddressSpaceTest {
         assertThrows(
             UaException.class,
             () ->
-                ModbusAddressSpace.writeBooleanArray(
-                    booleans, new Variant(new Boolean[] {true, null, false}), address));
+                ModbusValueAccess.writeBooleanArray(
+                    booleans, address, new Variant(new Boolean[] {true, null, false})));
 
     assertEquals(StatusCodes.Bad_TypeMismatch, exception.getStatusCode().getValue());
     assertTrue(booleans.isEmpty());
@@ -672,10 +672,10 @@ class ModbusAddressSpaceTest {
     ArrayAddress address = arrayAddress("C<bool[2][2]>0");
     Map<Integer, Boolean> booleans = new HashMap<>();
 
-    ModbusAddressSpace.writeBooleanArray(
+    ModbusValueAccess.writeBooleanArray(
         booleans,
-        new Variant(Matrix.ofBoolean(new boolean[][] {{true, false}, {false, true}})),
-        address);
+        address,
+        new Variant(Matrix.ofBoolean(new boolean[][] {{true, false}, {false, true}})));
 
     assertEquals(Map.of(0, true, 1, false, 2, false, 3, true), booleans);
   }
@@ -749,7 +749,7 @@ class ModbusAddressSpaceTest {
     UaException exception =
         assertThrows(
             UaException.class,
-            () -> ModbusAddressSpace.getRegisterWriteBytes(address, new Variant(value)));
+            () -> ModbusValueAccess.getRegisterWriteBytes(address, new Variant(value)));
 
     assertEquals(StatusCodes.Bad_TypeMismatch, exception.getStatusCode().getValue());
   }

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
@@ -2,13 +2,28 @@ package com.kevinherron.ignition.modbus;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.digitalpetri.modbus.server.ProcessImage;
 import com.kevinherron.ignition.modbus.address.ModbusAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddress.ArrayAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddressParser;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.eclipse.milo.opcua.sdk.core.AccessLevel;
+import org.eclipse.milo.opcua.sdk.core.ValueRank;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -56,6 +71,492 @@ class ModbusAddressSpaceTest {
           booleanMap.get(entry.getKey()),
           "Value at offset " + entry.getKey() + " should match");
     }
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("registerWriteBytesArguments")
+  void getRegisterWriteBytes(String addressString, Object value, byte[] expectedBytes)
+      throws Exception {
+
+    ModbusAddress address = ModbusAddressParser.parse(addressString);
+
+    byte[] bytes = ModbusAddressSpace.getRegisterWriteBytes(address, new Variant(value));
+
+    assertArrayEquals(expectedBytes, bytes);
+  }
+
+  @Test
+  void getRegisterWriteBytesRejectsScalarForArrayAddress() throws Exception {
+    assertRegisterWriteTypeMismatch("HR<int16[10]>0", (short) 1);
+  }
+
+  @Test
+  void getRegisterWriteBytesRejectsShortArray() throws Exception {
+    assertRegisterWriteTypeMismatch(
+        "HR<int16[10]>0", new Short[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  void getRegisterWriteBytesRejectsWrongMatrixShape() throws Exception {
+    assertRegisterWriteTypeMismatch(
+        "HR<int16[2][2]>0",
+        new Matrix(new Short[] {1, 2, 3, 4, 5, 6}, new int[] {2, 3}));
+  }
+
+  @Test
+  void getRegisterWriteBytesRejectsWrongArrayElementType() throws Exception {
+    assertRegisterWriteTypeMismatch("HR<int16[4]>0", new Integer[] {1, 2, 3, 4});
+  }
+
+  @Test
+  void getRegisterWriteBytesRejectsNull() throws Exception {
+    assertRegisterWriteTypeMismatch("HR<int16[4]>0", null);
+  }
+
+  @Test
+  void registerArrayWriteReadBytesRoundTrip() throws Exception {
+    ModbusAddress address = ModbusAddressParser.parse("HR<int16[10]>0");
+    Short[] value = new Short[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    byte[] writtenBytes =
+        ModbusAddressSpace.getRegisterWriteBytes(address, new Variant(value));
+    Map<Integer, byte[]> registers = new java.util.HashMap<>();
+
+    for (int i = 0; i < writtenBytes.length / 2; i++) {
+      registers.put(i, new byte[] {writtenBytes[i * 2], writtenBytes[i * 2 + 1]});
+    }
+
+    assertArrayEquals(writtenBytes, ModbusAddressSpace.readRegisters(registers, address));
+  }
+
+  @Test
+  void shapeCoilBooleanMatrix() throws Exception {
+    ArrayAddress address = arrayAddress("C<bool[2][2]>0");
+
+    Object value =
+        ModbusAddressSpace.shapeBooleanArray(
+            new boolean[] {true, false, false, true}, address);
+
+    Matrix matrix = assertInstanceOf(Matrix.class, value);
+    assertArrayEquals(new int[] {2, 2}, matrix.getDimensions());
+    assertArrayEquals(new Boolean[] {true, false, false, true}, (Boolean[]) matrix.getElements());
+    assertEquals(Boolean.class, matrix.getElementType().orElseThrow());
+    assertEquals(OpcUaDataType.Boolean, matrix.getDataType().orElseThrow());
+  }
+
+  @Test
+  void shapeDiscreteInputBooleanMatrix() throws Exception {
+    ArrayAddress address = arrayAddress("DI<bool[2][3]>0");
+
+    Object value =
+        ModbusAddressSpace.shapeBooleanArray(
+            new boolean[] {true, false, true, false, true, false}, address);
+
+    Matrix matrix = assertInstanceOf(Matrix.class, value);
+    assertArrayEquals(new int[] {2, 3}, matrix.getDimensions());
+    assertArrayEquals(
+        new Boolean[] {true, false, true, false, true, false},
+        (Boolean[]) matrix.getElements());
+    assertEquals(Boolean.class, matrix.getElementType().orElseThrow());
+    assertEquals(OpcUaDataType.Boolean, matrix.getDataType().orElseThrow());
+  }
+
+  @Test
+  void shapeOneDimensionalBooleanArrayAsBoxedArray() throws Exception {
+    ArrayAddress address = arrayAddress("C<bool[3]>0");
+
+    Object value =
+        ModbusAddressSpace.shapeBooleanArray(new boolean[] {true, false, true}, address);
+
+    assertArrayEquals(
+        new Boolean[] {true, false, true}, assertInstanceOf(Boolean[].class, value));
+  }
+
+  @Test
+  void coilMatrixShapeAgreesWithNodeMetadata() throws Exception {
+    ArrayAddress address = arrayAddress("C<bool[2][2]>0");
+    Matrix matrix =
+        assertInstanceOf(
+            Matrix.class,
+            ModbusAddressSpace.shapeBooleanArray(
+                new boolean[] {true, false, false, true}, address));
+
+    Variant valueRank = ModbusAddressSpace.readAddressAttribute(AttributeId.ValueRank, address);
+    Variant arrayDimensions =
+        ModbusAddressSpace.readAddressAttribute(AttributeId.ArrayDimensions, address);
+
+    assertEquals(matrix.getValueRank(), valueRank.getValue());
+    assertArrayEquals(
+        matrix.getDimensions(),
+        Stream.of((UInteger[]) arrayDimensions.getValue()).mapToInt(UInteger::intValue).toArray());
+  }
+
+  @Test
+  void shapedCoilMatrixCanBeWrittenBackToSameAddress() throws Exception {
+    ArrayAddress address = arrayAddress("C<bool[2][2]>0");
+    Object value =
+        ModbusAddressSpace.shapeBooleanArray(
+            new boolean[] {true, false, false, true}, address);
+    Map<Integer, Boolean> booleans = new HashMap<>();
+
+    ModbusAddressSpace.writeBooleanArray(booleans, new Variant(value), address);
+
+    assertEquals(
+        Map.of(
+            0, true,
+            1, false,
+            2, false,
+            3, true),
+        booleans);
+  }
+
+  @Test
+  void registerArrayDimensionsHaveResolvableUint32Type() throws Exception {
+    ModbusAddress address = ModbusAddressParser.parse("HR<int16[4][5]>0");
+
+    Variant arrayDimensions =
+        ModbusAddressSpace.readAddressAttribute(AttributeId.ArrayDimensions, address);
+
+    assertArrayEquals(
+        new UInteger[] {UInteger.valueOf(4), UInteger.valueOf(5)},
+        (UInteger[]) arrayDimensions.getValue());
+    assertEquals(OpcUaDataType.UInt32, arrayDimensions.getDataType().orElseThrow());
+    assertTrue(arrayDimensions.getDataTypeId().isPresent());
+  }
+
+  @Test
+  void scalarMetadataHasNullArrayDimensionsAndScalarValueRank() throws Exception {
+    ModbusAddress address = ModbusAddressParser.parse("HR<int16>0");
+
+    Variant arrayDimensions =
+        ModbusAddressSpace.readAddressAttribute(AttributeId.ArrayDimensions, address);
+    Variant valueRank = ModbusAddressSpace.readAddressAttribute(AttributeId.ValueRank, address);
+
+    assertNull(arrayDimensions.getValue());
+    assertEquals(ValueRank.Scalar.getValue(), valueRank.getValue());
+  }
+
+  @Test
+  void addressDerivedAttributesPreserveDataTypeAndAccessLevels() throws Exception {
+    ModbusAddress address = ModbusAddressParser.parse("C<bool[2][2]>0");
+
+    assertEquals(
+        NodeIds.Boolean,
+        ModbusAddressSpace.readAddressAttribute(AttributeId.DataType, address).getValue());
+    assertEquals(
+        AccessLevel.toValue(AccessLevel.READ_WRITE),
+        ModbusAddressSpace.readAddressAttribute(AttributeId.AccessLevel, address).getValue());
+    assertEquals(
+        AccessLevel.toValue(AccessLevel.READ_WRITE),
+        ModbusAddressSpace.readAddressAttribute(AttributeId.UserAccessLevel, address).getValue());
+  }
+
+  @Test
+  void readHoldingRegisterArrayRanges() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<int16[10]>0");
+    writeValue(processImage, address, shorts(0, 10));
+
+    assertArrayEquals(
+        new Short[] {2, 3, 4},
+        (Short[])
+            ModbusAddressSpace.readValueAttribute(processImage, address, "2:4").getValue());
+    assertArrayEquals(
+        new Short[] {0},
+        (Short[])
+            ModbusAddressSpace.readValueAttribute(processImage, address, "0").getValue());
+  }
+
+  @Test
+  void readHoldingRegisterSubmatrix() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<int16[4][4]>0");
+    writeValue(
+        processImage,
+        address,
+        new Matrix(shorts(0, 16), new int[] {4, 4}));
+
+    Matrix matrix =
+        assertInstanceOf(
+            Matrix.class,
+            ModbusAddressSpace.readValueAttribute(processImage, address, "1:2,0:1")
+                .getValue());
+
+    assertArrayEquals(new int[] {2, 2}, matrix.getDimensions());
+    assertArrayEquals(new Short[] {4, 5, 8, 9}, (Short[]) matrix.getElements());
+  }
+
+  @Test
+  void readCoilArrayRange() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("C<bool[8]>0");
+    writeValue(
+        processImage,
+        address,
+        new Boolean[] {false, true, false, true, true, false, true, false});
+
+    assertArrayEquals(
+        new Boolean[] {true, true, false},
+        (Boolean[])
+            ModbusAddressSpace.readValueAttribute(processImage, address, "3:5").getValue());
+  }
+
+  @Test
+  void rangedHoldingRegisterWritePreservesNeighbours() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<int16[10]>0");
+    writeValue(processImage, address, shorts(0, 10));
+
+    ModbusAddressSpace.writeValueAttribute(
+        processImage, address, new Variant(new Short[] {20, 30, 40}), "2:4");
+
+    assertArrayEquals(
+        new Short[] {0, 1, 20, 30, 40, 5, 6, 7, 8, 9},
+        (Short[])
+            ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+  }
+
+  @Test
+  void rangedHoldingRegisterMatrixWritePreservesUnselectedCells() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<int16[4][4]>0");
+    writeValue(
+        processImage,
+        address,
+        new Matrix(shorts(0, 16), new int[] {4, 4}));
+
+    ModbusAddressSpace.writeValueAttribute(
+        processImage,
+        address,
+        new Variant(new Matrix(new Short[] {40, 41, 80, 81}, new int[] {2, 2})),
+        "1:2,0:1");
+
+    Matrix matrix =
+        assertInstanceOf(
+            Matrix.class,
+            ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+    assertArrayEquals(
+        new Short[] {0, 1, 2, 3, 40, 41, 6, 7, 80, 81, 10, 11, 12, 13, 14, 15},
+        (Short[]) matrix.getElements());
+  }
+
+  @Test
+  void rangedHoldingRegisterWriteUsesZeroForSparseBase() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<int16[6]>100");
+
+    ModbusAddressSpace.writeValueAttribute(
+        processImage, address, new Variant(new Short[] {7, 8}), "2:3");
+
+    assertArrayEquals(
+        new Short[] {0, 0, 7, 8, 0, 0},
+        (Short[])
+            ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+  }
+
+  @Test
+  void malformedPastEndAndScalarRangesReturnSpecifiedStatusCodes() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress array = ModbusAddressParser.parse("HR<int16[10]>0");
+    ModbusAddress scalar = ModbusAddressParser.parse("HR<int16>20");
+    writeValue(processImage, array, shorts(0, 10));
+    writeValue(processImage, scalar, (short) 1);
+
+    List<DataValue> values =
+        ModbusAddressSpace.readValueAttributes(
+            processImage,
+            List.of(
+                new ModbusAddressSpace.ValueRead(array, "1::2"),
+                new ModbusAddressSpace.ValueRead(scalar, "1::2"),
+                new ModbusAddressSpace.ValueRead(array, "10"),
+                new ModbusAddressSpace.ValueRead(scalar, "0")));
+
+    assertStatus(StatusCodes.Bad_IndexRangeInvalid, values.get(0).getStatusCode());
+    assertStatus(StatusCodes.Bad_IndexRangeInvalid, values.get(1).getStatusCode());
+    assertStatus(StatusCodes.Bad_IndexRangeNoData, values.get(2).getStatusCode());
+    assertStatus(StatusCodes.Bad_IndexRangeNoData, values.get(3).getStatusCode());
+  }
+
+  @Test
+  void malformedScalarWriteRangesReturnInvalidWithoutMutation() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress register = ModbusAddressParser.parse("HR<int16>0");
+    ModbusAddress coil = ModbusAddressParser.parse("C10");
+    writeValue(processImage, register, (short) 7);
+    writeValue(processImage, coil, true);
+
+    List<StatusCode> statuses =
+        ModbusAddressSpace.writeValueAttributes(
+            processImage,
+            List.of(
+                new ModbusAddressSpace.ValueWrite(
+                    register, new Variant((short) 99), "1::2"),
+                new ModbusAddressSpace.ValueWrite(coil, new Variant(false), "1::2")));
+
+    assertStatus(StatusCodes.Bad_IndexRangeInvalid, statuses.get(0));
+    assertStatus(StatusCodes.Bad_IndexRangeInvalid, statuses.get(1));
+    assertEquals(
+        (short) 7,
+        ModbusAddressSpace.readValueAttribute(processImage, register, null).getValue());
+    assertEquals(
+        true, ModbusAddressSpace.readValueAttribute(processImage, coil, null).getValue());
+  }
+
+  @Test
+  void mismatchedRangedWriteDoesNotMutateProcessImage() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<int16[6]>0");
+    Short[] initial = shorts(0, 6);
+    writeValue(processImage, address, initial);
+
+    List<StatusCode> statuses =
+        ModbusAddressSpace.writeValueAttributes(
+            processImage,
+            List.of(
+                new ModbusAddressSpace.ValueWrite(
+                    address, new Variant(new Short[] {90, 91}), "2:4")));
+
+    assertTrue(statuses.get(0).isBad());
+    assertArrayEquals(
+        initial,
+        (Short[])
+            ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+  }
+
+  @Test
+  void scalarStringIndexRangeReadsAndWritesSubString() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<string10>0");
+    writeValue(processImage, address, "HELLOWORLD");
+
+    assertEquals(
+        "HELLO", ModbusAddressSpace.readValueAttribute(processImage, address, "0:4").getValue());
+
+    ModbusAddressSpace.writeValueAttribute(processImage, address, new Variant("WORLD"), "0:4");
+
+    assertEquals(
+        "WORLDWORLD",
+        ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+  }
+
+  @Test
+  void stringArraySubStringRangeReadsAndWrites() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<string8[4]>0");
+    writeValue(processImage, address, new String[] {"alpha", "beta", "gamma", "delta"});
+
+    assertArrayEquals(
+        new String[] {"bet"},
+        (String[])
+            ModbusAddressSpace.readValueAttribute(processImage, address, "1,0:2").getValue());
+
+    ModbusAddressSpace.writeValueAttribute(
+        processImage, address, new Variant(new String[] {"BET"}), "1,0:2");
+
+    assertArrayEquals(
+        new String[] {"alpha", "BETa", "gamma", "delta"},
+        (String[]) ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+  }
+
+  @Test
+  void threeReadBatchWithMiddleRangeReturnsCompleteResults() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress first = ModbusAddressParser.parse("HR<int16>0");
+    ModbusAddress middle = ModbusAddressParser.parse("HR<int16[4]>10");
+    ModbusAddress last = ModbusAddressParser.parse("C0");
+    writeValue(processImage, first, (short) 11);
+    writeValue(processImage, middle, new Short[] {1, 2, 3, 4});
+    writeValue(processImage, last, true);
+
+    List<DataValue> values =
+        ModbusAddressSpace.readValueAttributes(
+            processImage,
+            List.of(
+                new ModbusAddressSpace.ValueRead(first, null),
+                new ModbusAddressSpace.ValueRead(middle, "1:2"),
+                new ModbusAddressSpace.ValueRead(last, null)));
+
+    assertEquals(3, values.size());
+    assertTrue(values.stream().allMatch(v -> v != null && v.getValue() != null));
+    assertArrayEquals(new Short[] {2, 3}, (Short[]) values.get(1).getValue().getValue());
+  }
+
+  @Test
+  void normalValueWriteBatchReturnsNonNullStatuses() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress first = ModbusAddressParser.parse("HR<int16>0");
+    ModbusAddress second = ModbusAddressParser.parse("C0");
+
+    List<StatusCode> statuses =
+        ModbusAddressSpace.writeValueAttributes(
+            processImage,
+            List.of(
+                new ModbusAddressSpace.ValueWrite(first, new Variant((short) 7), null),
+                new ModbusAddressSpace.ValueWrite(second, new Variant(true), null)));
+
+    assertEquals(2, statuses.size());
+    assertTrue(statuses.stream().allMatch(status -> status != null && status.isGood()));
+  }
+
+  private static void writeValue(
+      ProcessImage processImage, ModbusAddress address, Object value) throws UaException {
+    ModbusAddressSpace.writeValueAttribute(processImage, address, new Variant(value), null);
+  }
+
+  private static Short[] shorts(int startInclusive, int endExclusive) {
+    Short[] values = new Short[endExclusive - startInclusive];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = (short) (startInclusive + i);
+    }
+    return values;
+  }
+
+  private static void assertStatus(long expected, StatusCode actual) {
+    assertNotNull(actual);
+    assertEquals(expected, actual.getValue());
+  }
+
+  private static ArrayAddress arrayAddress(String addressString) throws Exception {
+    return assertInstanceOf(ArrayAddress.class, ModbusAddressParser.parse(addressString));
+  }
+
+  private static void assertRegisterWriteTypeMismatch(String addressString, Object value)
+      throws Exception {
+    ModbusAddress address = ModbusAddressParser.parse(addressString);
+
+    UaException exception =
+        assertThrows(
+            UaException.class,
+            () -> ModbusAddressSpace.getRegisterWriteBytes(address, new Variant(value)));
+
+    assertEquals(StatusCodes.Bad_TypeMismatch, exception.getStatusCode().getValue());
+  }
+
+  private static Stream<Arguments> registerWriteBytesArguments() {
+    return Stream.of(
+        Arguments.of(
+            "HR<int16[10]>0",
+            new Short[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+            new byte[] {
+              0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9, 0, 10
+            }),
+        Arguments.of(
+            "HR<float[4]>0",
+            new Float[] {1.0f, -2.5f, 0.0f, 3.75f},
+            new byte[] {
+              0x3F, (byte) 0x80, 0, 0,
+              (byte) 0xC0, 0x20, 0, 0,
+              0, 0, 0, 0,
+              0x40, 0x70, 0, 0
+            }),
+        Arguments.of(
+            "IR<uint16[3]>0",
+            new UShort[] {UShort.valueOf(1), UShort.valueOf(32768), UShort.valueOf(65535)},
+            new byte[] {0, 1, (byte) 0x80, 0, (byte) 0xFF, (byte) 0xFF}),
+        Arguments.of(
+            "HR<int16[2][2]>0",
+            new Matrix(new Short[] {1, 2, -1, 32767}, new int[] {2, 2}),
+            new byte[] {0, 1, 0, 2, (byte) 0xFF, (byte) 0xFF, 0x7F, (byte) 0xFF}),
+        Arguments.of("HR<int16>0", (short) -2, new byte[] {(byte) 0xFF, (byte) 0xFE}));
   }
 
   private static Stream<Arguments> readBooleansArguments() {

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
@@ -553,6 +553,134 @@ class ModbusAddressSpaceTest {
   }
 
   @Test
+  void rangedStringElementWriteDoesNotDisturbUnselectedRegisters() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<string4[2]>0");
+    // Element 0 holds bytes a String round-trip cannot represent: content after an embedded NUL.
+    processImage.with(
+        tx ->
+            tx.writeHoldingRegisters(
+                registers -> {
+                  registers.put(0, new byte[] {0x00, 0x41});
+                  registers.put(1, new byte[] {0x42, 0x43});
+                }));
+
+    ModbusAddressSpace.writeValueAttribute(
+        processImage, address, new Variant(new String[] {"WX"}), "1");
+
+    byte[][] element0 =
+        processImage.get(
+            tx ->
+                tx.readHoldingRegisters(
+                    registers -> new byte[][] {registers.get(0), registers.get(1)}));
+    assertArrayEquals(new byte[] {0x00, 0x41}, element0[0]);
+    assertArrayEquals(new byte[] {0x42, 0x43}, element0[1]);
+    assertArrayEquals(
+        new String[] {"", "WX"},
+        (String[]) ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+  }
+
+  @Test
+  void rangedCoilWritePreservesNeighbours() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("C<bool[6]>0");
+    writeValue(processImage, address, new Boolean[] {true, true, true, true, true, true});
+
+    ModbusAddressSpace.writeValueAttribute(
+        processImage, address, new Variant(new Boolean[] {false, false}), "2:3");
+
+    assertArrayEquals(
+        new Boolean[] {true, true, false, false, true, true},
+        (Boolean[]) ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+  }
+
+  @Test
+  void subStringWriteRejectsMergeExceedingByteCapacity() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<string10>0");
+    writeValue(processImage, address, "HELLOWORLD");
+
+    StatusCode status =
+        ModbusAddressSpace.writeValueAttributes(
+                processImage,
+                List.of(
+                    new ModbusAddressSpace.ValueWrite(
+                        address, new Variant("ÉÉÉÉÉ"), "0:4")))
+            .get(0);
+
+    assertStatus(StatusCodes.Bad_IndexRangeDataMismatch, status);
+    assertEquals(
+        "HELLOWORLD",
+        ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+  }
+
+  @Test
+  void subStringWriteWithMismatchedShapeReturnsDataMismatch() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<string10>0");
+    writeValue(processImage, address, "HELLOWORLD");
+
+    StatusCode status =
+        ModbusAddressSpace.writeValueAttributes(
+                processImage,
+                List.of(
+                    new ModbusAddressSpace.ValueWrite(
+                        address, new Variant(new String[] {"abc", "def", "ghi"}), "0:2")))
+            .get(0);
+
+    assertStatus(StatusCodes.Bad_IndexRangeDataMismatch, status);
+    assertEquals(
+        "HELLOWORLD",
+        ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+  }
+
+  @Test
+  void hugeRangedWriteReturnsNoDataInsteadOfMismatch() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<int16[4]>0");
+    writeValue(processImage, address, shorts(0, 4));
+
+    StatusCode status =
+        ModbusAddressSpace.writeValueAttributes(
+                processImage,
+                List.of(
+                    new ModbusAddressSpace.ValueWrite(
+                        address, new Variant(new Short[] {1, 2}), "0:2147483647")))
+            .get(0);
+
+    assertStatus(StatusCodes.Bad_IndexRangeNoData, status);
+  }
+
+  @Test
+  void writeBooleanArrayRejectsNullElements() throws Exception {
+    ArrayAddress address = arrayAddress("C<bool[3]>0");
+    Map<Integer, Boolean> booleans = new HashMap<>();
+
+    UaException exception =
+        assertThrows(
+            UaException.class,
+            () ->
+                ModbusAddressSpace.writeBooleanArray(
+                    booleans, new Variant(new Boolean[] {true, null, false}), address));
+
+    assertEquals(StatusCodes.Bad_TypeMismatch, exception.getStatusCode().getValue());
+    assertTrue(booleans.isEmpty());
+  }
+
+  @Test
+  void writeBooleanArrayAcceptsPrimitiveBackedMatrix() throws Exception {
+    ArrayAddress address = arrayAddress("C<bool[2][2]>0");
+    Map<Integer, Boolean> booleans = new HashMap<>();
+
+    ModbusAddressSpace.writeBooleanArray(
+        booleans,
+        new Variant(Matrix.ofBoolean(new boolean[][] {{true, false}, {false, true}})),
+        address);
+
+    assertEquals(Map.of(0, true, 1, false, 2, false, 3, true), booleans);
+  }
+
+  @Test
   void threeReadBatchWithMiddleRangeReturnsCompleteResults() throws Exception {
     ProcessImage processImage = new ProcessImage();
     ModbusAddress first = ModbusAddressParser.parse("HR<int16>0");

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
@@ -1,0 +1,111 @@
+package com.kevinherron.ignition.modbus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.kevinherron.ignition.modbus.address.ModbusAddress;
+import com.kevinherron.ignition.modbus.address.ModbusAddressParser;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ModbusAddressSpaceTest {
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("readRegistersArguments")
+  void readRegisters(String addressString, Map<Integer, byte[]> registers, byte[] expectedBytes)
+      throws Exception {
+
+    ModbusAddress address = ModbusAddressParser.parse(addressString);
+    byte[] bytes = ModbusAddressSpace.readRegisters(registers, address);
+    assertArrayEquals(expectedBytes, bytes);
+  }
+
+  private static Stream<Arguments> readRegistersArguments() {
+    return Stream.of(
+        // Test INT32 (2 registers)
+        Arguments.of(
+            "HR<int32>0",
+            Map.of(
+                0, new byte[] {0x00, 0x01},
+                1, new byte[] {0x02, 0x03}),
+            new byte[] {0x00, 0x01, 0x02, 0x03}),
+
+        // Test INT16 (1 register)
+        Arguments.of("HR<int16>10", Map.of(10, new byte[] {0x04, 0x05}), new byte[] {0x04, 0x05}),
+
+        // Test INT64 (4 registers)
+        Arguments.of(
+            "HR<int64>20",
+            Map.of(
+                20, new byte[] {0x00, 0x01},
+                21, new byte[] {0x02, 0x03},
+                22, new byte[] {0x04, 0x05},
+                23, new byte[] {0x06, 0x07}),
+            new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}),
+
+        // Test FLOAT (2 registers)
+        Arguments.of(
+            "HR<float>30",
+            Map.of(
+                30, new byte[] {0x41, 0x20}, // IEEE 754 representation of 10.0
+                31, new byte[] {0x00, 0x00}),
+            new byte[] {0x41, 0x20, 0x00, 0x00}),
+
+        // Test STRING (3 registers for 5 characters)
+        Arguments.of(
+            "HR<string5>40",
+            Map.of(
+                40, new byte[] {0x48, 0x65}, // "He"
+                41, new byte[] {0x6C, 0x6C}, // "ll"
+                42, new byte[] {0x6F, 0x00}), // "o" + null
+            new byte[] {0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x00}),
+
+        // Test Input Registers
+        Arguments.of(
+            "IR<int32>50",
+            Map.of(
+                50, new byte[] {0x08, 0x09},
+                51, new byte[] {0x0A, 0x0B}),
+            new byte[] {0x08, 0x09, 0x0A, 0x0B}),
+
+        // Test 1D array of INT16 (3 elements)
+        Arguments.of(
+            "HR<int16[3]>100",
+            Map.of(
+                100, new byte[] {0x01, 0x02}, // First element
+                101, new byte[] {0x03, 0x04}, // Second element
+                102, new byte[] {0x05, 0x06}), // Third element
+            new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06}),
+
+        // Test 1D array of INT32 (2 elements)
+        Arguments.of(
+            "HR<int32[2]>200",
+            Map.of(
+                200, new byte[] {0x00, 0x01}, // First element, first register
+                201, new byte[] {0x02, 0x03}, // First element, second register
+                202, new byte[] {0x04, 0x05}, // Second element, first register
+                203, new byte[] {0x06, 0x07}), // Second element, second register
+            new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}),
+
+        // Test 2D array of INT16 (2x2 elements)
+        Arguments.of(
+            "HR<int16[2][2]>300",
+            Map.of(
+                300, new byte[] {0x0A, 0x0B}, // [0][0]
+                301, new byte[] {0x0C, 0x0D}, // [0][1]
+                302, new byte[] {0x0E, 0x0F}, // [1][0]
+                303, new byte[] {0x10, 0x11}), // [1][1]
+            new byte[] {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11}),
+
+        // Test array with missing values (should return zeros for missing registers)
+        Arguments.of(
+            "HR<int16[3]>400",
+            Map.of(
+                400, new byte[] {0x01, 0x02},
+                // 401 is missing
+                402, new byte[] {0x05, 0x06}),
+            new byte[] {0x01, 0x02, 0x00, 0x00, 0x05, 0x06}));
+  }
+}

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
@@ -7,6 +7,8 @@ import com.kevinherron.ignition.modbus.address.ModbusAddress.ArrayAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddressParser;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -32,6 +34,28 @@ class ModbusAddressSpaceTest {
     ModbusAddress address = ModbusAddressParser.parse(addressString);
     byte[] bytes = ModbusAddressSpace.readRegisters(registers, address);
     assertArrayEquals(expectedBytes, bytes);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("writeBooleanArrayArguments")
+  void writeBooleanArray(String addressString, Object value, Map<Integer, Boolean> expectedMap)
+      throws Exception {
+
+    ModbusAddress address = ModbusAddressParser.parse(addressString);
+    assertInstanceOf(ArrayAddress.class, address, "Address must be an array address");
+
+    Map<Integer, Boolean> booleanMap = new java.util.HashMap<>();
+    Variant variant = new Variant(value);
+
+    ModbusAddressSpace.writeBooleanArray(booleanMap, variant, (ArrayAddress) address);
+
+    assertEquals(expectedMap.size(), booleanMap.size(), "Map size should match");
+    for (Map.Entry<Integer, Boolean> entry : expectedMap.entrySet()) {
+      assertEquals(
+          entry.getValue(),
+          booleanMap.get(entry.getKey()),
+          "Value at offset " + entry.getKey() + " should match");
+    }
   }
 
   private static Stream<Arguments> readBooleansArguments() {
@@ -100,6 +124,56 @@ class ModbusAddressSpaceTest {
                 44, false,
                 45, true),
             new boolean[] {true, false, true, true, false, true}));
+  }
+
+  private static Stream<Arguments> writeBooleanArrayArguments() {
+    // 1D array test
+    Boolean[] array1d = new Boolean[] {true, false, true};
+    Map<Integer, Boolean> expected1d =
+        Map.of(
+            0, true,
+            1, false,
+            2, true);
+
+    // 2D array test (2x2)
+    Boolean[] array2d = new Boolean[] {true, false, false, true};
+    int[] dimensions2d = new int[] {2, 2};
+    Matrix matrix2d = new Matrix(array2d, dimensions2d);
+    Map<Integer, Boolean> expected2d =
+        Map.of(
+            10, true, // [0][0]
+            11, false, // [0][1]
+            12, false, // [1][0]
+            13, true); // [1][1]
+
+    // 3D array test (2x2x2)
+    Boolean[] array3d =
+        new Boolean[] {
+          true, false, true, false,
+          false, true, true, false
+        };
+    int[] dimensions3d = new int[] {2, 2, 2};
+    Matrix matrix3d = new Matrix(array3d, dimensions3d);
+    Map<Integer, Boolean> expected3d =
+        Map.of(
+            50, true, // [0][0][0]
+            51, false, // [0][0][1]
+            52, true, // [0][1][0]
+            53, false, // [0][1][1]
+            54, false, // [1][0][0]
+            55, true, // [1][0][1]
+            56, true, // [1][1][0]
+            57, false); // [1][1][1]
+
+    return Stream.of(
+        // Test 1D array
+        Arguments.of("C<bool[3]>0", array1d, expected1d),
+
+        // Test 2D array (Matrix)
+        Arguments.of("C<bool[2][2]>10", matrix2d, expected2d),
+
+        // Test 3D array (Matrix)
+        Arguments.of("C<bool[2][2][2]>50", matrix3d, expected3d));
   }
 
   private static Stream<Arguments> readRegistersArguments() {

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
@@ -367,13 +367,17 @@ class ModbusAddressSpaceTest {
             List.of(
                 new ModbusAddressSpace.ValueRead(array, "1::2"),
                 new ModbusAddressSpace.ValueRead(scalar, "1::2"),
+                new ModbusAddressSpace.ValueRead(array, "1:"),
+                new ModbusAddressSpace.ValueRead(array, "1,"),
                 new ModbusAddressSpace.ValueRead(array, "10"),
                 new ModbusAddressSpace.ValueRead(scalar, "0")));
 
     assertStatus(StatusCodes.Bad_IndexRangeInvalid, values.get(0).getStatusCode());
     assertStatus(StatusCodes.Bad_IndexRangeInvalid, values.get(1).getStatusCode());
-    assertStatus(StatusCodes.Bad_IndexRangeNoData, values.get(2).getStatusCode());
-    assertStatus(StatusCodes.Bad_IndexRangeNoData, values.get(3).getStatusCode());
+    assertStatus(StatusCodes.Bad_IndexRangeInvalid, values.get(2).getStatusCode());
+    assertStatus(StatusCodes.Bad_IndexRangeInvalid, values.get(3).getStatusCode());
+    assertStatus(StatusCodes.Bad_IndexRangeNoData, values.get(4).getStatusCode());
+    assertStatus(StatusCodes.Bad_IndexRangeNoData, values.get(5).getStatusCode());
   }
 
   @Test
@@ -390,10 +394,14 @@ class ModbusAddressSpaceTest {
             List.of(
                 new ModbusAddressSpace.ValueWrite(
                     register, new Variant((short) 99), "1::2"),
-                new ModbusAddressSpace.ValueWrite(coil, new Variant(false), "1::2")));
+                new ModbusAddressSpace.ValueWrite(coil, new Variant(false), "1::2"),
+                new ModbusAddressSpace.ValueWrite(register, new Variant((short) 99), "1:"),
+                new ModbusAddressSpace.ValueWrite(coil, new Variant(false), "1,")));
 
     assertStatus(StatusCodes.Bad_IndexRangeInvalid, statuses.get(0));
     assertStatus(StatusCodes.Bad_IndexRangeInvalid, statuses.get(1));
+    assertStatus(StatusCodes.Bad_IndexRangeInvalid, statuses.get(2));
+    assertStatus(StatusCodes.Bad_IndexRangeInvalid, statuses.get(3));
     assertEquals(
         (short) 7,
         ModbusAddressSpace.readValueAttribute(processImage, register, null).getValue());
@@ -415,11 +423,80 @@ class ModbusAddressSpaceTest {
                 new ModbusAddressSpace.ValueWrite(
                     address, new Variant(new Short[] {90, 91}), "2:4")));
 
-    assertTrue(statuses.get(0).isBad());
+    assertStatus(StatusCodes.Bad_IndexRangeDataMismatch, statuses.get(0));
     assertArrayEquals(
         initial,
         (Short[])
             ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+  }
+
+  @Test
+  void multidimensionalRangesRequireEveryDimensionWithoutMutation() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<int16[2][2]>0");
+    Short[] initial = shorts(0, 4);
+    writeValue(processImage, address, new Matrix(initial, new int[] {2, 2}));
+
+    DataValue read =
+        ModbusAddressSpace.readValueAttributes(
+                processImage, List.of(new ModbusAddressSpace.ValueRead(address, "1")))
+            .get(0);
+    StatusCode write =
+        ModbusAddressSpace.writeValueAttributes(
+                processImage,
+                List.of(
+                    new ModbusAddressSpace.ValueWrite(
+                        address, new Variant(new Short[] {8, 9}), "1")))
+            .get(0);
+
+    assertStatus(StatusCodes.Bad_IndexRangeNoData, read.getStatusCode());
+    assertStatus(StatusCodes.Bad_IndexRangeNoData, write);
+    Matrix actual =
+        assertInstanceOf(
+            Matrix.class,
+            ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+    assertArrayEquals(initial, (Short[]) actual.getElements());
+  }
+
+  @Test
+  void rangedWriteElementTypeMismatchDoesNotMutateProcessImage() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<int16[4]>0");
+    Short[] initial = shorts(0, 4);
+    writeValue(processImage, address, initial);
+
+    StatusCode status =
+        ModbusAddressSpace.writeValueAttributes(
+                processImage,
+                List.of(
+                    new ModbusAddressSpace.ValueWrite(
+                        address, new Variant(new Integer[] {8, 9}), "1:2")))
+            .get(0);
+
+    assertStatus(StatusCodes.Bad_TypeMismatch, status);
+    assertArrayEquals(
+        initial,
+        (Short[])
+            ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+  }
+
+  @Test
+  void stringRangeLengthMismatchDoesNotMutateProcessImage() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<string10>0");
+    writeValue(processImage, address, "HELLOWORLD");
+
+    StatusCode status =
+        ModbusAddressSpace.writeValueAttributes(
+                processImage,
+                List.of(
+                    new ModbusAddressSpace.ValueWrite(address, new Variant("NO"), "0:4")))
+            .get(0);
+
+    assertStatus(StatusCodes.Bad_IndexRangeDataMismatch, status);
+    assertEquals(
+        "HELLOWORLD",
+        ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
   }
 
   @Test
@@ -454,6 +531,24 @@ class ModbusAddressSpaceTest {
 
     assertArrayEquals(
         new String[] {"alpha", "BETa", "gamma", "delta"},
+        (String[]) ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+  }
+
+  @Test
+  void stringArrayElementRangeReadsAndWritesWholeStrings() throws Exception {
+    ProcessImage processImage = new ProcessImage();
+    ModbusAddress address = ModbusAddressParser.parse("HR<string8[4]>0");
+    writeValue(processImage, address, new String[] {"alpha", "beta", "gamma", "delta"});
+
+    assertArrayEquals(
+        new String[] {"beta", "gamma"},
+        (String[]) ModbusAddressSpace.readValueAttribute(processImage, address, "1:2").getValue());
+
+    ModbusAddressSpace.writeValueAttribute(
+        processImage, address, new Variant(new String[] {"BETA", "GAMMA"}), "1:2");
+
+    assertArrayEquals(
+        new String[] {"alpha", "BETA", "GAMMA", "delta"},
         (String[]) ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
   }
 

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
@@ -3,6 +3,7 @@ package com.kevinherron.ignition.modbus;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.kevinherron.ignition.modbus.address.ModbusAddress;
+import com.kevinherron.ignition.modbus.address.ModbusAddress.ArrayAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddressParser;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -13,6 +14,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 class ModbusAddressSpaceTest {
 
   @ParameterizedTest(name = "{0}")
+  @MethodSource("readBooleansArguments")
+  void readBooleans(String addressString, Map<Integer, Boolean> booleans, boolean[] expectedValues)
+      throws Exception {
+
+    ModbusAddress address = ModbusAddressParser.parse(addressString);
+    assertInstanceOf(ArrayAddress.class, address, "Address must be an array address");
+    boolean[] values = ModbusAddressSpace.readBooleans(booleans, (ArrayAddress) address);
+    assertArrayEquals(expectedValues, values);
+  }
+
+  @ParameterizedTest(name = "{0}")
   @MethodSource("readRegistersArguments")
   void readRegisters(String addressString, Map<Integer, byte[]> registers, byte[] expectedBytes)
       throws Exception {
@@ -20,6 +32,74 @@ class ModbusAddressSpaceTest {
     ModbusAddress address = ModbusAddressParser.parse(addressString);
     byte[] bytes = ModbusAddressSpace.readRegisters(registers, address);
     assertArrayEquals(expectedBytes, bytes);
+  }
+
+  private static Stream<Arguments> readBooleansArguments() {
+    return Stream.of(
+        // Test 1D array of booleans (3 elements)
+        Arguments.of(
+            "C<bool[3]>0",
+            Map.of(
+                0, true,
+                1, false,
+                2, true),
+            new boolean[] {true, false, true}),
+
+        // Test 2D array of booleans (2x2 elements)
+        Arguments.of(
+            "C<bool[2][2]>10",
+            Map.of(
+                10, true, // [0][0]
+                11, false, // [0][1]
+                12, false, // [1][0]
+                13, true), // [1][1]
+            new boolean[] {true, false, false, true}),
+
+        // Test 3D array of booleans (2x2x2 elements)
+        Arguments.of(
+            "C<bool[2][2][2]>50",
+            Map.of(
+                50, true, // [0][0][0]
+                51, false, // [0][0][1]
+                52, true, // [0][1][0]
+                53, false, // [0][1][1]
+                54, false, // [1][0][0]
+                55, true, // [1][0][1]
+                56, true, // [1][1][0]
+                57, false // [1][1][1]
+                ),
+            new boolean[] {true, false, true, false, false, true, true, false}),
+
+        // Test array with missing values (should return false for missing values)
+        Arguments.of(
+            "C<bool[3]>20",
+            Map.of(
+                20, true,
+                // 21 is missing
+                22, true),
+            new boolean[] {true, false, true}),
+
+        // Test discrete inputs
+        Arguments.of(
+            "DI<bool[4]>30",
+            Map.of(
+                30, true,
+                31, true,
+                32, false,
+                33, true),
+            new boolean[] {true, true, false, true}),
+
+        // Test larger array
+        Arguments.of(
+            "C<bool[6]>40",
+            Map.of(
+                40, true,
+                41, false,
+                42, true,
+                43, true,
+                44, false,
+                45, true),
+            new boolean[] {true, false, true, true, false, true}));
   }
 
   private static Stream<Arguments> readRegistersArguments() {
@@ -98,6 +178,24 @@ class ModbusAddressSpaceTest {
                 302, new byte[] {0x0E, 0x0F}, // [1][0]
                 303, new byte[] {0x10, 0x11}), // [1][1]
             new byte[] {0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11}),
+
+        // Test 3D array of INT16 (2x2x2 elements)
+        Arguments.of(
+            "HR<int16[2][2][2]>500",
+            Map.of(
+                500, new byte[] {0x01, 0x01}, // [0][0][0]
+                501, new byte[] {0x02, 0x02}, // [0][0][1]
+                502, new byte[] {0x03, 0x03}, // [0][1][0]
+                503, new byte[] {0x04, 0x04}, // [0][1][1]
+                504, new byte[] {0x05, 0x05}, // [1][0][0]
+                505, new byte[] {0x06, 0x06}, // [1][0][1]
+                506, new byte[] {0x07, 0x07}, // [1][1][0]
+                507, new byte[] {0x08, 0x08} // [1][1][1]
+                ),
+            new byte[] {
+              0x01, 0x01, 0x02, 0x02, 0x03, 0x03, 0x04, 0x04, 0x05, 0x05, 0x06, 0x06, 0x07, 0x07,
+              0x08, 0x08
+            }),
 
         // Test array with missing values (should return zeros for missing registers)
         Arguments.of(

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusValueAccessTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusValueAccessTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package com.kevinherron.ignition.modbus;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.digitalpetri.modbus.server.ProcessImage;
+import com.kevinherron.ignition.modbus.address.ModbusAddress;
+import com.kevinherron.ignition.modbus.address.ModbusAddressParser;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.UaRuntimeException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ModbusValueAccessTest {
+
+  @Nested
+  class Read {
+
+    // The four Modbus areas are independent stores; selecting the wrong one can return a
+    // plausible value from the same offset and hide the routing error.
+    @Test
+    void readsFromTheAreaSelectedByTheAddress() throws Exception {
+      ProcessImage processImage = new ProcessImage();
+      processImage.with(
+          tx -> {
+            tx.writeCoils(values -> values.put(10, true));
+            tx.writeDiscreteInputs(values -> values.put(10, false));
+            tx.writeHoldingRegisters(values -> values.put(10, new byte[] {0, 11}));
+            tx.writeInputRegisters(values -> values.put(10, new byte[] {0, 22}));
+          });
+
+      assertEquals(true, read(processImage, "C10", null).getValue());
+      assertEquals(false, read(processImage, "DI10", null).getValue());
+      assertEquals((short) 11, read(processImage, "HR<int16>10", null).getValue());
+      assertEquals((short) 22, read(processImage, "IR<int16>10", null).getValue());
+    }
+
+    // Sparse process images are normal; absent entries must have deterministic Modbus zero
+    // semantics instead of leaking nulls into OPC UA values.
+    @Test
+    void absentProcessImageEntriesReadAsZeroValues() throws Exception {
+      ProcessImage processImage = new ProcessImage();
+
+      assertEquals(false, read(processImage, "C0", null).getValue());
+      assertEquals(false, read(processImage, "DI0", null).getValue());
+      assertEquals(0, read(processImage, "HR<int32>0", null).getValue());
+      assertEquals(ushort(0), read(processImage, "IR<uint16>0", null).getValue());
+    }
+
+    // A first-dimension slice must advance by both the row width and the registers per element;
+    // otherwise ranged reads of multi-register values start at the wrong Modbus offset.
+    @Test
+    void rangedMatrixReadAccountsForRegistersPerElement() throws Exception {
+      ProcessImage processImage = new ProcessImage();
+      putInt32Values(processImage, 100, new int[] {10, 11, 20, 21, 30, 31});
+
+      Matrix value =
+          assertInstanceOf(
+              Matrix.class,
+              read(processImage, "HR<int32[3][2]>100", "1,0:1").getValue());
+
+      assertArrayEquals(new int[] {1, 2}, value.getDimensions());
+      assertArrayEquals(new Integer[] {20, 21}, (Integer[]) value.getElements());
+    }
+  }
+
+  @Nested
+  class Write {
+
+    // Each write must mutate only the process-image area named by its address; the same offset may
+    // legitimately hold unrelated values in all four areas.
+    @Test
+    void writesOnlyToTheAreaSelectedByTheAddress() throws Exception {
+      ProcessImage processImage = new ProcessImage();
+
+      write(processImage, "C10", true, null);
+      write(processImage, "DI10", false, null);
+      write(processImage, "HR<int16>10", (short) 11, null);
+      write(processImage, "IR<int16>10", (short) 22, null);
+
+      processImage.with(
+          tx -> {
+            assertEquals(Map.of(10, true), tx.readCoils(Map::copyOf));
+            assertEquals(Map.of(10, false), tx.readDiscreteInputs(Map::copyOf));
+            assertArrayEquals(
+                new byte[] {0, 11},
+                tx.readHoldingRegisters(registers -> registers.get(10)));
+            assertArrayEquals(
+                new byte[] {0, 22}, tx.readInputRegisters(registers -> registers.get(10)));
+          });
+    }
+
+    // High-bit writes exercise the signed narrowing and unsigned wrappers used to encode every
+    // supported integer width without losing the other bits in the register value.
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("com.kevinherron.ignition.modbus.ModbusValueAccessTest#highBitWriteArguments")
+    void settingHighBitPreservesNumericWidth(
+        String dataType,
+        String address,
+        String underlyingAddress,
+        Object initialValue,
+        Object expectedValue)
+        throws Exception {
+      ProcessImage processImage = new ProcessImage();
+      write(processImage, underlyingAddress, initialValue, null);
+
+      write(processImage, address, true, null);
+
+      assertEquals(expectedValue, read(processImage, underlyingAddress, null).getValue());
+    }
+
+    // A bit address is a read-modify-write view of its underlying registers; clearing one bit must
+    // not disturb any of the other 31 bits.
+    @Test
+    void clearingBitPreservesOtherBits() throws Exception {
+      ProcessImage processImage = new ProcessImage();
+      write(processImage, "HR<uint32>50", uint(0xFFFF_FFFFL), null);
+
+      write(processImage, "HR<uint32>50.20", false, null);
+
+      assertEquals(uint(0xFFEF_FFFFL), read(processImage, "HR<uint32>50", null).getValue());
+    }
+
+    // A selected matrix row spans its width times the registers per element; omitting either factor
+    // writes the update to the wrong Modbus offsets.
+    @Test
+    void rangedMatrixWriteAccountsForRegistersPerElement() throws Exception {
+      ProcessImage processImage = new ProcessImage();
+      putInt32Values(processImage, 100, new int[] {10, 11, 20, 21, 30, 31});
+
+      write(
+          processImage,
+          "HR<int32[3][2]>100",
+          new Matrix(new Integer[] {200, 201}, new int[] {1, 2}),
+          "1,0:1");
+
+      assertArrayEquals(
+          new Integer[] {10, 11, 200, 201, 30, 31},
+          (Integer[]) read(processImage, "HR<int32[6]>100", null).getValue());
+    }
+
+    // Invalid values must be rejected before the read-modify-write path mutates the underlying
+    // registers, or a bad OPC UA request could corrupt an otherwise valid process image.
+    @Test
+    void invalidBitWriteLeavesRegistersUnchanged() throws Exception {
+      ProcessImage processImage = new ProcessImage();
+      write(processImage, "HR<uint32>50", uint(0x1234_5678L), null);
+
+      UaRuntimeException exception =
+          assertThrows(
+              UaRuntimeException.class,
+              () -> write(processImage, "HR<uint32>50.20", "not a Boolean", null));
+
+      assertEquals(
+          StatusCodes.Bad_TypeMismatch,
+          UaException.extract(exception).orElseThrow().getStatusCode().getValue());
+      assertEquals(uint(0x1234_5678L), read(processImage, "HR<uint32>50", null).getValue());
+    }
+  }
+
+  private static Stream<Arguments> highBitWriteArguments() {
+    return Stream.of(
+        Arguments.of("Int16", "HR<int16>0.15", "HR<int16>0", (short) 1, (short) 0x8001),
+        Arguments.of("UInt16", "HR<uint16>10.15", "HR<uint16>10", ushort(1), ushort(0x8001)),
+        Arguments.of("Int32", "HR<int32>20.31", "HR<int32>20", 1, 0x8000_0001),
+        Arguments.of(
+            "UInt32", "HR<uint32>30.31", "HR<uint32>30", uint(1), uint(0x8000_0001L)),
+        Arguments.of(
+            "Int64", "HR<int64>40.63", "HR<int64>40", 1L, Long.MIN_VALUE | 1L),
+        Arguments.of(
+            "UInt64", "HR<uint64>50.63", "HR<uint64>50", ulong(1), ulong(Long.MIN_VALUE | 1L)));
+  }
+
+  private static Variant read(ProcessImage processImage, String address, String indexRange)
+      throws UaException {
+    ModbusAddress parsedAddress = parse(address);
+    try {
+      return processImage.get(
+          tx -> {
+            try {
+              return ModbusValueAccess.readValueAttribute(tx, parsedAddress, indexRange);
+            } catch (UaException e) {
+              throw new UaRuntimeException(e);
+            }
+          });
+    } catch (UaRuntimeException e) {
+      throw UaException.extract(e).orElseThrow();
+    }
+  }
+
+  private static void write(
+      ProcessImage processImage, String address, Object value, String indexRange) {
+    ModbusAddress parsedAddress = parse(address);
+    processImage.with(
+        tx ->
+            ModbusValueAccess.writeValueAttribute(
+                tx, parsedAddress, new Variant(value), indexRange));
+  }
+
+  private static ModbusAddress parse(String address) {
+    try {
+      return ModbusAddressParser.parse(address);
+    } catch (Exception e) {
+      throw new AssertionError("invalid test address: " + address, e);
+    }
+  }
+
+  private static void putInt32Values(ProcessImage processImage, int offset, int[] values) {
+    processImage.with(
+        tx ->
+            tx.writeHoldingRegisters(
+                registers -> {
+                  for (int i = 0; i < values.length; i++) {
+                    int value = values[i];
+                    registers.put(
+                        offset + i * 2,
+                        new byte[] {(byte) (value >>> 24), (byte) (value >>> 16)});
+                    registers.put(
+                        offset + i * 2 + 1,
+                        new byte[] {(byte) (value >>> 8), (byte) value});
+                  }
+                }));
+  }
+}

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/address/ModbusAddressParserTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/address/ModbusAddressParserTest.java
@@ -2,14 +2,90 @@ package com.kevinherron.ignition.modbus.address;
 
 import static com.kevinherron.ignition.modbus.address.ModbusAddressParser.ADDRESS_PATTERN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.kevinherron.ignition.modbus.address.ModbusAddress.ModbusArea;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ModbusAddressParserTest {
+
+  @ParameterizedTest(name = "README valid address: {0}")
+  @ValueSource(
+      strings = {
+        "C0",
+        "DI0",
+        "HR<int16>0",
+        "HR<int32>0.5",
+        "HR<string10>0",
+        "IR<int32@LE>0",
+        "IR<float@LH>0",
+        "HR<int16[10]>0",
+        "HR<int32[5][2]@LE>100",
+        "C<bool[2][2]>0",
+        "HR<int16[10]>0[5]",
+        "HR<int32[5][2]>100[2][1]",
+        "HR<int16[36]>65500"
+      })
+  void parsesEveryValidReadmeAddressExample(String address) throws Exception {
+    assertTrue(ModbusAddressParser.isValidAddress(address));
+    ModbusAddressParser.parse(address);
+  }
+
+  @ParameterizedTest(name = "README rejected address: {0}")
+  @ValueSource(
+      strings = {
+        "HR<int32@LE[5][2]>100",
+        "HR<int16[37]>65500",
+        "HR<int64[99999][99999][99999]>0",
+        "HR<int16[10]>0.5",
+        "HR0[5]",
+        "HR<int16[10]>0[2:5]"
+      })
+  void rejectsEveryInvalidReadmeAddressExample(String address) {
+    assertFalse(ModbusAddressParser.isValidAddress(address));
+  }
+
+  @ParameterizedTest(name = "register data type on bit area rejected: {0}")
+  @ValueSource(
+      strings = {"C<int16>0", "DI<int16>0", "C<string4>0", "DI<float[2]>0", "C<uint32[2][2]>0"})
+  void rejectsRegisterDataTypesOnCoilAndDiscreteInputAreas(String address) {
+    assertFalse(ModbusAddressParser.isValidAddress(address));
+  }
+
+  @ParameterizedTest(name = "bit specifier rejected: {0}")
+  @ValueSource(
+      strings = {
+        "HR<int16>0.16",
+        "HR<int32>0.32",
+        "HR<int64>0.64",
+        "HR<float>0.5",
+        "HR<double>0.5",
+        "HR<string4>0.0",
+        "HR<bool>0.0",
+        "C0.0"
+      })
+  void rejectsBitIndexOutsideWidthOrNonIntegerType(String address) {
+    assertFalse(ModbusAddressParser.isValidAddress(address));
+  }
+
+  @ParameterizedTest(name = "bit specifier accepted: {0}")
+  @ValueSource(
+      strings = {
+        "HR0.15",
+        "HR<int16>0.15",
+        "HR<uint16>0.0",
+        "HR<int32>0.31",
+        "HR<uint64>0.63",
+        "HR<int16[10]>0[3].15"
+      })
+  void acceptsBitIndexWithinWidthOnIntegerTypes(String address) {
+    assertTrue(ModbusAddressParser.isValidAddress(address));
+  }
 
   @Test
   void patternMatchesBasicAddress() {
@@ -249,5 +325,86 @@ class ModbusAddressParserTest {
 
     // Negative index
     assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<int16[10]>1[-1]"));
+  }
+
+  @Test
+  void rejectsOversizedArrayExtentWithoutAllocation() {
+    assertThrows(
+        Exception.class,
+        () -> ModbusAddressParser.parse("HR<int64[99999][99999][99999]>0"));
+    assertFalse(ModbusAddressParser.isValidAddress("HR<int64[99999][99999][99999]>0"));
+  }
+
+  @Test
+  void rejectsOffsetsOutsideAddressSpace() throws Exception {
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR70000"));
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR-1"));
+
+    assertEquals(65535, ModbusAddressParser.parse("HR65535").getOffset());
+    assertEquals(65535, ModbusAddressParser.parse("C65535").getOffset());
+  }
+
+  @Test
+  void rejectsExtentThatWouldOverflowToNegativeInt() {
+    assertThrows(
+        Exception.class, () -> ModbusAddressParser.parse("HR<int64[536870912]>0"));
+  }
+
+  @Test
+  void rejectsStringRegisterCountThatPreviouslyOverflowedNegative() {
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<string2147483647>0"));
+    assertThrows(
+        Exception.class,
+        () -> ModbusAddressParser.parse("HR<string2147483647[2]>0"));
+  }
+
+  @Test
+  void rejectsOversizedDeclaredExtentOnIndexedScalar() {
+    assertThrows(
+        Exception.class, () -> ModbusAddressParser.parse("HR<int16[65537]>0[0]"));
+  }
+
+  @Test
+  void validatesArrayExtentAtAddressSpaceBoundary() throws Exception {
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<int16[100]>65500"));
+
+    var address = ModbusAddressParser.parse("HR<int16[36]>65500");
+    assertInstanceOf(ModbusAddress.ArrayAddress.class, address);
+    assertEquals(65500, address.getOffset());
+  }
+
+  @Test
+  void rejectsScalarWhoseExtentExceedsAddressSpace() {
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<int32>65535"));
+  }
+
+  @Test
+  void rejectsBitSpecifierOnArrayButAllowsBitOnIndexedElement() throws Exception {
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<int16[10]>0.5"));
+
+    var address = ModbusAddressParser.parse("HR<int16[10]>0[3].5");
+    assertInstanceOf(ModbusAddress.ScalarAddress.class, address);
+    assertEquals(3, address.getOffset());
+    var bit = assertInstanceOf(ModbusDataType.Bit.class, address.getDataType());
+    assertInstanceOf(ModbusDataType.Int16.class, bit.underlyingType());
+    assertEquals(5, bit.bit());
+  }
+
+  @Test
+  void rejectsIndicesWithoutDimensionsUsingDeclaredException() {
+    var exception = assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR0[5]"));
+
+    assertEquals(Exception.class, exception.getClass());
+  }
+
+  @Test
+  void rejectsConflictingAndMalformedDataTypeModifiers() throws Exception {
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<int16@BE@LE>0"));
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<int16@HL@LH>0"));
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<int16@BEL>0"));
+
+    assertEquals(1, ModbusAddressParser.parse("HR<int16@BE>0").getDataTypeModifiers().size());
+    assertEquals(
+        2, ModbusAddressParser.parse("HR<int16@BE@HL>0").getDataTypeModifiers().size());
   }
 }

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/address/ModbusAddressParserTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/address/ModbusAddressParserTest.java
@@ -114,4 +114,140 @@ class ModbusAddressParserTest {
 
     assertThrows(Exception.class, () -> ModbusAddressParser.parse("256.HR1"));
   }
+
+  @Test
+  void parseArrayAddress() throws Exception {
+    // 1-dimensional array
+    var address = ModbusAddressParser.parse("HR<int16[10]>1");
+    assertInstanceOf(ModbusAddress.ArrayAddress.class, address);
+
+    var arrayAddress = (ModbusAddress.ArrayAddress) address;
+    assertEquals(ModbusArea.HOLDING_REGISTERS, arrayAddress.getArea());
+    assertEquals(1, arrayAddress.getOffset());
+    assertInstanceOf(ModbusDataType.Int16.class, arrayAddress.getDataType());
+    assertEquals(1, arrayAddress.getDimensions().length);
+    assertEquals(10, arrayAddress.getDimensions()[0]);
+
+    // 2-dimensional array
+    address = ModbusAddressParser.parse("HR<int32[5][2]>100");
+    assertInstanceOf(ModbusAddress.ArrayAddress.class, address);
+
+    arrayAddress = (ModbusAddress.ArrayAddress) address;
+    assertEquals(ModbusArea.HOLDING_REGISTERS, arrayAddress.getArea());
+    assertEquals(100, arrayAddress.getOffset());
+    assertInstanceOf(ModbusDataType.Int32.class, arrayAddress.getDataType());
+    assertEquals(2, arrayAddress.getDimensions().length);
+    assertEquals(5, arrayAddress.getDimensions()[0]);
+    assertEquals(2, arrayAddress.getDimensions()[1]);
+
+    // 3-dimensional array
+    address = ModbusAddressParser.parse("IR<float[3][4][5]>200");
+    assertInstanceOf(ModbusAddress.ArrayAddress.class, address);
+
+    arrayAddress = (ModbusAddress.ArrayAddress) address;
+    assertEquals(ModbusArea.INPUT_REGISTERS, arrayAddress.getArea());
+    assertEquals(200, arrayAddress.getOffset());
+    assertInstanceOf(ModbusDataType.Float32.class, arrayAddress.getDataType());
+    assertEquals(3, arrayAddress.getDimensions().length);
+    assertEquals(3, arrayAddress.getDimensions()[0]);
+    assertEquals(4, arrayAddress.getDimensions()[1]);
+    assertEquals(5, arrayAddress.getDimensions()[2]);
+  }
+
+  @Test
+  void parseArrayAddressWithUnitId() throws Exception {
+    var address = ModbusAddressParser.parse("10.HR<int16[10]>1");
+    assertInstanceOf(ModbusAddress.ArrayAddress.class, address);
+
+    var arrayAddress = (ModbusAddress.ArrayAddress) address;
+    assertEquals(10, arrayAddress.getUnitId().orElseThrow());
+    assertEquals(ModbusArea.HOLDING_REGISTERS, arrayAddress.getArea());
+    assertEquals(1, arrayAddress.getOffset());
+    assertInstanceOf(ModbusDataType.Int16.class, arrayAddress.getDataType());
+    assertEquals(1, arrayAddress.getDimensions().length);
+    assertEquals(10, arrayAddress.getDimensions()[0]);
+  }
+
+  @Test
+  void parseArrayAddressWithDataTypeModifiers() throws Exception {
+    var address = ModbusAddressParser.parse("HR<int32[5][2]@LE@LH>100");
+    assertInstanceOf(ModbusAddress.ArrayAddress.class, address);
+
+    var arrayAddress = (ModbusAddress.ArrayAddress) address;
+    assertEquals(ModbusArea.HOLDING_REGISTERS, arrayAddress.getArea());
+    assertEquals(100, arrayAddress.getOffset());
+    assertInstanceOf(ModbusDataType.Int32.class, arrayAddress.getDataType());
+    assertEquals(2, arrayAddress.getDimensions().length);
+    assertEquals(5, arrayAddress.getDimensions()[0]);
+    assertEquals(2, arrayAddress.getDimensions()[1]);
+
+    var modifiers = arrayAddress.getDataTypeModifiers();
+    assertEquals(2, modifiers.size());
+    assertTrue(modifiers.stream().anyMatch(m -> m instanceof DataTypeModifier.ByteOrderModifier));
+    assertTrue(modifiers.stream().anyMatch(m -> m instanceof DataTypeModifier.WordOrderModifier));
+  }
+
+  @Test
+  void parseArrayAddressWithIndices() throws Exception {
+    // 1-dimensional array with index
+    var address = ModbusAddressParser.parse("HR<int16[10]>1[5]");
+    assertInstanceOf(ModbusAddress.ScalarAddress.class, address);
+
+    var scalarAddress = (ModbusAddress.ScalarAddress) address;
+    assertEquals(ModbusArea.HOLDING_REGISTERS, scalarAddress.getArea());
+    assertEquals(6, scalarAddress.getOffset()); // base offset 1 + index 5 * register count 1
+    assertInstanceOf(ModbusDataType.Int16.class, scalarAddress.getDataType());
+
+    // 2-dimensional array with indices
+    address = ModbusAddressParser.parse("HR<int32[5][2]>100[2][1]");
+    assertInstanceOf(ModbusAddress.ScalarAddress.class, address);
+
+    scalarAddress = (ModbusAddress.ScalarAddress) address;
+    assertEquals(ModbusArea.HOLDING_REGISTERS, scalarAddress.getArea());
+    assertEquals(110, scalarAddress.getOffset()); // base offset 100 + (2*2 + 1) * register count 2
+    assertInstanceOf(ModbusDataType.Int32.class, scalarAddress.getDataType());
+
+    // 3-dimensional array with indices
+    address = ModbusAddressParser.parse("IR<float[3][4][5]>200[1][2][3]");
+    assertInstanceOf(ModbusAddress.ScalarAddress.class, address);
+
+    scalarAddress = (ModbusAddress.ScalarAddress) address;
+    assertEquals(ModbusArea.INPUT_REGISTERS, scalarAddress.getArea());
+    assertEquals(
+        266, scalarAddress.getOffset()); // base offset 200 + (1*4*5 + 2*5 + 3) * register count 2
+    assertInstanceOf(ModbusDataType.Float32.class, scalarAddress.getDataType());
+
+    // With unit ID and data type modifiers
+    address = ModbusAddressParser.parse("10.HR<int32[5][2]@LE@LH>100[4][0]");
+    assertInstanceOf(ModbusAddress.ScalarAddress.class, address);
+
+    scalarAddress = (ModbusAddress.ScalarAddress) address;
+    assertEquals(10, scalarAddress.getUnitId().orElseThrow());
+    assertEquals(ModbusArea.HOLDING_REGISTERS, scalarAddress.getArea());
+    assertEquals(116, scalarAddress.getOffset()); // base offset 100 + (4*2 + 0) * register count 2
+    assertInstanceOf(ModbusDataType.Int32.class, scalarAddress.getDataType());
+
+    var modifiers = scalarAddress.getDataTypeModifiers();
+    assertEquals(2, modifiers.size());
+    assertTrue(modifiers.stream().anyMatch(m -> m instanceof DataTypeModifier.ByteOrderModifier));
+    assertTrue(modifiers.stream().anyMatch(m -> m instanceof DataTypeModifier.WordOrderModifier));
+  }
+
+  @Test
+  void parseArrayAddressWithInvalidIndices() {
+    // The number of indices doesn't match dimensions
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<int16[10][20]>1[5]"));
+
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<int16[10]>1[5][2]"));
+
+    // Index out of bounds
+    assertThrows(
+        Exception.class,
+        () -> ModbusAddressParser.parse("HR<int16[10]>1[10]")); // index must be < dimension
+
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<int16[10][20]>1[5][20]"));
+
+    // Negative index
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<int16[10]>1[-1]"));
+  }
 }

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/util/ModbusByteUtilTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/util/ModbusByteUtilTest.java
@@ -1,13 +1,16 @@
 package com.kevinherron.ignition.modbus.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.kevinherron.ignition.modbus.address.DataTypeModifier;
 import com.kevinherron.ignition.modbus.address.ModbusDataType;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Set;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
@@ -19,8 +22,8 @@ class ModbusByteUtilTest {
 
   @Test
   void testGetBytesForArrayValue_Bool() throws UaException {
-    Boolean[] booleans = new Boolean[]{true, false, true};
-    int[] dimensions = new int[]{booleans.length};
+    Boolean[] booleans = new Boolean[] {true, false, true};
+    int[] dimensions = new int[] {booleans.length};
 
     byte[] bytes =
         ModbusByteUtil.getBytesForArrayValue(
@@ -48,8 +51,8 @@ class ModbusByteUtilTest {
 
   @Test
   void testGetBytesForArrayValue_Int16() throws UaException {
-    Short[] shorts = new Short[]{(short) 1, (short) 2, (short) 3};
-    int[] dimensions = new int[]{shorts.length};
+    Short[] shorts = new Short[] {(short) 1, (short) 2, (short) 3};
+    int[] dimensions = new int[] {shorts.length};
 
     byte[] bytes =
         ModbusByteUtil.getBytesForArrayValue(
@@ -69,8 +72,8 @@ class ModbusByteUtilTest {
 
   @Test
   void testGetBytesForArrayValue_UInt16() throws UaException {
-    UShort[] ushorts = new UShort[]{UShort.valueOf(1), UShort.valueOf(2), UShort.valueOf(3)};
-    int[] dimensions = new int[]{ushorts.length};
+    UShort[] ushorts = new UShort[] {UShort.valueOf(1), UShort.valueOf(2), UShort.valueOf(3)};
+    int[] dimensions = new int[] {ushorts.length};
 
     byte[] bytes =
         ModbusByteUtil.getBytesForArrayValue(
@@ -90,8 +93,8 @@ class ModbusByteUtilTest {
 
   @Test
   void testGetBytesForArrayValue_Int32() throws UaException {
-    Integer[] ints = new Integer[]{1, 2, 3};
-    int[] dimensions = new int[]{ints.length};
+    Integer[] ints = new Integer[] {1, 2, 3};
+    int[] dimensions = new int[] {ints.length};
 
     byte[] bytes =
         ModbusByteUtil.getBytesForArrayValue(
@@ -120,8 +123,8 @@ class ModbusByteUtilTest {
   @Test
   void testGetBytesForArrayValue_UInt32() throws UaException {
     UInteger[] uints =
-        new UInteger[]{UInteger.valueOf(1), UInteger.valueOf(2), UInteger.valueOf(3)};
-    int[] dimensions = new int[]{uints.length};
+        new UInteger[] {UInteger.valueOf(1), UInteger.valueOf(2), UInteger.valueOf(3)};
+    int[] dimensions = new int[] {uints.length};
 
     byte[] bytes =
         ModbusByteUtil.getBytesForArrayValue(
@@ -152,8 +155,8 @@ class ModbusByteUtilTest {
 
   @Test
   void testGetBytesForArrayValue_Int64() throws UaException {
-    Long[] longs = new Long[]{1L, 2L, 3L};
-    int[] dimensions = new int[]{longs.length};
+    Long[] longs = new Long[] {1L, 2L, 3L};
+    int[] dimensions = new int[] {longs.length};
 
     byte[] bytes =
         ModbusByteUtil.getBytesForArrayValue(
@@ -184,8 +187,8 @@ class ModbusByteUtilTest {
 
   @Test
   void testGetBytesForArrayValue_UInt64() throws UaException {
-    ULong[] ulongs = new ULong[]{ULong.valueOf(1), ULong.valueOf(2), ULong.valueOf(3)};
-    int[] dimensions = new int[]{ulongs.length};
+    ULong[] ulongs = new ULong[] {ULong.valueOf(1), ULong.valueOf(2), ULong.valueOf(3)};
+    int[] dimensions = new int[] {ulongs.length};
 
     byte[] bytes =
         ModbusByteUtil.getBytesForArrayValue(
@@ -216,8 +219,8 @@ class ModbusByteUtilTest {
 
   @Test
   void testGetBytesForArrayValue_Float32() throws UaException {
-    Float[] floats = new Float[]{1.0f, 2.5f, 3.75f};
-    int[] dimensions = new int[]{floats.length};
+    Float[] floats = new Float[] {1.0f, 2.5f, 3.75f};
+    int[] dimensions = new int[] {floats.length};
 
     byte[] bytes =
         ModbusByteUtil.getBytesForArrayValue(
@@ -251,8 +254,8 @@ class ModbusByteUtilTest {
 
   @Test
   void testGetBytesForArrayValue_Double64() throws UaException {
-    Double[] doubles = new Double[]{1.0, 2.5, 3.75};
-    int[] dimensions = new int[]{doubles.length};
+    Double[] doubles = new Double[] {1.0, 2.5, 3.75};
+    int[] dimensions = new int[] {doubles.length};
 
     byte[] bytes =
         ModbusByteUtil.getBytesForArrayValue(
@@ -286,8 +289,8 @@ class ModbusByteUtilTest {
 
   @Test
   void testGetBytesForArrayValue_String() throws UaException {
-    String[] strings = new String[]{"abc", "def", "ghi"};
-    int[] dimensions = new int[]{strings.length};
+    String[] strings = new String[] {"abc", "def", "ghi"};
+    int[] dimensions = new int[] {strings.length};
 
     // Create a String data type with length 4 (which means 2 registers or 4 bytes per string)
     byte[] bytes =
@@ -316,5 +319,367 @@ class ModbusByteUtilTest {
       assertEquals(ghi[i], bytes[8 + i]);
     }
     assertEquals(0, bytes[11]); // Padding
+  }
+
+  @Test
+  void testGetBytesForMatrixValue_Bool_2D() throws UaException {
+    // Create a 2x2 matrix of Boolean values
+    Boolean[] booleans = new Boolean[] {true, false, false, true};
+    int[] dimensions = new int[] {2, 2};
+    Matrix matrix = new Matrix(booleans, dimensions);
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForMatrixValue(
+            matrix, new ModbusDataType.Bool(), NO_MODIFIERS, dimensions);
+
+    // Each Bool takes 2 bytes, so the total should be 8 bytes
+    assertEquals(8, bytes.length);
+
+    // Extract 2-byte chunks and convert back to verify
+    byte[] chunk1 = new byte[2];
+    byte[] chunk2 = new byte[2];
+    byte[] chunk3 = new byte[2];
+    byte[] chunk4 = new byte[2];
+
+    System.arraycopy(bytes, 0, chunk1, 0, 2);
+    System.arraycopy(bytes, 2, chunk2, 0, 2);
+    System.arraycopy(bytes, 4, chunk3, 0, 2);
+    System.arraycopy(bytes, 6, chunk4, 0, 2);
+
+    assertEquals(
+        true, ModbusByteUtil.getValueForBytes(chunk1, new ModbusDataType.Bool(), NO_MODIFIERS));
+    assertEquals(
+        false, ModbusByteUtil.getValueForBytes(chunk2, new ModbusDataType.Bool(), NO_MODIFIERS));
+    assertEquals(
+        false, ModbusByteUtil.getValueForBytes(chunk3, new ModbusDataType.Bool(), NO_MODIFIERS));
+    assertEquals(
+        true, ModbusByteUtil.getValueForBytes(chunk4, new ModbusDataType.Bool(), NO_MODIFIERS));
+  }
+
+  @Test
+  void testGetBytesForMatrixValue_Int16_2D() throws UaException {
+    // Create a 2x2 matrix of Int16 values
+    Short[] shorts = new Short[] {(short) 1, (short) 2, (short) 3, (short) 4};
+    int[] dimensions = new int[] {2, 2};
+    Matrix matrix = new Matrix(shorts, dimensions);
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForMatrixValue(
+            matrix, new ModbusDataType.Int16(), NO_MODIFIERS, dimensions);
+
+    // Each Int16 takes 2 bytes, so the total should be 8 bytes
+    assertEquals(8, bytes.length);
+
+    // Verify the content (big endian by default)
+    assertEquals(0, bytes[0]); // high byte of 1
+    assertEquals(1, bytes[1]); // low byte of 1
+    assertEquals(0, bytes[2]); // high byte of 2
+    assertEquals(2, bytes[3]); // low byte of 2
+    assertEquals(0, bytes[4]); // high byte of 3
+    assertEquals(3, bytes[5]); // low byte of 3
+    assertEquals(0, bytes[6]); // high byte of 4
+    assertEquals(4, bytes[7]); // low byte of 4
+  }
+
+  @Test
+  void testGetBytesForMatrixValue_UInt16_2D() throws UaException {
+    // Create a 2x2 matrix of UInt16 values
+    UShort[] ushorts =
+        new UShort[] {UShort.valueOf(1), UShort.valueOf(2), UShort.valueOf(3), UShort.valueOf(4)};
+    int[] dimensions = new int[] {2, 2};
+    Matrix matrix = new Matrix(ushorts, dimensions);
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForMatrixValue(
+            matrix, new ModbusDataType.UInt16(), NO_MODIFIERS, dimensions);
+
+    // Each UInt16 takes 2 bytes, so the total should be 8 bytes
+    assertEquals(8, bytes.length);
+
+    // Verify the content (big endian by default)
+    assertEquals(0, bytes[0]); // high byte of 1
+    assertEquals(1, bytes[1]); // low byte of 1
+    assertEquals(0, bytes[2]); // high byte of 2
+    assertEquals(2, bytes[3]); // low byte of 2
+    assertEquals(0, bytes[4]); // high byte of 3
+    assertEquals(3, bytes[5]); // low byte of 3
+    assertEquals(0, bytes[6]); // high byte of 4
+    assertEquals(4, bytes[7]); // low byte of 4
+  }
+
+  @Test
+  void testGetBytesForMatrixValue_Int32_2D() throws UaException {
+    // Create a 2x2 matrix of Int32 values
+    Integer[] integers = new Integer[] {1, 2, 3, 4};
+    int[] dimensions = new int[] {2, 2};
+    Matrix matrix = new Matrix(integers, dimensions);
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForMatrixValue(
+            matrix, new ModbusDataType.Int32(), NO_MODIFIERS, dimensions);
+
+    // Each Int32 takes 4 bytes, so the total should be 16 bytes
+    assertEquals(16, bytes.length);
+
+    // Extract 4-byte chunks and convert back to verify
+    for (int i = 0; i < 4; i++) {
+      byte[] chunk = new byte[4];
+      System.arraycopy(bytes, i * 4, chunk, 0, 4);
+
+      int expectedValue = integers[i];
+      int actualValue =
+          (Integer)
+              ModbusByteUtil.getValueForBytes(chunk, new ModbusDataType.Int32(), NO_MODIFIERS);
+
+      assertEquals(expectedValue, actualValue);
+    }
+  }
+
+  @Test
+  void testGetBytesForMatrixValue_UInt32_2D() throws UaException {
+    // Create a 2x2 matrix of UInt32 values
+    UInteger[] uintegers =
+        new UInteger[] {
+          UInteger.valueOf(1), UInteger.valueOf(2),
+          UInteger.valueOf(3), UInteger.valueOf(4)
+        };
+    int[] dimensions = new int[] {2, 2};
+    Matrix matrix = new Matrix(uintegers, dimensions);
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForMatrixValue(
+            matrix, new ModbusDataType.UInt32(), NO_MODIFIERS, dimensions);
+
+    // Each UInt32 takes 4 bytes, so the total should be 16 bytes
+    assertEquals(16, bytes.length);
+
+    // Extract 4-byte chunks and convert back to verify
+    for (int i = 0; i < 4; i++) {
+      byte[] chunk = new byte[4];
+      System.arraycopy(bytes, i * 4, chunk, 0, 4);
+
+      UInteger expectedValue = uintegers[i];
+      UInteger actualValue =
+          (UInteger)
+              ModbusByteUtil.getValueForBytes(chunk, new ModbusDataType.UInt32(), NO_MODIFIERS);
+
+      assertEquals(expectedValue, actualValue);
+    }
+  }
+
+  @Test
+  void testGetBytesForMatrixValue_Int64_2D() throws UaException {
+    // Create a 2x2 matrix of Int64 values
+    Long[] longs = new Long[] {1L, 2L, 3L, 4L};
+    int[] dimensions = new int[] {2, 2};
+    Matrix matrix = new Matrix(longs, dimensions);
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForMatrixValue(
+            matrix, new ModbusDataType.Int64(), NO_MODIFIERS, dimensions);
+
+    // Each Int64 takes 8 bytes, so the total should be 32 bytes
+    assertEquals(32, bytes.length);
+
+    // Extract 8-byte chunks and convert back to verify
+    for (int i = 0; i < 4; i++) {
+      byte[] chunk = new byte[8];
+      System.arraycopy(bytes, i * 8, chunk, 0, 8);
+
+      Long expectedValue = longs[i];
+      Long actualValue =
+          (Long) ModbusByteUtil.getValueForBytes(chunk, new ModbusDataType.Int64(), NO_MODIFIERS);
+
+      assertEquals(expectedValue, actualValue);
+    }
+  }
+
+  @Test
+  void testGetBytesForMatrixValue_UInt64_2D() throws UaException {
+    // Create a 2x2 matrix of UInt64 values
+    ULong[] ulongs =
+        new ULong[] {
+          ULong.valueOf(1), ULong.valueOf(2),
+          ULong.valueOf(3), ULong.valueOf(4)
+        };
+    int[] dimensions = new int[] {2, 2};
+    Matrix matrix = new Matrix(ulongs, dimensions);
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForMatrixValue(
+            matrix, new ModbusDataType.UInt64(), NO_MODIFIERS, dimensions);
+
+    // Each UInt64 takes 8 bytes, so the total should be 32 bytes
+    assertEquals(32, bytes.length);
+
+    // Extract 8-byte chunks and convert back to verify
+    for (int i = 0; i < 4; i++) {
+      byte[] chunk = new byte[8];
+      System.arraycopy(bytes, i * 8, chunk, 0, 8);
+
+      ULong expectedValue = ulongs[i];
+      ULong actualValue =
+          (ULong) ModbusByteUtil.getValueForBytes(chunk, new ModbusDataType.UInt64(), NO_MODIFIERS);
+
+      assertEquals(expectedValue, actualValue);
+    }
+  }
+
+  @Test
+  void testGetBytesForMatrixValue_Float32_3D() throws UaException {
+    // Create a 2x2x2 matrix of Float32 values
+    Float[] floats = new Float[] {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
+    int[] dimensions = new int[] {2, 2, 2};
+    Matrix matrix = new Matrix(floats, dimensions);
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForMatrixValue(
+            matrix, new ModbusDataType.Float32(), NO_MODIFIERS, dimensions);
+
+    // Each Float32 takes 4 bytes, so the total should be 32 bytes
+    assertEquals(32, bytes.length);
+
+    // Extract 4-byte chunks and convert back to verify
+    for (int i = 0; i < 8; i++) {
+      byte[] chunk = new byte[4];
+      System.arraycopy(bytes, i * 4, chunk, 0, 4);
+
+      float expectedValue = floats[i];
+      float actualValue =
+          (Float)
+              ModbusByteUtil.getValueForBytes(chunk, new ModbusDataType.Float32(), NO_MODIFIERS);
+
+      assertEquals(expectedValue, actualValue);
+    }
+  }
+
+  @Test
+  void testGetBytesForMatrixValue_Double64_2D() throws UaException {
+    // Create a 2x2 matrix of Double64 values
+    Double[] doubles = new Double[] {1.0, 2.5, 3.75, 4.125};
+    int[] dimensions = new int[] {2, 2};
+    Matrix matrix = new Matrix(doubles, dimensions);
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForMatrixValue(
+            matrix, new ModbusDataType.Double64(), NO_MODIFIERS, dimensions);
+
+    // Each Double64 takes 8 bytes, so the total should be 32 bytes
+    assertEquals(32, bytes.length);
+
+    // Extract 8-byte chunks and convert back to verify
+    for (int i = 0; i < 4; i++) {
+      byte[] chunk = new byte[8];
+      System.arraycopy(bytes, i * 8, chunk, 0, 8);
+
+      Double expectedValue = doubles[i];
+      Double actualValue =
+          (Double)
+              ModbusByteUtil.getValueForBytes(chunk, new ModbusDataType.Double64(), NO_MODIFIERS);
+
+      assertEquals(expectedValue, actualValue);
+    }
+  }
+
+  @Test
+  void testGetBytesForMatrixValue_String_2D() throws UaException {
+    // Create a 2x2 matrix of String values
+    String[] strings = new String[] {"ab", "cd", "ef", "gh"};
+    int[] dimensions = new int[] {2, 2};
+    Matrix matrix = new Matrix(strings, dimensions);
+
+    // Create a String data type with length 4 (which means 2 registers or 4 bytes per string)
+    byte[] bytes =
+        ModbusByteUtil.getBytesForMatrixValue(
+            matrix, new ModbusDataType.String(4), NO_MODIFIERS, dimensions);
+
+    // Each String takes 4 bytes, so the total should be 16 bytes
+    assertEquals(16, bytes.length);
+
+    // Verify the content
+    byte[] ab = "ab".getBytes(StandardCharsets.UTF_8);
+    byte[] cd = "cd".getBytes(StandardCharsets.UTF_8);
+    byte[] ef = "ef".getBytes(StandardCharsets.UTF_8);
+    byte[] gh = "gh".getBytes(StandardCharsets.UTF_8);
+
+    // First string "ab"
+    assertEquals(ab[0], bytes[0]);
+    assertEquals(ab[1], bytes[1]);
+    assertEquals(0, bytes[2]); // Padding
+    assertEquals(0, bytes[3]); // Padding
+
+    // Second string "cd"
+    assertEquals(cd[0], bytes[4]);
+    assertEquals(cd[1], bytes[5]);
+    assertEquals(0, bytes[6]); // Padding
+    assertEquals(0, bytes[7]); // Padding
+
+    // Third string "ef"
+    assertEquals(ef[0], bytes[8]);
+    assertEquals(ef[1], bytes[9]);
+    assertEquals(0, bytes[10]); // Padding
+    assertEquals(0, bytes[11]); // Padding
+
+    // Fourth string "gh"
+    assertEquals(gh[0], bytes[12]);
+    assertEquals(gh[1], bytes[13]);
+    assertEquals(0, bytes[14]); // Padding
+    assertEquals(0, bytes[15]); // Padding
+  }
+
+  @Test
+  void testGetBytesForMatrixValue_DimensionMismatch() {
+    // Create a 2x2 matrix of Boolean values
+    Boolean[] booleans = new Boolean[] {true, false, false, true};
+    int[] matrixDimensions = new int[] {2, 2};
+    Matrix matrix = new Matrix(booleans, matrixDimensions);
+
+    // Try to use with mismatched dimensions (3x3)
+    int[] requestedDimensions = new int[] {3, 3};
+
+    UaException exception =
+        assertThrows(
+            UaException.class,
+            () ->
+                ModbusByteUtil.getBytesForMatrixValue(
+                    matrix, new ModbusDataType.Bool(), NO_MODIFIERS, requestedDimensions));
+
+    assertEquals(StatusCodes.Bad_TypeMismatch, exception.getStatusCode().getValue());
+  }
+
+  @Test
+  void testGetBytesForMatrixValue_DimensionCountMismatch() {
+    // Create a 2x2 matrix of Boolean values
+    Boolean[] booleans = new Boolean[] {true, false, false, true};
+    int[] matrixDimensions = new int[] {2, 2};
+    Matrix matrix = new Matrix(booleans, matrixDimensions);
+
+    // Try to use with mismatched dimension count (1D instead of 2D)
+    int[] requestedDimensions = new int[] {4};
+
+    UaException exception =
+        assertThrows(
+            UaException.class,
+            () ->
+                ModbusByteUtil.getBytesForMatrixValue(
+                    matrix, new ModbusDataType.Bool(), NO_MODIFIERS, requestedDimensions));
+
+    assertEquals(StatusCodes.Bad_TypeMismatch, exception.getStatusCode().getValue());
+  }
+
+  @Test
+  void testGetBytesForMatrixValue_NotMatrix() {
+    // Try to use a non-Matrix object
+    Boolean[] booleans = new Boolean[] {true, false, false, true};
+    int[] dimensions = new int[] {2, 2};
+
+    UaException exception =
+        assertThrows(
+            UaException.class,
+            () ->
+                ModbusByteUtil.getBytesForMatrixValue(
+                    booleans, new ModbusDataType.Bool(), NO_MODIFIERS, dimensions));
+
+    assertEquals(StatusCodes.Bad_TypeMismatch, exception.getStatusCode().getValue());
   }
 }

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/util/ModbusByteUtilTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/util/ModbusByteUtilTest.java
@@ -21,6 +21,256 @@ class ModbusByteUtilTest {
   private static final Set<DataTypeModifier> NO_MODIFIERS = Collections.emptySet();
 
   @Test
+  void testGetArrayValueForBytes_Bool() throws UaException {
+    // Create a byte array for 3 boolean values: true, false, true
+    byte[] bytes = new byte[] {1, 0, 0, 0, 1, 0};
+    int[] dimensions = new int[] {3};
+
+    Object result =
+        ModbusByteUtil.getArrayValueForBytes(
+            bytes, new ModbusDataType.Bool(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Boolean array with the expected values
+    assertEquals(Boolean[].class, result.getClass());
+    Boolean[] booleans = (Boolean[]) result;
+    assertEquals(3, booleans.length);
+    assertEquals(true, booleans[0]);
+    assertEquals(false, booleans[1]);
+    assertEquals(true, booleans[2]);
+  }
+
+  @Test
+  void testGetArrayValueForBytes_Int16() throws UaException {
+    // Create a byte array for 3 short values: 1, 2, 3 (big endian)
+    byte[] bytes = new byte[] {0, 1, 0, 2, 0, 3};
+    int[] dimensions = new int[] {3};
+
+    Object result =
+        ModbusByteUtil.getArrayValueForBytes(
+            bytes, new ModbusDataType.Int16(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Short array with the expected values
+    assertEquals(Short[].class, result.getClass());
+    Short[] shorts = (Short[]) result;
+    assertEquals(3, shorts.length);
+    assertEquals((short) 1, shorts[0]);
+    assertEquals((short) 2, shorts[1]);
+    assertEquals((short) 3, shorts[2]);
+  }
+
+  @Test
+  void testGetArrayValueForBytes_UInt16() throws UaException {
+    // Create a byte array for 3 ushort values: 1, 2, 3 (big endian)
+    byte[] bytes = new byte[] {0, 1, 0, 2, 0, 3};
+    int[] dimensions = new int[] {3};
+
+    Object result =
+        ModbusByteUtil.getArrayValueForBytes(
+            bytes, new ModbusDataType.UInt16(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a UShort array with the expected values
+    assertEquals(UShort[].class, result.getClass());
+    UShort[] ushorts = (UShort[]) result;
+    assertEquals(3, ushorts.length);
+    assertEquals(UShort.valueOf(1), ushorts[0]);
+    assertEquals(UShort.valueOf(2), ushorts[1]);
+    assertEquals(UShort.valueOf(3), ushorts[2]);
+  }
+
+  @Test
+  void testGetArrayValueForBytes_Int32() throws UaException {
+    // Create a byte array for 3 int values: 1, 2, 3 (big endian)
+    byte[] bytes = new byte[] {0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3};
+    int[] dimensions = new int[] {3};
+
+    Object result =
+        ModbusByteUtil.getArrayValueForBytes(
+            bytes, new ModbusDataType.Int32(), NO_MODIFIERS, dimensions);
+
+    // Verify result is an Integer array with the expected values
+    assertEquals(Integer[].class, result.getClass());
+    Integer[] integers = (Integer[]) result;
+    assertEquals(3, integers.length);
+    assertEquals(1, integers[0]);
+    assertEquals(2, integers[1]);
+    assertEquals(3, integers[2]);
+  }
+
+  @Test
+  void testGetArrayValueForBytes_UInt32() throws UaException {
+    // Create a byte array for 3 uint values: 1, 2, 3 (big endian)
+    byte[] bytes = new byte[] {0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3};
+    int[] dimensions = new int[] {3};
+
+    Object result =
+        ModbusByteUtil.getArrayValueForBytes(
+            bytes, new ModbusDataType.UInt32(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a UInteger array with the expected values
+    assertEquals(UInteger[].class, result.getClass());
+    UInteger[] uintegers = (UInteger[]) result;
+    assertEquals(3, uintegers.length);
+    assertEquals(UInteger.valueOf(1), uintegers[0]);
+    assertEquals(UInteger.valueOf(2), uintegers[1]);
+    assertEquals(UInteger.valueOf(3), uintegers[2]);
+  }
+
+  @Test
+  void testGetArrayValueForBytes_Int64() throws UaException {
+    // Create a byte array for 3 long values: 1, 2, 3 (big endian)
+    byte[] bytes =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 0, 1,
+          0, 0, 0, 0, 0, 0, 0, 2,
+          0, 0, 0, 0, 0, 0, 0, 3
+        };
+    int[] dimensions = new int[] {3};
+
+    Object result =
+        ModbusByteUtil.getArrayValueForBytes(
+            bytes, new ModbusDataType.Int64(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Long array with the expected values
+    assertEquals(Long[].class, result.getClass());
+    Long[] longs = (Long[]) result;
+    assertEquals(3, longs.length);
+    assertEquals(1L, longs[0]);
+    assertEquals(2L, longs[1]);
+    assertEquals(3L, longs[2]);
+  }
+
+  @Test
+  void testGetArrayValueForBytes_UInt64() throws UaException {
+    // Create a byte array for 3 ulong values: 1, 2, 3 (big endian)
+    byte[] bytes =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 0, 1,
+          0, 0, 0, 0, 0, 0, 0, 2,
+          0, 0, 0, 0, 0, 0, 0, 3
+        };
+    int[] dimensions = new int[] {3};
+
+    Object result =
+        ModbusByteUtil.getArrayValueForBytes(
+            bytes, new ModbusDataType.UInt64(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a ULong array with the expected values
+    assertEquals(ULong[].class, result.getClass());
+    ULong[] ulongs = (ULong[]) result;
+    assertEquals(3, ulongs.length);
+    assertEquals(ULong.valueOf(1), ulongs[0]);
+    assertEquals(ULong.valueOf(2), ulongs[1]);
+    assertEquals(ULong.valueOf(3), ulongs[2]);
+  }
+
+  @Test
+  void testGetArrayValueForBytes_Float32() throws UaException {
+    // Create a byte array for 3 float values: 1.0, 2.5, 3.75 (big endian)
+    // IEEE 754 representation of these values
+    byte[] bytes =
+        new byte[] {
+          0x3F, (byte) 0x80, 0x00, 0x00, // 1.0
+          0x40, 0x20, 0x00, 0x00, // 2.5
+          0x40, 0x70, 0x00, 0x00 // 3.75
+        };
+    int[] dimensions = new int[] {3};
+
+    Object result =
+        ModbusByteUtil.getArrayValueForBytes(
+            bytes, new ModbusDataType.Float32(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Float array with the expected values
+    assertEquals(Float[].class, result.getClass());
+    Float[] floats = (Float[]) result;
+    assertEquals(3, floats.length);
+    assertEquals(1.0f, floats[0]);
+    assertEquals(2.5f, floats[1]);
+    assertEquals(3.75f, floats[2]);
+  }
+
+  @Test
+  void testGetArrayValueForBytes_Double64() throws UaException {
+    // Create a byte array for 3 double values: 1.0, 2.5, 3.75 (big endian)
+    // IEEE 754 representation of these values
+    byte[] bytes =
+        new byte[] {
+          0x3F, (byte) 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 1.0
+          0x40, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 2.5
+          0x40, 0x0E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 // 3.75
+        };
+    int[] dimensions = new int[] {3};
+
+    Object result =
+        ModbusByteUtil.getArrayValueForBytes(
+            bytes, new ModbusDataType.Double64(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Double array with the expected values
+    assertEquals(Double[].class, result.getClass());
+    Double[] doubles = (Double[]) result;
+    assertEquals(3, doubles.length);
+    assertEquals(1.0, doubles[0]);
+    assertEquals(2.5, doubles[1]);
+    assertEquals(3.75, doubles[2]);
+  }
+
+  @Test
+  void testGetArrayValueForBytes_String() throws UaException {
+    // Create a byte array for 3 string values: "abc", "def", "ghi" with 4 bytes each
+    byte[] bytes =
+        new byte[] {
+          'a', 'b', 'c', 0, // "abc" with null terminator
+          'd', 'e', 'f', 0, // "def" with null terminator
+          'g', 'h', 'i', 0 // "ghi" with null terminator
+        };
+    int[] dimensions = new int[] {3};
+
+    Object result =
+        ModbusByteUtil.getArrayValueForBytes(
+            bytes, new ModbusDataType.String(4), NO_MODIFIERS, dimensions);
+
+    // Verify result is a String array with the expected values
+    assertEquals(String[].class, result.getClass());
+    String[] strings = (String[]) result;
+    assertEquals(3, strings.length);
+    assertEquals("abc", strings[0]);
+    assertEquals("def", strings[1]);
+    assertEquals("ghi", strings[2]);
+  }
+
+  @Test
+  void testGetArrayValueForBytes_InsufficientData() {
+    // Create a byte array that's too short for the requested dimensions
+    byte[] bytes = new byte[] {0, 1, 0, 2}; // Only enough for 2 Int16 values
+    int[] dimensions = new int[] {3}; // But we're asking for 3
+
+    // Verify that an exception is thrown with the expected status code
+    UaException exception =
+        assertThrows(
+            UaException.class,
+            () ->
+                ModbusByteUtil.getArrayValueForBytes(
+                    bytes, new ModbusDataType.Int16(), NO_MODIFIERS, dimensions));
+
+    assertEquals(StatusCodes.Bad_InternalError, exception.getStatusCode().getValue());
+  }
+
+  @Test
+  void testGetArrayValueForBytes_InvalidDimensions() {
+    byte[] bytes = new byte[] {0, 1, 0, 2, 0, 3};
+    int[] dimensions = new int[] {2, 3}; // 2D array, not supported
+
+    // Verify that an exception is thrown with the expected status code
+    UaException exception =
+        assertThrows(
+            UaException.class,
+            () ->
+                ModbusByteUtil.getArrayValueForBytes(
+                    bytes, new ModbusDataType.Int16(), NO_MODIFIERS, dimensions));
+
+    assertEquals(StatusCodes.Bad_TypeMismatch, exception.getStatusCode().getValue());
+  }
+
+  @Test
   void testGetBytesForArrayValue_Bool() throws UaException {
     Boolean[] booleans = new Boolean[] {true, false, true};
     int[] dimensions = new int[] {booleans.length};

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/util/ModbusByteUtilTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/util/ModbusByteUtilTest.java
@@ -326,6 +326,21 @@ class ModbusByteUtilTest {
   }
 
   @Test
+  void testGetBytesForArrayValue_ShorterThanDeclaredDimension() {
+    UaException exception =
+        assertThrows(
+            UaException.class,
+            () ->
+                ModbusByteUtil.getBytesForArrayValue(
+                    new Short[] {1, 2},
+                    new ModbusDataType.Int16(),
+                    NO_MODIFIERS,
+                    new int[] {3}));
+
+    assertEquals(StatusCodes.Bad_TypeMismatch, exception.getStatusCode().getValue());
+  }
+
+  @Test
   void testGetBytesForArrayValue_UInt16() throws UaException {
     UShort[] ushorts = new UShort[] {UShort.valueOf(1), UShort.valueOf(2), UShort.valueOf(3)};
     int[] dimensions = new int[] {ushorts.length};

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/util/ModbusByteUtilTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/util/ModbusByteUtilTest.java
@@ -42,11 +42,14 @@ class ModbusByteUtilTest {
     System.arraycopy(bytes, 4, chunk3, 0, 2);
 
     assertEquals(
-        true, ModbusByteUtil.getValueForBytes(chunk1, new ModbusDataType.Bool(), NO_MODIFIERS));
+        true,
+        ModbusByteUtil.getScalarValueForBytes(chunk1, new ModbusDataType.Bool(), NO_MODIFIERS));
     assertEquals(
-        false, ModbusByteUtil.getValueForBytes(chunk2, new ModbusDataType.Bool(), NO_MODIFIERS));
+        false,
+        ModbusByteUtil.getScalarValueForBytes(chunk2, new ModbusDataType.Bool(), NO_MODIFIERS));
     assertEquals(
-        true, ModbusByteUtil.getValueForBytes(chunk3, new ModbusDataType.Bool(), NO_MODIFIERS));
+        true,
+        ModbusByteUtil.getScalarValueForBytes(chunk3, new ModbusDataType.Bool(), NO_MODIFIERS));
   }
 
   @Test
@@ -144,13 +147,13 @@ class ModbusByteUtilTest {
 
     assertEquals(
         UInteger.valueOf(1),
-        ModbusByteUtil.getValueForBytes(chunk1, new ModbusDataType.UInt32(), NO_MODIFIERS));
+        ModbusByteUtil.getScalarValueForBytes(chunk1, new ModbusDataType.UInt32(), NO_MODIFIERS));
     assertEquals(
         UInteger.valueOf(2),
-        ModbusByteUtil.getValueForBytes(chunk2, new ModbusDataType.UInt32(), NO_MODIFIERS));
+        ModbusByteUtil.getScalarValueForBytes(chunk2, new ModbusDataType.UInt32(), NO_MODIFIERS));
     assertEquals(
         UInteger.valueOf(3),
-        ModbusByteUtil.getValueForBytes(chunk3, new ModbusDataType.UInt32(), NO_MODIFIERS));
+        ModbusByteUtil.getScalarValueForBytes(chunk3, new ModbusDataType.UInt32(), NO_MODIFIERS));
   }
 
   @Test
@@ -176,13 +179,19 @@ class ModbusByteUtilTest {
 
     assertEquals(
         1L,
-        (Long) ModbusByteUtil.getValueForBytes(chunk1, new ModbusDataType.Int64(), NO_MODIFIERS));
+        (Long)
+            ModbusByteUtil.getScalarValueForBytes(
+                chunk1, new ModbusDataType.Int64(), NO_MODIFIERS));
     assertEquals(
         2L,
-        (Long) ModbusByteUtil.getValueForBytes(chunk2, new ModbusDataType.Int64(), NO_MODIFIERS));
+        (Long)
+            ModbusByteUtil.getScalarValueForBytes(
+                chunk2, new ModbusDataType.Int64(), NO_MODIFIERS));
     assertEquals(
         3L,
-        (Long) ModbusByteUtil.getValueForBytes(chunk3, new ModbusDataType.Int64(), NO_MODIFIERS));
+        (Long)
+            ModbusByteUtil.getScalarValueForBytes(
+                chunk3, new ModbusDataType.Int64(), NO_MODIFIERS));
   }
 
   @Test
@@ -208,13 +217,13 @@ class ModbusByteUtilTest {
 
     assertEquals(
         ULong.valueOf(1),
-        ModbusByteUtil.getValueForBytes(chunk1, new ModbusDataType.UInt64(), NO_MODIFIERS));
+        ModbusByteUtil.getScalarValueForBytes(chunk1, new ModbusDataType.UInt64(), NO_MODIFIERS));
     assertEquals(
         ULong.valueOf(2),
-        ModbusByteUtil.getValueForBytes(chunk2, new ModbusDataType.UInt64(), NO_MODIFIERS));
+        ModbusByteUtil.getScalarValueForBytes(chunk2, new ModbusDataType.UInt64(), NO_MODIFIERS));
     assertEquals(
         ULong.valueOf(3),
-        ModbusByteUtil.getValueForBytes(chunk3, new ModbusDataType.UInt64(), NO_MODIFIERS));
+        ModbusByteUtil.getScalarValueForBytes(chunk3, new ModbusDataType.UInt64(), NO_MODIFIERS));
   }
 
   @Test
@@ -241,15 +250,18 @@ class ModbusByteUtilTest {
     assertEquals(
         1.0f,
         (Float)
-            ModbusByteUtil.getValueForBytes(chunk1, new ModbusDataType.Float32(), NO_MODIFIERS));
+            ModbusByteUtil.getScalarValueForBytes(
+                chunk1, new ModbusDataType.Float32(), NO_MODIFIERS));
     assertEquals(
         2.5f,
         (Float)
-            ModbusByteUtil.getValueForBytes(chunk2, new ModbusDataType.Float32(), NO_MODIFIERS));
+            ModbusByteUtil.getScalarValueForBytes(
+                chunk2, new ModbusDataType.Float32(), NO_MODIFIERS));
     assertEquals(
         3.75f,
         (Float)
-            ModbusByteUtil.getValueForBytes(chunk3, new ModbusDataType.Float32(), NO_MODIFIERS));
+            ModbusByteUtil.getScalarValueForBytes(
+                chunk3, new ModbusDataType.Float32(), NO_MODIFIERS));
   }
 
   @Test
@@ -276,15 +288,18 @@ class ModbusByteUtilTest {
     assertEquals(
         1.0,
         (Double)
-            ModbusByteUtil.getValueForBytes(chunk1, new ModbusDataType.Double64(), NO_MODIFIERS));
+            ModbusByteUtil.getScalarValueForBytes(
+                chunk1, new ModbusDataType.Double64(), NO_MODIFIERS));
     assertEquals(
         2.5,
         (Double)
-            ModbusByteUtil.getValueForBytes(chunk2, new ModbusDataType.Double64(), NO_MODIFIERS));
+            ModbusByteUtil.getScalarValueForBytes(
+                chunk2, new ModbusDataType.Double64(), NO_MODIFIERS));
     assertEquals(
         3.75,
         (Double)
-            ModbusByteUtil.getValueForBytes(chunk3, new ModbusDataType.Double64(), NO_MODIFIERS));
+            ModbusByteUtil.getScalarValueForBytes(
+                chunk3, new ModbusDataType.Double64(), NO_MODIFIERS));
   }
 
   @Test
@@ -347,13 +362,17 @@ class ModbusByteUtilTest {
     System.arraycopy(bytes, 6, chunk4, 0, 2);
 
     assertEquals(
-        true, ModbusByteUtil.getValueForBytes(chunk1, new ModbusDataType.Bool(), NO_MODIFIERS));
+        true,
+        ModbusByteUtil.getScalarValueForBytes(chunk1, new ModbusDataType.Bool(), NO_MODIFIERS));
     assertEquals(
-        false, ModbusByteUtil.getValueForBytes(chunk2, new ModbusDataType.Bool(), NO_MODIFIERS));
+        false,
+        ModbusByteUtil.getScalarValueForBytes(chunk2, new ModbusDataType.Bool(), NO_MODIFIERS));
     assertEquals(
-        false, ModbusByteUtil.getValueForBytes(chunk3, new ModbusDataType.Bool(), NO_MODIFIERS));
+        false,
+        ModbusByteUtil.getScalarValueForBytes(chunk3, new ModbusDataType.Bool(), NO_MODIFIERS));
     assertEquals(
-        true, ModbusByteUtil.getValueForBytes(chunk4, new ModbusDataType.Bool(), NO_MODIFIERS));
+        true,
+        ModbusByteUtil.getScalarValueForBytes(chunk4, new ModbusDataType.Bool(), NO_MODIFIERS));
   }
 
   @Test
@@ -429,7 +448,8 @@ class ModbusByteUtilTest {
       int expectedValue = integers[i];
       int actualValue =
           (Integer)
-              ModbusByteUtil.getValueForBytes(chunk, new ModbusDataType.Int32(), NO_MODIFIERS);
+              ModbusByteUtil.getScalarValueForBytes(
+                  chunk, new ModbusDataType.Int32(), NO_MODIFIERS);
 
       assertEquals(expectedValue, actualValue);
     }
@@ -461,7 +481,8 @@ class ModbusByteUtilTest {
       UInteger expectedValue = uintegers[i];
       UInteger actualValue =
           (UInteger)
-              ModbusByteUtil.getValueForBytes(chunk, new ModbusDataType.UInt32(), NO_MODIFIERS);
+              ModbusByteUtil.getScalarValueForBytes(
+                  chunk, new ModbusDataType.UInt32(), NO_MODIFIERS);
 
       assertEquals(expectedValue, actualValue);
     }
@@ -488,7 +509,9 @@ class ModbusByteUtilTest {
 
       Long expectedValue = longs[i];
       Long actualValue =
-          (Long) ModbusByteUtil.getValueForBytes(chunk, new ModbusDataType.Int64(), NO_MODIFIERS);
+          (Long)
+              ModbusByteUtil.getScalarValueForBytes(
+                  chunk, new ModbusDataType.Int64(), NO_MODIFIERS);
 
       assertEquals(expectedValue, actualValue);
     }
@@ -519,7 +542,9 @@ class ModbusByteUtilTest {
 
       ULong expectedValue = ulongs[i];
       ULong actualValue =
-          (ULong) ModbusByteUtil.getValueForBytes(chunk, new ModbusDataType.UInt64(), NO_MODIFIERS);
+          (ULong)
+              ModbusByteUtil.getScalarValueForBytes(
+                  chunk, new ModbusDataType.UInt64(), NO_MODIFIERS);
 
       assertEquals(expectedValue, actualValue);
     }
@@ -547,7 +572,8 @@ class ModbusByteUtilTest {
       float expectedValue = floats[i];
       float actualValue =
           (Float)
-              ModbusByteUtil.getValueForBytes(chunk, new ModbusDataType.Float32(), NO_MODIFIERS);
+              ModbusByteUtil.getScalarValueForBytes(
+                  chunk, new ModbusDataType.Float32(), NO_MODIFIERS);
 
       assertEquals(expectedValue, actualValue);
     }
@@ -575,7 +601,8 @@ class ModbusByteUtilTest {
       Double expectedValue = doubles[i];
       Double actualValue =
           (Double)
-              ModbusByteUtil.getValueForBytes(chunk, new ModbusDataType.Double64(), NO_MODIFIERS);
+              ModbusByteUtil.getScalarValueForBytes(
+                  chunk, new ModbusDataType.Double64(), NO_MODIFIERS);
 
       assertEquals(expectedValue, actualValue);
     }

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/util/ModbusByteUtilTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/util/ModbusByteUtilTest.java
@@ -1,0 +1,320 @@
+package com.kevinherron.ignition.modbus.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.kevinherron.ignition.modbus.address.DataTypeModifier;
+import com.kevinherron.ignition.modbus.address.ModbusDataType;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Set;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.junit.jupiter.api.Test;
+
+class ModbusByteUtilTest {
+
+  private static final Set<DataTypeModifier> NO_MODIFIERS = Collections.emptySet();
+
+  @Test
+  void testGetBytesForArrayValue_Bool() throws UaException {
+    Boolean[] booleans = new Boolean[]{true, false, true};
+    int[] dimensions = new int[]{booleans.length};
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForArrayValue(
+            booleans, new ModbusDataType.Bool(), NO_MODIFIERS, dimensions);
+
+    // Each Bool takes 2 bytes, so the total should be 6 bytes
+    assertEquals(6, bytes.length);
+
+    // Extract 2-byte chunks and convert back to verify
+    byte[] chunk1 = new byte[2];
+    byte[] chunk2 = new byte[2];
+    byte[] chunk3 = new byte[2];
+
+    System.arraycopy(bytes, 0, chunk1, 0, 2);
+    System.arraycopy(bytes, 2, chunk2, 0, 2);
+    System.arraycopy(bytes, 4, chunk3, 0, 2);
+
+    assertEquals(
+        true, ModbusByteUtil.getValueForBytes(chunk1, new ModbusDataType.Bool(), NO_MODIFIERS));
+    assertEquals(
+        false, ModbusByteUtil.getValueForBytes(chunk2, new ModbusDataType.Bool(), NO_MODIFIERS));
+    assertEquals(
+        true, ModbusByteUtil.getValueForBytes(chunk3, new ModbusDataType.Bool(), NO_MODIFIERS));
+  }
+
+  @Test
+  void testGetBytesForArrayValue_Int16() throws UaException {
+    Short[] shorts = new Short[]{(short) 1, (short) 2, (short) 3};
+    int[] dimensions = new int[]{shorts.length};
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForArrayValue(
+            shorts, new ModbusDataType.Int16(), NO_MODIFIERS, dimensions);
+
+    // Each Int16 takes 2 bytes, so the total should be 6 bytes
+    assertEquals(6, bytes.length);
+
+    // Verify the content (big endian by default)
+    assertEquals(0, bytes[0]); // high byte of 1
+    assertEquals(1, bytes[1]); // low byte of 1
+    assertEquals(0, bytes[2]); // high byte of 2
+    assertEquals(2, bytes[3]); // low byte of 2
+    assertEquals(0, bytes[4]); // high byte of 3
+    assertEquals(3, bytes[5]); // low byte of 3
+  }
+
+  @Test
+  void testGetBytesForArrayValue_UInt16() throws UaException {
+    UShort[] ushorts = new UShort[]{UShort.valueOf(1), UShort.valueOf(2), UShort.valueOf(3)};
+    int[] dimensions = new int[]{ushorts.length};
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForArrayValue(
+            ushorts, new ModbusDataType.UInt16(), NO_MODIFIERS, dimensions);
+
+    // Each UInt16 takes 2 bytes, so the total should be 6 bytes
+    assertEquals(6, bytes.length);
+
+    // Verify the content (big endian by default)
+    assertEquals(0, bytes[0]); // high byte of 1
+    assertEquals(1, bytes[1]); // low byte of 1
+    assertEquals(0, bytes[2]); // high byte of 2
+    assertEquals(2, bytes[3]); // low byte of 2
+    assertEquals(0, bytes[4]); // high byte of 3
+    assertEquals(3, bytes[5]); // low byte of 3
+  }
+
+  @Test
+  void testGetBytesForArrayValue_Int32() throws UaException {
+    Integer[] ints = new Integer[]{1, 2, 3};
+    int[] dimensions = new int[]{ints.length};
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForArrayValue(
+            ints, new ModbusDataType.Int32(), NO_MODIFIERS, dimensions);
+
+    // Each Int32 takes 4 bytes, so the total should be 12 bytes
+    assertEquals(12, bytes.length);
+
+    // Verify the content (big endian by default)
+    assertEquals(0, bytes[0]); // highest byte of 1
+    assertEquals(0, bytes[1]);
+    assertEquals(0, bytes[2]);
+    assertEquals(1, bytes[3]); // lowest byte of 1
+
+    assertEquals(0, bytes[4]); // highest byte of 2
+    assertEquals(0, bytes[5]);
+    assertEquals(0, bytes[6]);
+    assertEquals(2, bytes[7]); // lowest byte of 2
+
+    assertEquals(0, bytes[8]); // highest byte of 3
+    assertEquals(0, bytes[9]);
+    assertEquals(0, bytes[10]);
+    assertEquals(3, bytes[11]); // lowest byte of 3
+  }
+
+  @Test
+  void testGetBytesForArrayValue_UInt32() throws UaException {
+    UInteger[] uints =
+        new UInteger[]{UInteger.valueOf(1), UInteger.valueOf(2), UInteger.valueOf(3)};
+    int[] dimensions = new int[]{uints.length};
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForArrayValue(
+            uints, new ModbusDataType.UInt32(), NO_MODIFIERS, dimensions);
+
+    // Each UInt32 takes 4 bytes, so the total should be 12 bytes
+    assertEquals(12, bytes.length);
+
+    // Extract 4-byte chunks and convert back to verify
+    byte[] chunk1 = new byte[4];
+    byte[] chunk2 = new byte[4];
+    byte[] chunk3 = new byte[4];
+
+    System.arraycopy(bytes, 0, chunk1, 0, 4);
+    System.arraycopy(bytes, 4, chunk2, 0, 4);
+    System.arraycopy(bytes, 8, chunk3, 0, 4);
+
+    assertEquals(
+        UInteger.valueOf(1),
+        ModbusByteUtil.getValueForBytes(chunk1, new ModbusDataType.UInt32(), NO_MODIFIERS));
+    assertEquals(
+        UInteger.valueOf(2),
+        ModbusByteUtil.getValueForBytes(chunk2, new ModbusDataType.UInt32(), NO_MODIFIERS));
+    assertEquals(
+        UInteger.valueOf(3),
+        ModbusByteUtil.getValueForBytes(chunk3, new ModbusDataType.UInt32(), NO_MODIFIERS));
+  }
+
+  @Test
+  void testGetBytesForArrayValue_Int64() throws UaException {
+    Long[] longs = new Long[]{1L, 2L, 3L};
+    int[] dimensions = new int[]{longs.length};
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForArrayValue(
+            longs, new ModbusDataType.Int64(), NO_MODIFIERS, dimensions);
+
+    // Each Int64 takes 8 bytes, so the total should be 24 bytes
+    assertEquals(24, bytes.length);
+
+    // Extract 8-byte chunks and convert back to verify
+    byte[] chunk1 = new byte[8];
+    byte[] chunk2 = new byte[8];
+    byte[] chunk3 = new byte[8];
+
+    System.arraycopy(bytes, 0, chunk1, 0, 8);
+    System.arraycopy(bytes, 8, chunk2, 0, 8);
+    System.arraycopy(bytes, 16, chunk3, 0, 8);
+
+    assertEquals(
+        1L,
+        (Long) ModbusByteUtil.getValueForBytes(chunk1, new ModbusDataType.Int64(), NO_MODIFIERS));
+    assertEquals(
+        2L,
+        (Long) ModbusByteUtil.getValueForBytes(chunk2, new ModbusDataType.Int64(), NO_MODIFIERS));
+    assertEquals(
+        3L,
+        (Long) ModbusByteUtil.getValueForBytes(chunk3, new ModbusDataType.Int64(), NO_MODIFIERS));
+  }
+
+  @Test
+  void testGetBytesForArrayValue_UInt64() throws UaException {
+    ULong[] ulongs = new ULong[]{ULong.valueOf(1), ULong.valueOf(2), ULong.valueOf(3)};
+    int[] dimensions = new int[]{ulongs.length};
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForArrayValue(
+            ulongs, new ModbusDataType.UInt64(), NO_MODIFIERS, dimensions);
+
+    // Each UInt64 takes 8 bytes, so the total should be 24 bytes
+    assertEquals(24, bytes.length);
+
+    // Extract 8-byte chunks and convert back to verify
+    byte[] chunk1 = new byte[8];
+    byte[] chunk2 = new byte[8];
+    byte[] chunk3 = new byte[8];
+
+    System.arraycopy(bytes, 0, chunk1, 0, 8);
+    System.arraycopy(bytes, 8, chunk2, 0, 8);
+    System.arraycopy(bytes, 16, chunk3, 0, 8);
+
+    assertEquals(
+        ULong.valueOf(1),
+        ModbusByteUtil.getValueForBytes(chunk1, new ModbusDataType.UInt64(), NO_MODIFIERS));
+    assertEquals(
+        ULong.valueOf(2),
+        ModbusByteUtil.getValueForBytes(chunk2, new ModbusDataType.UInt64(), NO_MODIFIERS));
+    assertEquals(
+        ULong.valueOf(3),
+        ModbusByteUtil.getValueForBytes(chunk3, new ModbusDataType.UInt64(), NO_MODIFIERS));
+  }
+
+  @Test
+  void testGetBytesForArrayValue_Float32() throws UaException {
+    Float[] floats = new Float[]{1.0f, 2.5f, 3.75f};
+    int[] dimensions = new int[]{floats.length};
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForArrayValue(
+            floats, new ModbusDataType.Float32(), NO_MODIFIERS, dimensions);
+
+    // Each Float32 takes 4 bytes, so the total should be 12 bytes
+    assertEquals(12, bytes.length);
+
+    // Extract 4-byte chunks and convert back to verify
+    byte[] chunk1 = new byte[4];
+    byte[] chunk2 = new byte[4];
+    byte[] chunk3 = new byte[4];
+
+    System.arraycopy(bytes, 0, chunk1, 0, 4);
+    System.arraycopy(bytes, 4, chunk2, 0, 4);
+    System.arraycopy(bytes, 8, chunk3, 0, 4);
+
+    assertEquals(
+        1.0f,
+        (Float)
+            ModbusByteUtil.getValueForBytes(chunk1, new ModbusDataType.Float32(), NO_MODIFIERS));
+    assertEquals(
+        2.5f,
+        (Float)
+            ModbusByteUtil.getValueForBytes(chunk2, new ModbusDataType.Float32(), NO_MODIFIERS));
+    assertEquals(
+        3.75f,
+        (Float)
+            ModbusByteUtil.getValueForBytes(chunk3, new ModbusDataType.Float32(), NO_MODIFIERS));
+  }
+
+  @Test
+  void testGetBytesForArrayValue_Double64() throws UaException {
+    Double[] doubles = new Double[]{1.0, 2.5, 3.75};
+    int[] dimensions = new int[]{doubles.length};
+
+    byte[] bytes =
+        ModbusByteUtil.getBytesForArrayValue(
+            doubles, new ModbusDataType.Double64(), NO_MODIFIERS, dimensions);
+
+    // Each Double64 takes 8 bytes, so the total should be 24 bytes
+    assertEquals(24, bytes.length);
+
+    // Extract 8-byte chunks and convert back to verify
+    byte[] chunk1 = new byte[8];
+    byte[] chunk2 = new byte[8];
+    byte[] chunk3 = new byte[8];
+
+    System.arraycopy(bytes, 0, chunk1, 0, 8);
+    System.arraycopy(bytes, 8, chunk2, 0, 8);
+    System.arraycopy(bytes, 16, chunk3, 0, 8);
+
+    assertEquals(
+        1.0,
+        (Double)
+            ModbusByteUtil.getValueForBytes(chunk1, new ModbusDataType.Double64(), NO_MODIFIERS));
+    assertEquals(
+        2.5,
+        (Double)
+            ModbusByteUtil.getValueForBytes(chunk2, new ModbusDataType.Double64(), NO_MODIFIERS));
+    assertEquals(
+        3.75,
+        (Double)
+            ModbusByteUtil.getValueForBytes(chunk3, new ModbusDataType.Double64(), NO_MODIFIERS));
+  }
+
+  @Test
+  void testGetBytesForArrayValue_String() throws UaException {
+    String[] strings = new String[]{"abc", "def", "ghi"};
+    int[] dimensions = new int[]{strings.length};
+
+    // Create a String data type with length 4 (which means 2 registers or 4 bytes per string)
+    byte[] bytes =
+        ModbusByteUtil.getBytesForArrayValue(
+            strings, new ModbusDataType.String(4), NO_MODIFIERS, dimensions);
+
+    // Each String takes 4 bytes, so the total should be 12 bytes
+    assertEquals(12, bytes.length);
+
+    // Verify the content
+    byte[] abc = "abc".getBytes(StandardCharsets.UTF_8);
+    byte[] def = "def".getBytes(StandardCharsets.UTF_8);
+    byte[] ghi = "ghi".getBytes(StandardCharsets.UTF_8);
+
+    for (int i = 0; i < abc.length; i++) {
+      assertEquals(abc[i], bytes[i]);
+    }
+    assertEquals(0, bytes[3]); // Padding
+
+    for (int i = 0; i < def.length; i++) {
+      assertEquals(def[i], bytes[4 + i]);
+    }
+    assertEquals(0, bytes[7]); // Padding
+
+    for (int i = 0; i < ghi.length; i++) {
+      assertEquals(ghi[i], bytes[8 + i]);
+    }
+    assertEquals(0, bytes[11]); // Padding
+  }
+}

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/util/ModbusByteUtilTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/util/ModbusByteUtilTest.java
@@ -1,6 +1,8 @@
 package com.kevinherron.ignition.modbus.util;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.kevinherron.ignition.modbus.address.DataTypeModifier;
@@ -958,5 +960,436 @@ class ModbusByteUtilTest {
                     booleans, new ModbusDataType.Bool(), NO_MODIFIERS, dimensions));
 
     assertEquals(StatusCodes.Bad_TypeMismatch, exception.getStatusCode().getValue());
+  }
+
+  @Test
+  void testGetMatrixValueForBytes_Bool_2D() throws UaException {
+    // Create register bytes for a 2x2 matrix of Boolean values
+    // [true, false, false, true]
+    // Each Bool takes 2 bytes (1 register)
+    byte[] registerBytes = new byte[] {1, 0, 0, 0, 0, 0, 1, 0};
+    int[] dimensions = new int[] {2, 2};
+
+    // Get matrix value
+    Object result =
+        ModbusByteUtil.getMatrixValueForBytes(
+            registerBytes, new ModbusDataType.Bool(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Matrix
+    assertInstanceOf(Matrix.class, result);
+    Matrix matrix = (Matrix) result;
+
+    // Verify dimensions
+    assertArrayEquals(dimensions, matrix.getDimensions());
+
+    // Verify contents
+    Object array = matrix.getElements();
+    assertInstanceOf(Boolean[].class, array);
+    Boolean[] booleans = (Boolean[]) array;
+
+    assertEquals(4, booleans.length);
+    assertEquals(true, booleans[0]);
+    assertEquals(false, booleans[1]);
+    assertEquals(false, booleans[2]);
+    assertEquals(true, booleans[3]);
+  }
+
+  @Test
+  void testGetMatrixValueForBytes_Int16_3D() throws UaException {
+    // Create register bytes for a 2x2x2 matrix of Int16 values
+    // Each Int16 takes 2 bytes
+    byte[] registerBytes =
+        new byte[] {
+          0, 1, // 1
+          0, 2, // 2
+          0, 3, // 3
+          0, 4, // 4
+          0, 5, // 5
+          0, 6, // 6
+          0, 7, // 7
+          0, 8 // 8
+        };
+    int[] dimensions = new int[] {2, 2, 2};
+
+    // Get matrix value
+    Object result =
+        ModbusByteUtil.getMatrixValueForBytes(
+            registerBytes, new ModbusDataType.Int16(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Matrix
+    assertInstanceOf(Matrix.class, result);
+    Matrix matrix = (Matrix) result;
+
+    // Verify dimensions
+    assertArrayEquals(dimensions, matrix.getDimensions());
+
+    // Verify contents
+    Object array = matrix.getElements();
+    assertInstanceOf(Short[].class, array);
+    Short[] shorts = (Short[]) array;
+
+    assertEquals(8, shorts.length);
+    for (int i = 0; i < 8; i++) {
+      assertEquals((short) (i + 1), shorts[i]);
+    }
+  }
+
+  @Test
+  void testGetMatrixValueForBytes_UInt16_2D() throws UaException {
+    // Create register bytes for a 2x2 matrix of UInt16 values
+    // [1, 2, 3, 4]
+    // Each UInt16 takes 2 bytes
+    byte[] registerBytes =
+        new byte[] {
+          0, 1, // 1
+          0, 2, // 2
+          0, 3, // 3
+          0, 4 // 4
+        };
+    int[] dimensions = new int[] {2, 2};
+
+    // Get matrix value
+    Object result =
+        ModbusByteUtil.getMatrixValueForBytes(
+            registerBytes, new ModbusDataType.UInt16(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Matrix
+    assertInstanceOf(Matrix.class, result);
+    Matrix matrix = (Matrix) result;
+
+    // Verify dimensions
+    assertArrayEquals(dimensions, matrix.getDimensions());
+
+    // Verify contents
+    Object array = matrix.getElements();
+    assertInstanceOf(UShort[].class, array);
+    UShort[] ushorts = (UShort[]) array;
+
+    assertEquals(4, ushorts.length);
+    assertEquals(UShort.valueOf(1), ushorts[0]);
+    assertEquals(UShort.valueOf(2), ushorts[1]);
+    assertEquals(UShort.valueOf(3), ushorts[2]);
+    assertEquals(UShort.valueOf(4), ushorts[3]);
+  }
+
+  @Test
+  void testGetMatrixValueForBytes_Int32_2D() throws UaException {
+    // Create register bytes for a 2x2 matrix of Int32 values
+    // [1, 2, 3, 4]
+    // Each Int32 takes 4 bytes
+    byte[] registerBytes =
+        new byte[] {
+          0, 0, 0, 1, // 1
+          0, 0, 0, 2, // 2
+          0, 0, 0, 3, // 3
+          0, 0, 0, 4 // 4
+        };
+    int[] dimensions = new int[] {2, 2};
+
+    // Get matrix value
+    Object result =
+        ModbusByteUtil.getMatrixValueForBytes(
+            registerBytes, new ModbusDataType.Int32(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Matrix
+    assertInstanceOf(Matrix.class, result);
+    Matrix matrix = (Matrix) result;
+
+    // Verify dimensions
+    assertArrayEquals(dimensions, matrix.getDimensions());
+
+    // Verify contents
+    Object array = matrix.getElements();
+    assertInstanceOf(Integer[].class, array);
+    Integer[] integers = (Integer[]) array;
+
+    assertEquals(4, integers.length);
+    assertEquals(1, integers[0]);
+    assertEquals(2, integers[1]);
+    assertEquals(3, integers[2]);
+    assertEquals(4, integers[3]);
+  }
+
+  @Test
+  void testGetMatrixValueForBytes_UInt32_2D() throws UaException {
+    // Create register bytes for a 2x2 matrix of UInt32 values
+    // [1, 2, 3, 4]
+    // Each UInt32 takes 4 bytes
+    byte[] registerBytes =
+        new byte[] {
+          0, 0, 0, 1, // 1
+          0, 0, 0, 2, // 2
+          0, 0, 0, 3, // 3
+          0, 0, 0, 4 // 4
+        };
+    int[] dimensions = new int[] {2, 2};
+
+    // Get matrix value
+    Object result =
+        ModbusByteUtil.getMatrixValueForBytes(
+            registerBytes, new ModbusDataType.UInt32(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Matrix
+    assertInstanceOf(Matrix.class, result);
+    Matrix matrix = (Matrix) result;
+
+    // Verify dimensions
+    assertArrayEquals(dimensions, matrix.getDimensions());
+
+    // Verify contents
+    Object array = matrix.getElements();
+    assertInstanceOf(UInteger[].class, array);
+    UInteger[] uintegers = (UInteger[]) array;
+
+    assertEquals(4, uintegers.length);
+    assertEquals(UInteger.valueOf(1), uintegers[0]);
+    assertEquals(UInteger.valueOf(2), uintegers[1]);
+    assertEquals(UInteger.valueOf(3), uintegers[2]);
+    assertEquals(UInteger.valueOf(4), uintegers[3]);
+  }
+
+  @Test
+  void testGetMatrixValueForBytes_Int64_2D() throws UaException {
+    // Create register bytes for a 2x2 matrix of Int64 values
+    // [1, 2, 3, 4]
+    // Each Int64 takes 8 bytes
+    byte[] registerBytes =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 0, 1, // 1
+          0, 0, 0, 0, 0, 0, 0, 2, // 2
+          0, 0, 0, 0, 0, 0, 0, 3, // 3
+          0, 0, 0, 0, 0, 0, 0, 4 // 4
+        };
+    int[] dimensions = new int[] {2, 2};
+
+    // Get matrix value
+    Object result =
+        ModbusByteUtil.getMatrixValueForBytes(
+            registerBytes, new ModbusDataType.Int64(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Matrix
+    assertInstanceOf(Matrix.class, result);
+    Matrix matrix = (Matrix) result;
+
+    // Verify dimensions
+    assertArrayEquals(dimensions, matrix.getDimensions());
+
+    // Verify contents
+    Object array = matrix.getElements();
+    assertInstanceOf(Long[].class, array);
+    Long[] longs = (Long[]) array;
+
+    assertEquals(4, longs.length);
+    assertEquals(1L, longs[0]);
+    assertEquals(2L, longs[1]);
+    assertEquals(3L, longs[2]);
+    assertEquals(4L, longs[3]);
+  }
+
+  @Test
+  void testGetMatrixValueForBytes_UInt64_2D() throws UaException {
+    // Create register bytes for a 2x2 matrix of UInt64 values
+    // [1, 2, 3, 4]
+    // Each UInt64 takes 8 bytes
+    byte[] registerBytes =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 0, 1, // 1
+          0, 0, 0, 0, 0, 0, 0, 2, // 2
+          0, 0, 0, 0, 0, 0, 0, 3, // 3
+          0, 0, 0, 0, 0, 0, 0, 4 // 4
+        };
+    int[] dimensions = new int[] {2, 2};
+
+    // Get matrix value
+    Object result =
+        ModbusByteUtil.getMatrixValueForBytes(
+            registerBytes, new ModbusDataType.UInt64(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Matrix
+    assertInstanceOf(Matrix.class, result);
+    Matrix matrix = (Matrix) result;
+
+    // Verify dimensions
+    assertArrayEquals(dimensions, matrix.getDimensions());
+
+    // Verify contents
+    Object array = matrix.getElements();
+    assertInstanceOf(ULong[].class, array);
+    ULong[] ulongs = (ULong[]) array;
+
+    assertEquals(4, ulongs.length);
+    assertEquals(ULong.valueOf(1), ulongs[0]);
+    assertEquals(ULong.valueOf(2), ulongs[1]);
+    assertEquals(ULong.valueOf(3), ulongs[2]);
+    assertEquals(ULong.valueOf(4), ulongs[3]);
+  }
+
+  @Test
+  void testGetMatrixValueForBytes_Float32_2D() throws UaException {
+    // Create register bytes for a 2x2 matrix of Float32 values
+    // [1.0, 2.5, 3.75, 4.125]
+    // Each Float32 takes 4 bytes
+    // Using IEEE 754 binary representation for these values
+    byte[] registerBytes =
+        new byte[] {
+          0x3F,
+          (byte) 0x80,
+          0x00,
+          0x00, // 1.0f in IEEE 754
+          0x40,
+          0x20,
+          0x00,
+          0x00, // 2.5f in IEEE 754
+          0x40,
+          0x70,
+          0x00,
+          0x00, // 3.75f in IEEE 754
+          0x40,
+          (byte) 0x84,
+          0x00,
+          0x00 // 4.125f in IEEE 754
+        };
+
+    int[] dimensions = new int[] {2, 2};
+
+    // Get matrix value
+    Object result =
+        ModbusByteUtil.getMatrixValueForBytes(
+            registerBytes, new ModbusDataType.Float32(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Matrix
+    assertInstanceOf(Matrix.class, result);
+    Matrix matrix = (Matrix) result;
+
+    // Verify dimensions
+    assertArrayEquals(dimensions, matrix.getDimensions());
+
+    // Verify contents
+    Object array = matrix.getElements();
+    assertInstanceOf(Float[].class, array);
+    Float[] floats = (Float[]) array;
+
+    assertEquals(4, floats.length);
+    assertEquals(1.0f, floats[0], 0.0001);
+    assertEquals(2.5f, floats[1], 0.0001);
+    assertEquals(3.75f, floats[2], 0.0001);
+    assertEquals(4.125f, floats[3], 0.0001);
+  }
+
+  @Test
+  void testGetMatrixValueForBytes_Double64_2D() throws UaException {
+    // Create register bytes for a 2x2 matrix of Double64 values
+    // [1.0, 2.5, 3.75, 4.125]
+    // Each Double64 takes 8 bytes
+    // Using IEEE 754 binary representation for these values
+    byte[] registerBytes =
+        new byte[] {
+          0x3F, (byte) 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 1.0 in IEEE 754
+          0x40, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 2.5 in IEEE 754
+          0x40, 0x0E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 3.75 in IEEE 754
+          0x40, 0x10, (byte) 0x80, 0x00, 0x00, 0x00, 0x00, 0x00 // 4.125 in IEEE 754
+        };
+
+    int[] dimensions = new int[] {2, 2};
+
+    // Get matrix value
+    Object result =
+        ModbusByteUtil.getMatrixValueForBytes(
+            registerBytes, new ModbusDataType.Double64(), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Matrix
+    assertInstanceOf(Matrix.class, result);
+    Matrix matrix = (Matrix) result;
+
+    // Verify dimensions
+    assertArrayEquals(dimensions, matrix.getDimensions());
+
+    // Verify contents
+    Object array = matrix.getElements();
+    assertInstanceOf(Double[].class, array);
+    Double[] doubles = (Double[]) array;
+
+    assertEquals(4, doubles.length);
+    assertEquals(1.0, doubles[0], 0.0001);
+    assertEquals(2.5, doubles[1], 0.0001);
+    assertEquals(3.75, doubles[2], 0.0001);
+    assertEquals(4.125, doubles[3], 0.0001);
+  }
+
+  @Test
+  void testGetMatrixValueForBytes_String_2D() throws UaException {
+    // Create register bytes for a 2x2 matrix of String values
+    // ["ab", "cd", "ef", "gh"]
+    // Each String takes 4 bytes (2 chars + potential null termination)
+    byte[] registerBytes = new byte[16]; // 4 strings * 4 bytes each
+
+    // Set the bytes for each string value
+    byte[] ab = "ab".getBytes(StandardCharsets.UTF_8);
+    byte[] cd = "cd".getBytes(StandardCharsets.UTF_8);
+    byte[] ef = "ef".getBytes(StandardCharsets.UTF_8);
+    byte[] gh = "gh".getBytes(StandardCharsets.UTF_8);
+
+    System.arraycopy(ab, 0, registerBytes, 0, ab.length);
+    System.arraycopy(cd, 0, registerBytes, 4, cd.length);
+    System.arraycopy(ef, 0, registerBytes, 8, ef.length);
+    System.arraycopy(gh, 0, registerBytes, 12, gh.length);
+
+    int[] dimensions = new int[] {2, 2};
+
+    // Get matrix value
+    Object result =
+        ModbusByteUtil.getMatrixValueForBytes(
+            registerBytes, new ModbusDataType.String(4), NO_MODIFIERS, dimensions);
+
+    // Verify result is a Matrix
+    assertInstanceOf(Matrix.class, result);
+    Matrix matrix = (Matrix) result;
+
+    // Verify dimensions
+    assertArrayEquals(dimensions, matrix.getDimensions());
+
+    // Verify contents
+    Object array = matrix.getElements();
+    assertInstanceOf(String[].class, array);
+    String[] strings = (String[]) array;
+
+    assertEquals(4, strings.length);
+    assertEquals("ab", strings[0]);
+    assertEquals("cd", strings[1]);
+    assertEquals("ef", strings[2]);
+    assertEquals("gh", strings[3]);
+  }
+
+  @Test
+  void testGetMatrixValueForBytes_SingleDimension() {
+    int[] dimensions = new int[] {4};
+
+    UaException exception =
+        assertThrows(
+            UaException.class,
+            () ->
+                ModbusByteUtil.getMatrixValueForBytes(
+                    new byte[4], new ModbusDataType.Bool(), NO_MODIFIERS, dimensions));
+
+    assertEquals(StatusCodes.Bad_InternalError, exception.getStatusCode().getValue());
+  }
+
+  @Test
+  void testGetMatrixValueForBytes_InsufficientData() {
+    // Create dimensions for a 2x2 matrix of Int16 values (4 elements total)
+    // Each Int16 takes 2 bytes, so we need 8 bytes total
+    int[] dimensions = new int[] {2, 2};
+
+    // But provide only 6 bytes (insufficient)
+    byte[] registerBytes = new byte[6];
+
+    UaException exception =
+        assertThrows(
+            UaException.class,
+            () ->
+                ModbusByteUtil.getMatrixValueForBytes(
+                    registerBytes, new ModbusDataType.Int16(), NO_MODIFIERS, dimensions));
+
+    assertEquals(StatusCodes.Bad_InternalError, exception.getStatusCode().getValue());
   }
 }


### PR DESCRIPTION
This change lets a single Modbus address represent a list or multidimensional block of values instead of only one value. OPC UA clients can read or write the entire array, address an individual element, or select part of the value with an `IndexRange`.

It extends the Modbus address syntax with up to three array dimensions and optional element indices. Array elements map to consecutive coils or registers in row-major order, while one-dimensional values are exposed as OPC UA arrays and two- or three-dimensional values as matrices with matching metadata.

The change also:

- supports arrays across coil, discrete input, holding register, and input register areas
- supports ranged reads and writes, including substring ranges for string values
- validates dimensions, indices, bit selections, modifiers, data types, and address-space extents
- rejects previously tolerated invalid address forms instead of silently reinterpreting them
- extracts value conversion and range handling into `ModbusValueAccess`
- documents the new address syntax and upgrade considerations
- adds unit and end-to-end coverage for value shapes, wire encoding, indexed elements, ranges, and boundary behavior
