### PR TITLE
Add per-unit Modbus process images

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ read-only from Modbus clients.
 
 The syntax used in NodeIds has the following components:
 
+- Unit ID (optional `0` to `255`, followed by `.`)
 - Area (`C`, `DI`, `HR`, `IR`)
 - DataType (`bool`, `int16`, `int32`, `int64`, `uint16`, `uint32`, `uint64`, `float`, `double`,
   `stringN`). The `C` and `DI` areas only support `bool`; register-only data types are rejected.
@@ -38,8 +39,10 @@ Additionally, the DataType can have "modifiers" applied to influence the byte or
 Examples:
 
 - `C0` (coil area, offset 0)
+- `7.C0` (unit ID 7, coil area, offset 0)
 - `DI0` (discrete input area, offset 0)
 - `HR<int16>0` (holding register area, offset 0)
+- `7.HR<int16>0` (unit ID 7, holding register area, offset 0)
 - `HR<int32>0.5` (holding register area, offset 0, bit 5 within a 32-bit signed integer (2
   registers))
 - `HR<string10>0` (holding register area, offset 0, string of length 10 (5 registers))
@@ -47,6 +50,40 @@ Examples:
   little-endian byte order)
 - `IR<float@LH>0` (input register area, offset 0, 32-bit floating point number (2 registers),
   low-high word order)
+
+## Process Image Modes
+
+By default, the driver uses one unified process image. All Modbus unit IDs and OPC UA addresses
+refer to the same data. For example, `HR0`, `0.HR0`, and `7.HR0` all refer to the same holding
+register.
+
+Enable `processImage.separatePerUnitId` to maintain a separate process image for each Modbus unit
+ID. In this mode, an OPC UA address without a unit ID refers to unit 0, so `HR0` and `0.HR0` refer
+to the same register, while `1.HR0` refers to a different register. Every unit ID from 0 through
+255 remains directly accessible from Modbus and OPC UA.
+
+### Browsing separate process images
+
+In separate mode, `browsing.unitIdBrowseRanges` controls which unit folders appear in the OPC UA
+browse tree. Its default value is `0`. Enter comma-separated unit IDs and inclusive ranges, such as
+`0,2,10-15`; duplicate or overlapping entries are displayed once in ascending order. An empty
+value produces no unit folders.
+
+Each selected unit is displayed under a `Unit N` folder containing the normal area folders. For
+example, holding registers for unit 7 are browsed under `Unit 7/HoldingRegisters`, while their
+variable NodeIds retain the direct address syntax such as `7.HR<int16>0`.
+
+The browse ranges only control discovery. A unit-qualified address remains directly accessible
+even when that unit is not included in `browsing.unitIdBrowseRanges`.
+
+### Persistence and mode changes
+
+When persistence is enabled, unified mode continues to use `coils.bin`, `discreteInputs.bin`,
+`holdingRegisters.bin`, and `inputRegisters.bin` in the device data directory. Separate mode uses
+the same filenames under `units/<unitId>/`, including `units/0/`.
+
+The unified and per-unit datasets are independent. Changing modes does not copy or delete process
+image data; changing back restores the data most recently persisted in that mode.
 
 ### Arrays
 

--- a/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/ModbusToOpcUaIT.java
+++ b/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/ModbusToOpcUaIT.java
@@ -44,6 +44,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+/**
+ * Verifies scalar Modbus-to-OPC-UA interoperability through a real Ignition Gateway.
+ *
+ * <p>The shared container restores the legacy gateway backup, installs the current module, and
+ * exposes both protocol endpoints. Tests use independent Modbus and OPC UA clients so they cover
+ * module wiring, configuration compatibility, address parsing, and process-image routing rather
+ * than only the in-memory helpers exercised by unit tests.
+ */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ModbusToOpcUaIT {
 
@@ -135,6 +143,33 @@ public class ModbusToOpcUaIT {
 
       assertEquals(randomValues.get(i), value.getValue().getValue());
     }
+  }
+
+  // The gateway backup predates the per-unit properties; this end-to-end check protects existing
+  // devices from silently changing storage and routing semantics after a module upgrade.
+  @Test
+  void legacyConfigurationUsesUnifiedProcessImageAcrossUnitIds() throws Exception {
+    int address = 12345;
+    short expected = (short) 0x5A3C;
+
+    modbusClient.writeSingleRegister(7, new WriteSingleRegisterRequest(address, expected));
+
+    ReadHoldingRegistersResponse modbusResponse =
+        modbusClient.readHoldingRegisters(42, new ReadHoldingRegistersRequest(address, 1));
+    assertArrayEquals(new byte[] {0x5A, 0x3C}, modbusResponse.registers());
+
+    NodeId unqualifiedNodeId =
+        NodeId.parse("ns=1;s=[modbus-server]HR<int16>%d".formatted(address));
+    NodeId prefixedNodeId =
+        NodeId.parse("ns=1;s=[modbus-server]99.HR<int16>%d".formatted(address));
+
+    DataValue unqualifiedValue =
+        opcUaClient.readValue(0.0, TimestampsToReturn.Both, unqualifiedNodeId);
+    DataValue prefixedValue =
+        opcUaClient.readValue(0.0, TimestampsToReturn.Both, prefixedNodeId);
+
+    assertEquals(expected, unqualifiedValue.getValue().getValue());
+    assertEquals(expected, prefixedValue.getValue().getValue());
   }
 
   @Test

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/BrowsableAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/BrowsableAddressSpace.java
@@ -1,7 +1,11 @@
 package com.kevinherron.ignition.modbus;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.eclipse.milo.opcua.sdk.core.Reference;
@@ -29,21 +33,53 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ViewDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Supplies the configured OPC UA browse hierarchy for a {@link ModbusServerDevice}.
+ *
+ * <p>This fragment creates device, area, unit, and register-group folders. Variable NodeIds remain
+ * address strings resolved by {@link ModbusAddressSpace}; browsing therefore does not create or
+ * authorize process images. Unified mode exposes the legacy root area folders, while separate mode
+ * replaces them with the configured unit folders.
+ *
+ * <p>The owning device starts and stops this fragment with its other OPC UA address space.
+ */
 public class BrowsableAddressSpace extends ManagedAddressSpaceFragmentWithLifecycle {
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final List<String> AREA_NAMES =
+      List.of("Coils", "DiscreteInputs", "HoldingRegisters", "InputRegisters");
+  private static final List<String> REGISTER_DATA_TYPES =
+      List.of("int16", "uint16", "int32", "uint32", "int64", "uint64", "float", "double");
+  // Digit counts are bounded so client-supplied NodeIds can never overflow Integer.parseInt.
+  private static final Pattern ENUMERATED_AREA_PATTERN =
+      Pattern.compile("_(C|DI|HR|IR)(\\d{1,5})_");
+  private static final Pattern UNIT_ENUMERATED_AREA_PATTERN =
+      Pattern.compile("Unit(\\d{1,3})\\._(HR|IR)(\\d{1,5})_");
+  private static final Pattern UNIT_AREA_FOLDER_PATTERN =
+      Pattern.compile("Unit(\\d{1,3})\\.(Coils|DiscreteInputs|HoldingRegisters|InputRegisters)");
+  private static final Pattern UNIT_RANGE_PATTERN = Pattern.compile("(\\d+)(?:-(\\d+))?");
 
-  private final Pattern enumeratedAreaPattern = Pattern.compile("_(C|DI|HR|IR)(\\d+)_");
+  private final Logger logger = LoggerFactory.getLogger(getClass());
 
   private final AddressSpaceFilter filter;
 
   private final ModbusServerDevice device;
+  private final boolean separatePerUnitId;
+  private final Set<Integer> configuredUnitIds;
   private final SubscriptionModel subscriptionModel;
 
+  /**
+   * Creates an unstarted browse fragment for a device.
+   *
+   * @param server the OPC UA server that owns the address space.
+   * @param device the device whose settings define the browse hierarchy.
+   */
   public BrowsableAddressSpace(OpcUaServer server, ModbusServerDevice device) {
     super(server, device);
 
     this.device = device;
+    separatePerUnitId = device.deviceConfig.processImage().separatePerUnitId();
+    configuredUnitIds =
+        Set.copyOf(expandUnitIdRanges(device.deviceConfig.browsing().unitIdBrowseRanges()));
 
     filter =
         SimpleAddressSpaceFilter.create(
@@ -57,10 +93,17 @@ public class BrowsableAddressSpace extends ManagedAddressSpaceFragmentWithLifecy
               } else {
                 String id = nodeId.getIdentifier().toString();
                 id = id.substring(device.deviceContext.getName().length() + 2);
-                return switch (id) {
-                  case "Coils", "DiscreteInputs", "HoldingRegisters", "InputRegisters" -> true;
-                  default -> enumeratedAreaPattern.matcher(id).matches();
-                };
+
+                if (separatePerUnitId) {
+                  Matcher matcher = UNIT_ENUMERATED_AREA_PATTERN.matcher(id);
+                  return matcher.matches()
+                      && configuredUnitIds.contains(Integer.parseInt(matcher.group(1)));
+                } else {
+                  return switch (id) {
+                    case "Coils", "DiscreteInputs", "HoldingRegisters", "InputRegisters" -> true;
+                    default -> ENUMERATED_AREA_PATTERN.matcher(id).matches();
+                  };
+                }
               }
             });
 
@@ -92,84 +135,39 @@ public class BrowsableAddressSpace extends ManagedAddressSpaceFragmentWithLifecy
     String id = nodeId.getIdentifier().toString();
     id = id.substring(device.deviceContext.getName().length() + 2);
 
+    if (separatePerUnitId) {
+      Matcher areaMatcher = UNIT_AREA_FOLDER_PATTERN.matcher(id);
+      if (areaMatcher.matches()) {
+        int unitId = Integer.parseInt(areaMatcher.group(1));
+        if (configuredUnitIds.contains(unitId)) {
+          return browseArea(nodeId, areaMatcher.group(2), unitId);
+        }
+      }
+
+      Matcher matcher = UNIT_ENUMERATED_AREA_PATTERN.matcher(id);
+      if (matcher.matches()) {
+        int unitId = Integer.parseInt(matcher.group(1));
+        if (configuredUnitIds.contains(unitId)) {
+          String area = matcher.group(2);
+          int address = Integer.parseInt(matcher.group(3));
+
+          return ReferenceResult.of(
+              createRegisterAddressReferences(nodeId, area, address, unitId));
+        }
+      }
+
+      return super.browse(context, view, List.of(nodeId)).get(0);
+    }
+
     return switch (id) {
-      case "Coils" -> {
-        String coilBrowseRanges = device.deviceConfig.browsing().coilBrowseRanges();
-
-        if (coilBrowseRanges != null && !coilBrowseRanges.isEmpty()) {
-          var references = new ArrayList<Reference>();
-
-          List<Range> ranges = parseRanges(coilBrowseRanges);
-          for (Range range : ranges) {
-            for (int i = range.start; i <= range.end; i++) {
-              references.add(
-                  new Reference(
-                      nodeId,
-                      NodeIds.HasComponent,
-                      device.deviceContext.nodeId("C%d".formatted(i)).expanded(),
-                      Reference.Direction.FORWARD));
-            }
-          }
-
-          yield ReferenceResult.of(references);
-        } else {
-          yield ReferenceResult.of(List.of());
-        }
-      }
-      case "DiscreteInputs" -> {
-        String discreteInputBrowseRanges =
-            device.deviceConfig.browsing().discreteInputBrowseRanges();
-
-        if (discreteInputBrowseRanges != null && !discreteInputBrowseRanges.isEmpty()) {
-          var references = new ArrayList<Reference>();
-
-          List<Range> ranges = parseRanges(discreteInputBrowseRanges);
-          for (Range range : ranges) {
-            for (int i = range.start; i <= range.end; i++) {
-              references.add(
-                  new Reference(
-                      nodeId,
-                      NodeIds.HasComponent,
-                      device.deviceContext.nodeId("DI%d".formatted(i)).expanded(),
-                      Reference.Direction.FORWARD));
-            }
-          }
-
-          yield ReferenceResult.of(references);
-        } else {
-          yield ReferenceResult.of(List.of());
-        }
-      }
-      case "HoldingRegisters" -> {
-        String holdingRegisterBrowseRanges =
-            device.deviceConfig.browsing().holdingRegisterBrowseRanges();
-
-        if (holdingRegisterBrowseRanges != null && !holdingRegisterBrowseRanges.isEmpty()) {
-          yield ReferenceResult.of(
-              createRegisterFolderReferences(
-                  nodeId, "_HR%d_", parseRanges(holdingRegisterBrowseRanges)));
-        } else {
-          yield ReferenceResult.of(List.of());
-        }
-      }
-      case "InputRegisters" -> {
-        String inputRegisterBrowseRanges =
-            device.deviceConfig.browsing().inputRegisterBrowseRanges();
-
-        if (inputRegisterBrowseRanges != null && !inputRegisterBrowseRanges.isEmpty()) {
-          yield ReferenceResult.of(
-              createRegisterFolderReferences(
-                  nodeId, "_IR%d_", parseRanges(inputRegisterBrowseRanges)));
-        } else {
-          yield ReferenceResult.of(List.of());
-        }
-      }
+      case "Coils", "DiscreteInputs", "HoldingRegisters", "InputRegisters" ->
+          browseArea(nodeId, id, null);
       default -> {
-        Matcher matcher = enumeratedAreaPattern.matcher(id);
+        Matcher matcher = ENUMERATED_AREA_PATTERN.matcher(id);
         if (matcher.matches()) {
           String area = matcher.group(1);
           int address = Integer.parseInt(matcher.group(2));
-          yield ReferenceResult.of(createRegisterAddressReferences(nodeId, area, address));
+          yield ReferenceResult.of(createRegisterAddressReferences(nodeId, area, address, null));
         } else {
           if (logger.isDebugEnabled()) {
             logger.debug("Browsing super with: {}", nodeId);
@@ -180,36 +178,81 @@ public class BrowsableAddressSpace extends ManagedAddressSpaceFragmentWithLifecy
     };
   }
 
-  private List<Reference> createRegisterFolderReferences(
-      NodeId nodeId, String formatString, List<Range> ranges) {
+  private ReferenceResult browseArea(NodeId nodeId, String areaName, Integer unitId) {
+    String ranges =
+        switch (areaName) {
+          case "Coils" -> device.deviceConfig.browsing().coilBrowseRanges();
+          case "DiscreteInputs" -> device.deviceConfig.browsing().discreteInputBrowseRanges();
+          case "HoldingRegisters" -> device.deviceConfig.browsing().holdingRegisterBrowseRanges();
+          case "InputRegisters" -> device.deviceConfig.browsing().inputRegisterBrowseRanges();
+          default -> throw new IllegalArgumentException("unknown area: " + areaName);
+        };
+
+    if (ranges == null || ranges.isEmpty()) {
+      return ReferenceResult.of(List.of());
+    }
+
+    String area =
+        switch (areaName) {
+          case "Coils" -> "C";
+          case "DiscreteInputs" -> "DI";
+          case "HoldingRegisters" -> "HR";
+          case "InputRegisters" -> "IR";
+          default -> throw new IllegalArgumentException("unknown area: " + areaName);
+        };
 
     var references = new ArrayList<Reference>();
+    for (String identifier : browseIdentifiers(area, parseRanges(ranges), unitId)) {
+      references.add(
+          new Reference(
+              nodeId,
+              NodeIds.HasComponent,
+              device.deviceContext.nodeId(identifier).expanded(),
+              Reference.Direction.FORWARD));
+    }
 
+    return ReferenceResult.of(references);
+  }
+
+  /**
+   * Builds the child identifiers exposed beneath one Modbus area folder.
+   *
+   * @param area the Modbus area abbreviation: {@code C}, {@code DI}, {@code HR}, or {@code IR}.
+   * @param ranges the address ranges to expose.
+   * @param unitId the unit ID qualifier, or {@code null} for unified identifiers.
+   * @return the variable or register-group identifiers in range order.
+   * @throws IllegalArgumentException if {@code area} is not supported.
+   */
+  static List<String> browseIdentifiers(String area, List<Range> ranges, Integer unitId) {
+    var identifiers = new ArrayList<String>();
     for (Range range : ranges) {
       for (int i = range.start; i <= range.end; i++) {
-        NodeId childNodeId = device.deviceContext.nodeId(formatString.formatted(i));
-        references.add(
-            new Reference(
-                nodeId, NodeIds.HasComponent, childNodeId.expanded(), Reference.Direction.FORWARD));
+        if (area.equals("HR") || area.equals("IR")) {
+          identifiers.add(
+              unitId == null
+                  ? "_%s%d_".formatted(area, i)
+                  : registerFolderIdentifier(unitId, area, i));
+        } else if (area.equals("C") || area.equals("DI")) {
+          String address = "%s%d".formatted(area, i);
+          identifiers.add(unitId == null ? address : variableIdentifier(unitId, address));
+        } else {
+          throw new IllegalArgumentException("unknown area: " + area);
+        }
       }
     }
 
-    return references;
+    return identifiers;
   }
 
   private List<Reference> createRegisterAddressReferences(
-      NodeId parentNodeId, String area, int address) {
+      NodeId parentNodeId, String area, int address, Integer unitId) {
 
     var references = new ArrayList<Reference>();
 
     switch (area) {
       case "HR", "IR" -> {
-        List<String> dataTypes =
-            List.of("int16", "uint16", "int32", "uint32", "int64", "uint64", "float", "double");
-
-        for (String dataType : dataTypes) {
-          NodeId targetNodeId =
-              device.deviceContext.nodeId("%s<%s>%d".formatted(area, dataType, address));
+        for (String identifier : registerAddressIdentifiers(area, address, unitId)) {
+          NodeId targetNodeId = device.deviceContext.nodeId(identifier);
 
           references.add(
               new Reference(
@@ -225,6 +268,29 @@ public class BrowsableAddressSpace extends ManagedAddressSpaceFragmentWithLifecy
     }
 
     return references;
+  }
+
+  /**
+   * Builds the typed variable identifiers exposed beneath a register-group folder.
+   *
+   * @param area the {@code HR} or {@code IR} area abbreviation.
+   * @param address the register offset represented by the folder.
+   * @param unitId the unit ID qualifier, or {@code null} for unified identifiers.
+   * @return one variable identifier for each supported register data type.
+   * @throws IllegalArgumentException if {@code area} is not a register area.
+   */
+  static List<String> registerAddressIdentifiers(String area, int address, Integer unitId) {
+    if (!area.equals("HR") && !area.equals("IR")) {
+      throw new IllegalArgumentException("not a register area: " + area);
+    }
+
+    var identifiers = new ArrayList<String>();
+    for (String dataType : REGISTER_DATA_TYPES) {
+      String registerAddress = "%s<%s>%d".formatted(area, dataType, address);
+      identifiers.add(
+          unitId == null ? registerAddress : variableIdentifier(unitId, registerAddress));
+    }
+    return identifiers;
   }
 
   @Override
@@ -268,7 +334,12 @@ public class BrowsableAddressSpace extends ManagedAddressSpaceFragmentWithLifecy
             values.add(value);
           }
           default -> {
-            if (enumeratedAreaPattern.matcher(id).matches()) {
+            boolean syntheticNode =
+                separatePerUnitId
+                    ? isConfiguredUnitRegisterFolder(id)
+                    : ENUMERATED_AREA_PATTERN.matcher(id).matches();
+
+            if (syntheticNode) {
               DataValue value =
                   AttributeId.from(readValueId.getAttributeId())
                       .map(
@@ -290,27 +361,35 @@ public class BrowsableAddressSpace extends ManagedAddressSpaceFragmentWithLifecy
     return values;
   }
 
+  private boolean isConfiguredUnitRegisterFolder(String identifier) {
+    Matcher matcher = UNIT_ENUMERATED_AREA_PATTERN.matcher(identifier);
+    return matcher.matches() && configuredUnitIds.contains(Integer.parseInt(matcher.group(1)));
+  }
+
   private Variant readAttribute(NodeId nodeId, AttributeId attributeId) {
     Object o =
         switch (attributeId) {
           case NodeId -> nodeId;
           case NodeClass -> NodeClass.Object;
-          case BrowseName -> {
-            String id = nodeId.getIdentifier().toString();
-            String addr = id.substring(device.deviceContext.getName().length() + 2);
-            addr = addr.replace("_", "");
-            yield device.deviceContext.qualifiedName(addr);
-          }
-          case DisplayName, Description -> {
-            String id = nodeId.getIdentifier().toString();
-            String addr = id.substring(device.deviceContext.getName().length() + 2);
-            addr = addr.replace("_", "");
-            yield LocalizedText.english(addr);
-          }
+          case BrowseName -> device.deviceContext.qualifiedName(syntheticFolderName(nodeId));
+          case DisplayName, Description ->
+              LocalizedText.english(syntheticFolderName(nodeId));
           default -> null;
         };
 
     return o == null ? Variant.NULL_VALUE : new Variant(o);
+  }
+
+  private String syntheticFolderName(NodeId nodeId) {
+    String id = nodeId.getIdentifier().toString();
+    String addr = id.substring(device.deviceContext.getName().length() + 2);
+    // Separate-mode identifiers are unit-qualified ("Unit7._HR0_"); the folder's name is only
+    // the register-group segment, matching the unified-mode name ("HR0").
+    int dot = addr.indexOf('.');
+    if (dot >= 0) {
+      addr = addr.substring(dot + 1);
+    }
+    return addr.replace("_", "");
   }
 
   @Override
@@ -354,62 +433,141 @@ public class BrowsableAddressSpace extends ManagedAddressSpaceFragmentWithLifecy
             device.deviceContext.getRootNodeId().expanded(),
             Reference.Direction.INVERSE));
 
-    addCoilsNode(deviceNode);
-    addDiscreteInputsNode(deviceNode);
-    addHoldingRegistersNode(deviceNode);
-    addInputRegistersNode(deviceNode);
+    Map<String, UaFolderNode> parentNodes = new HashMap<>();
+    parentNodes.put("", deviceNode);
+
+    for (FolderDefinition definition :
+        folderDefinitions(separatePerUnitId, configuredUnitIds.stream().sorted().toList())) {
+      var folderNode =
+          new UaFolderNode(
+              getNodeContext(),
+              device.deviceContext.nodeId(definition.identifier()),
+              device.deviceContext.qualifiedName(definition.browseName()),
+              new LocalizedText(definition.displayName()));
+
+      getNodeManager().addNode(folderNode);
+      parentNodes.get(definition.parentIdentifier()).addOrganizes(folderNode);
+      parentNodes.put(definition.identifier(), folderNode);
+    }
   }
 
-  private void addCoilsNode(UaFolderNode deviceNode) {
-    var coilsNode =
-        new UaFolderNode(
-            getNodeContext(),
-            device.deviceContext.nodeId("Coils"),
-            device.deviceContext.qualifiedName("Coils"),
-            new LocalizedText("Coils"));
+  record FolderDefinition(
+      String identifier, String parentIdentifier, String browseName, String displayName) {}
 
-    getNodeManager().addNode(coilsNode);
+  /**
+   * Describes the concrete folder nodes for unified or separate browsing.
+   *
+   * @param separatePerUnitId whether unit folders replace the unified root area folders.
+   * @param unitIds the unit IDs whose folders should be exposed.
+   * @return folder definitions with unit IDs sorted and de-duplicated.
+   * @throws IllegalArgumentException if a unit ID is outside 0 through 255.
+   */
+  static List<FolderDefinition> folderDefinitions(
+      boolean separatePerUnitId, List<Integer> unitIds) {
 
-    deviceNode.addOrganizes(coilsNode);
+    var definitions = new ArrayList<FolderDefinition>();
+
+    if (separatePerUnitId) {
+      for (int unitId : new TreeSet<>(unitIds)) {
+        String unitIdentifier = unitFolderIdentifier(unitId);
+        definitions.add(
+            new FolderDefinition(unitIdentifier, "", unitIdentifier, "Unit " + unitId));
+
+        for (String areaName : AREA_NAMES) {
+          definitions.add(
+              new FolderDefinition(
+                  areaFolderIdentifier(unitId, areaName),
+                  unitIdentifier,
+                  areaName,
+                  areaName));
+        }
+      }
+    } else {
+      for (String areaName : AREA_NAMES) {
+        definitions.add(new FolderDefinition(areaName, "", areaName, areaName));
+      }
+    }
+
+    return List.copyOf(definitions);
   }
 
-  private void addDiscreteInputsNode(UaFolderNode deviceNode) {
-    var discreteInputsNode =
-        new UaFolderNode(
-            getNodeContext(),
-            device.deviceContext.nodeId("DiscreteInputs"),
-            device.deviceContext.qualifiedName("DiscreteInputs"),
-            new LocalizedText("DiscreteInputs"));
-
-    getNodeManager().addNode(discreteInputsNode);
-
-    deviceNode.addOrganizes(discreteInputsNode);
+  static String unitFolderIdentifier(int unitId) {
+    validateUnitId(unitId);
+    return "Unit" + unitId;
   }
 
-  private void addHoldingRegistersNode(UaFolderNode deviceNode) {
-    var holdingRegistersNode =
-        new UaFolderNode(
-            getNodeContext(),
-            device.deviceContext.nodeId("HoldingRegisters"),
-            device.deviceContext.qualifiedName("HoldingRegisters"),
-            new LocalizedText("HoldingRegisters"));
-
-    getNodeManager().addNode(holdingRegistersNode);
-
-    deviceNode.addOrganizes(holdingRegistersNode);
+  static String areaFolderIdentifier(int unitId, String areaName) {
+    validateUnitId(unitId);
+    if (!AREA_NAMES.contains(areaName)) {
+      throw new IllegalArgumentException("unknown area: " + areaName);
+    }
+    return "%s.%s".formatted(unitFolderIdentifier(unitId), areaName);
   }
 
-  private void addInputRegistersNode(UaFolderNode deviceNode) {
-    var inputRegistersNode =
-        new UaFolderNode(
-            getNodeContext(),
-            device.deviceContext.nodeId("InputRegisters"),
-            device.deviceContext.qualifiedName("InputRegisters"),
-            new LocalizedText("InputRegisters"));
+  static String registerFolderIdentifier(int unitId, String area, int address) {
+    validateUnitId(unitId);
+    if (!area.equals("HR") && !area.equals("IR")) {
+      throw new IllegalArgumentException("not a register area: " + area);
+    }
+    return "%s._%s%d_".formatted(unitFolderIdentifier(unitId), area, address);
+  }
 
-    getNodeManager().addNode(inputRegistersNode);
+  static String variableIdentifier(int unitId, String address) {
+    validateUnitId(unitId);
+    return "%d.%s".formatted(unitId, address);
+  }
 
-    deviceNode.addOrganizes(inputRegistersNode);
+  private static void validateUnitId(int unitId) {
+    ProcessImageManager.validateUnitId(unitId);
+  }
+
+  /**
+   * Expands a unit ID browse expression into an ascending, de-duplicated list.
+   *
+   * @param ranges comma-separated unit IDs and inclusive ranges, or an empty string.
+   * @return the selected unit IDs, or an empty list for an empty expression.
+   * @throws IllegalArgumentException if the expression is null, malformed, reversed, or outside 0
+   *     through 255.
+   */
+  static List<Integer> expandUnitIdRanges(String ranges) {
+    if (ranges == null) {
+      throw new IllegalArgumentException("unit ID browse ranges must not be null");
+    }
+    if (ranges.isEmpty()) {
+      return List.of();
+    }
+
+    var unitIds = new TreeSet<Integer>();
+    for (String range : ranges.split(",", -1)) {
+      Matcher matcher = UNIT_RANGE_PATTERN.matcher(range);
+      if (!matcher.matches()) {
+        throw new IllegalArgumentException("invalid unit ID browse range: " + range);
+      }
+
+      int start = parseUnitId(matcher.group(1));
+      int end = matcher.group(2) == null ? start : parseUnitId(matcher.group(2));
+      if (end < start) {
+        throw new IllegalArgumentException("unit ID browse range is reversed: " + range);
+      }
+
+      for (int unitId = start; unitId <= end; unitId++) {
+        unitIds.add(unitId);
+      }
+    }
+
+    return List.copyOf(unitIds);
+  }
+
+  private static int parseUnitId(String value) {
+    final int unitId;
+    try {
+      unitId = Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("invalid unit ID: " + value, e);
+    }
+
+    validateUnitId(unitId);
+    return unitId;
   }
 
   record Range(int start, int end) {}

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
@@ -1,24 +1,15 @@
 package com.kevinherron.ignition.modbus;
 
 import com.digitalpetri.modbus.server.ProcessImage;
-import com.digitalpetri.modbus.server.ProcessImage.Modification.CoilModification;
-import com.digitalpetri.modbus.server.ProcessImage.Modification.DiscreteInputModification;
-import com.digitalpetri.modbus.server.ProcessImage.Modification.HoldingRegisterModification;
-import com.digitalpetri.modbus.server.ProcessImage.Modification.InputRegisterModification;
-import com.digitalpetri.modbus.server.ProcessImage.Transaction;
-import com.inductiveautomation.ignition.gateway.opcua.server.api.OpcUa;
 import com.kevinherron.ignition.modbus.address.ModbusAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddress.ArrayAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddressParser;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.Reference.Direction;
@@ -48,17 +39,18 @@ import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.ViewDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteValue;
-import org.eclipse.milo.opcua.stack.core.util.ExecutionQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Presents a {@link ModbusServerDevice} process image as an OPC UA address-space fragment.
+ * Presents a {@link ModbusServerDevice} process image as OPC UA variable nodes.
  *
  * <p>The fragment resolves Modbus address strings as variable nodes, exposes their value and
- * metadata attributes, and supplies monitored values through the OPC UA subscription model. Its
- * {@link Lifecycle} must be started before use and shut down with the owning device; startup also
- * restores persisted process-image data when persistence is enabled.
+ * metadata attributes, and supplies monitored values through the OPC UA subscription model. Value
+ * operations select images through {@link ProcessImageManager}; unqualified addresses select unit
+ * 0 in separate mode, and mixed-unit batches retain their original result order.
+ *
+ * <p>Its {@link Lifecycle} must be started before use and shut down with the owning device.
  */
 public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
 
@@ -72,7 +64,7 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
   /**
    * Creates an unstarted address space for a Modbus server device.
    *
-   * @param device the device whose process image and OPC UA context back this address space.
+   * @param device the device whose process images and OPC UA context back this address space.
    */
   public ModbusAddressSpace(ModbusServerDevice device) {
     this.device = device;
@@ -84,22 +76,6 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
 
   @Override
   public void startup() {
-    if (device.deviceConfig.persistence().persistData()) {
-      Path deviceFolderPath = device.deviceContext.getDeviceFolderPath().toAbsolutePath();
-
-      if (!Files.exists(deviceFolderPath)) {
-        try {
-          Files.createDirectories(deviceFolderPath);
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
-      }
-
-      loadProcessImage();
-
-      device.processImage.addModificationListener(new ModificationListener());
-    }
-
     subscriptionModel.startup();
 
     device.register(this);
@@ -202,13 +178,14 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
         }
       } catch (Exception e) {
         logger.error("Error reading value: id={}, addr={}", id, addr, e);
-        pending.value = new DataValue(StatusCodes.Bad_ConfigurationError);
+        pending.value = new DataValue(StatusCodes.Bad_NodeIdInvalid);
       }
     }
 
     List<DataValue> values =
         readValueAttributes(
-            device.processImage, pendingValueReads.stream().map(PendingValueRead::read).toList());
+            device.processImageManager,
+            pendingValueReads.stream().map(PendingValueRead::read).toList());
     for (int i = 0; i < pendingValueReads.size(); i++) {
       pendingValueReads.get(i).pending().value = values.get(i);
     }
@@ -241,6 +218,53 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
           }
           return values;
         });
+  }
+
+  /**
+   * Reads a batch through the manager-selected process images.
+   *
+   * <p>Each image is read in one sequential transaction. Returned values correspond positionally
+   * to {@code reads}, including when the batch contains several unit IDs. A request racing device
+   * shutdown returns {@code Bad_Shutdown}; a persistence initialization failure returns {@code
+   * Bad_InternalError}.
+   *
+   * @param processImageManager the manager that resolves each address to an image.
+   * @param reads the value requests in OPC UA request order.
+   * @return the values and statuses in the same order as {@code reads}.
+   */
+  static List<DataValue> readValueAttributes(
+      ProcessImageManager processImageManager, List<ValueRead> reads) {
+    if (reads.isEmpty()) {
+      return List.of();
+    }
+
+    Map<ProcessImage, List<IndexedValueRead>> groups = new LinkedHashMap<>();
+    DataValue[] values = new DataValue[reads.size()];
+    for (int i = 0; i < reads.size(); i++) {
+      ValueRead read = reads.get(i);
+      try {
+        ProcessImage processImage = processImageManager.get(read.address());
+        groups.computeIfAbsent(processImage, ignored -> new ArrayList<>())
+            .add(new IndexedValueRead(i, read));
+      } catch (IllegalStateException e) {
+        values[i] = new DataValue(StatusCodes.Bad_Shutdown);
+      } catch (UncheckedIOException e) {
+        // A persistent image that cannot be initialized is an internal device failure.
+        values[i] = new DataValue(StatusCodes.Bad_InternalError);
+      }
+    }
+
+    for (Map.Entry<ProcessImage, List<IndexedValueRead>> entry : groups.entrySet()) {
+      List<IndexedValueRead> indexedReads = entry.getValue();
+      List<DataValue> groupValues =
+          readValueAttributes(
+              entry.getKey(), indexedReads.stream().map(IndexedValueRead::read).toList());
+      for (int i = 0; i < indexedReads.size(); i++) {
+        values[indexedReads.get(i).index()] = groupValues.get(i);
+      }
+    }
+
+    return Arrays.asList(values);
   }
 
   static Variant readValueAttribute(
@@ -356,7 +380,7 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
                   new ValueWrite(
                       address, writeValue.getValue().getValue(), writeValue.getIndexRange())));
         } catch (Exception e) {
-          pending.statusCode = new StatusCode(StatusCodes.Bad_ConfigurationError);
+          pending.statusCode = new StatusCode(StatusCodes.Bad_NodeIdInvalid);
         }
       } else {
         pending.statusCode = new StatusCode(StatusCodes.Bad_NotWritable);
@@ -365,7 +389,7 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
 
     List<StatusCode> statuses =
         writeValueAttributes(
-            device.processImage,
+            device.processImageManager,
             pendingValueWrites.stream().map(PendingValueWrite::write).toList());
     for (int i = 0; i < pendingValueWrites.size(); i++) {
       pendingValueWrites.get(i).pending().statusCode = statuses.get(i);
@@ -401,6 +425,53 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
           }
         });
     return statuses;
+  }
+
+  /**
+   * Writes a batch through the manager-selected process images.
+   *
+   * <p>Each image is updated in one sequential transaction, preserving the order of writes that
+   * target that image. Returned statuses correspond positionally to {@code writes}. A request
+   * racing device shutdown returns {@code Bad_Shutdown}; a persistence initialization failure
+   * returns {@code Bad_InternalError}.
+   *
+   * @param processImageManager the manager that resolves each address to an image.
+   * @param writes the value requests in OPC UA request order.
+   * @return the write statuses in the same order as {@code writes}.
+   */
+  static List<StatusCode> writeValueAttributes(
+      ProcessImageManager processImageManager, List<ValueWrite> writes) {
+    if (writes.isEmpty()) {
+      return List.of();
+    }
+
+    Map<ProcessImage, List<IndexedValueWrite>> groups = new LinkedHashMap<>();
+    StatusCode[] statuses = new StatusCode[writes.size()];
+    for (int i = 0; i < writes.size(); i++) {
+      ValueWrite write = writes.get(i);
+      try {
+        ProcessImage processImage = processImageManager.get(write.address());
+        groups.computeIfAbsent(processImage, ignored -> new ArrayList<>())
+            .add(new IndexedValueWrite(i, write));
+      } catch (IllegalStateException e) {
+        statuses[i] = new StatusCode(StatusCodes.Bad_Shutdown);
+      } catch (UncheckedIOException e) {
+        // A persistent image that cannot be initialized is an internal device failure.
+        statuses[i] = new StatusCode(StatusCodes.Bad_InternalError);
+      }
+    }
+
+    for (Map.Entry<ProcessImage, List<IndexedValueWrite>> entry : groups.entrySet()) {
+      List<IndexedValueWrite> indexedWrites = entry.getValue();
+      List<StatusCode> groupStatuses =
+          writeValueAttributes(
+              entry.getKey(), indexedWrites.stream().map(IndexedValueWrite::write).toList());
+      for (int i = 0; i < indexedWrites.size(); i++) {
+        statuses[indexedWrites.get(i).index()] = groupStatuses.get(i);
+      }
+    }
+
+    return Arrays.asList(statuses);
   }
 
   static void writeValueAttribute(
@@ -446,287 +517,6 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
 
   // endregion
 
-  // region ProcessImage Load/Save
-
-  private void loadProcessImage() {
-    device.processImage.with(
-        tx -> {
-          loadCoils(tx);
-          loadDiscreteInputs(tx);
-          loadHoldingRegisters(tx);
-          loadInputRegisters(tx);
-        });
-  }
-
-  private void loadCoils(Transaction tx) {
-    Path path = device.deviceContext.getDeviceFolderPath().resolve("coils.bin").toAbsolutePath();
-
-    try (FileChannel channel = openFileChannel(path)) {
-      channel.truncate(65535);
-      ByteBuffer coils = ByteBuffer.allocate(65535);
-      readChannelIntoBuffer(coils, channel);
-      coils.flip();
-
-      tx.writeCoils(
-          coilMap -> {
-            for (int i = 0; i < coils.limit(); i++) {
-              if (coils.get(i) != 0) {
-                coilMap.put(i, true);
-              }
-            }
-          });
-    } catch (IOException e) {
-      logger.error("Error reading coils.bin", e);
-    }
-  }
-
-  private void loadDiscreteInputs(Transaction tx) {
-    Path path =
-        device.deviceContext.getDeviceFolderPath().resolve("discreteInputs.bin").toAbsolutePath();
-
-    try (FileChannel channel = openFileChannel(path)) {
-      channel.truncate(65535);
-      ByteBuffer discreteInputs = ByteBuffer.allocate(65535);
-      readChannelIntoBuffer(discreteInputs, channel);
-      discreteInputs.flip();
-
-      tx.writeDiscreteInputs(
-          discreteInputMap -> {
-            for (int i = 0; i < discreteInputs.limit(); i++) {
-              if (discreteInputs.get(i) != 0) {
-                discreteInputMap.put(i, true);
-              }
-            }
-          });
-    } catch (IOException e) {
-      logger.error("Error reading discreteInputs.bin", e);
-    }
-  }
-
-  private void loadHoldingRegisters(Transaction tx) {
-    Path path =
-        device.deviceContext.getDeviceFolderPath().resolve("holdingRegisters.bin").toAbsolutePath();
-
-    try (FileChannel channel = openFileChannel(path)) {
-      int size = 65535 * 2;
-      channel.truncate(size);
-      ByteBuffer holdingRegisters = ByteBuffer.allocate(size);
-      readChannelIntoBuffer(holdingRegisters, channel);
-      holdingRegisters.flip();
-
-      tx.writeHoldingRegisters(
-          holdingRegisterMap -> {
-            for (int i = 0; i < holdingRegisters.limit(); i += 2) {
-              byte high = holdingRegisters.get(i);
-              byte low = holdingRegisters.get(i + 1);
-              if (high != 0 || low != 0) {
-                holdingRegisterMap.put(i / 2, new byte[] {high, low});
-              }
-            }
-          });
-    } catch (IOException e) {
-      logger.error("Error reading holdingRegisters.bin", e);
-    }
-  }
-
-  private void loadInputRegisters(Transaction tx) {
-    Path path =
-        device.deviceContext.getDeviceFolderPath().resolve("inputRegisters.bin").toAbsolutePath();
-
-    try (FileChannel channel = openFileChannel(path)) {
-      int size = 65535 * 2;
-      channel.truncate(size);
-      ByteBuffer inputRegisters = ByteBuffer.allocate(size);
-      readChannelIntoBuffer(inputRegisters, channel);
-      inputRegisters.flip();
-
-      tx.writeInputRegisters(
-          inputRegisterMap -> {
-            for (int i = 0; i < inputRegisters.limit(); i += 2) {
-              byte high = inputRegisters.get(i);
-              byte low = inputRegisters.get(i + 1);
-              if (high != 0 || low != 0) {
-                inputRegisterMap.put(i / 2, new byte[] {high, low});
-              }
-            }
-          });
-    } catch (IOException e) {
-      logger.error("Error reading inputRegisters.bin", e);
-    }
-  }
-
-  /**
-   * Opens a {@link FileChannel} for the specified file path with read, write, and create options.
-   *
-   * @param path the {@link Path} representing the file to be opened.
-   * @return the {@link FileChannel} instance associated with the specified file.
-   * @throws IOException if an I/O error occurs while opening the file.
-   */
-  private static FileChannel openFileChannel(Path path) throws IOException {
-    return FileChannel.open(
-        path, StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
-  }
-
-  /**
-   * Reads data from the given {@link FileChannel} into the provided {@link ByteBuffer} until the
-   * buffer is fully filled or the end of the file is reached.
-   *
-   * @param buffer the {@link ByteBuffer} into which data will be read.
-   * @param channel the {@link FileChannel} from which data will be read.
-   * @throws IOException if an I/O error occurs during reading from the file channel.
-   */
-  private static void readChannelIntoBuffer(ByteBuffer buffer, FileChannel channel)
-      throws IOException {
-
-    while (buffer.remaining() > 0) {
-      int bytesRead = channel.read(buffer);
-      if (bytesRead == -1) {
-        break; // EOF
-      }
-    }
-  }
-
-  private class ModificationListener implements ProcessImage.ModificationListener {
-
-    private final ExecutionQueue modificationQueue = new ExecutionQueue(OpcUa.SHARED_EXECUTOR);
-
-    @Override
-    public void onCoilsModified(List<CoilModification> modifications) {
-      modificationQueue.submit(
-          () -> {
-            logger.trace("onCoilsModified: {}", modifications);
-
-            Path path =
-                device.deviceContext.getDeviceFolderPath().resolve("coils.bin").toAbsolutePath();
-
-            try (FileChannel channel = openFileChannel(path)) {
-              ByteBuffer buffer = ByteBuffer.allocate(1);
-
-              for (CoilModification m : modifications) {
-                buffer.clear();
-                buffer.put((byte) (m.value() ? 1 : 0));
-                buffer.flip();
-                channel.position(m.address());
-                int bytesWritten = channel.write(buffer);
-                if (bytesWritten != buffer.capacity()) {
-                  throw new IOException(
-                      "failed to write all bytes to coils.bin: wrote %s of %s"
-                          .formatted(bytesWritten, buffer.capacity()));
-                }
-              }
-            } catch (IOException e) {
-              logger.error("Error writing coils.bin", e);
-            }
-          });
-    }
-
-    @Override
-    public void onDiscreteInputsModified(List<DiscreteInputModification> modifications) {
-      modificationQueue.submit(
-          () -> {
-            logger.trace("onDiscreteInputsModified: {}", modifications);
-
-            Path path =
-                device
-                    .deviceContext
-                    .getDeviceFolderPath()
-                    .resolve("discreteInputs.bin")
-                    .toAbsolutePath();
-
-            try (FileChannel channel = openFileChannel(path)) {
-              ByteBuffer buffer = ByteBuffer.allocate(1);
-
-              for (DiscreteInputModification m : modifications) {
-                buffer.clear();
-                buffer.put((byte) (m.value() ? 1 : 0));
-                buffer.flip();
-                channel.position(m.address());
-                int bytesWritten = channel.write(buffer);
-                if (bytesWritten != buffer.capacity()) {
-                  throw new IOException(
-                      "failed to write all bytes to discreteInputs.bin: wrote %s of %s"
-                          .formatted(bytesWritten, buffer.capacity()));
-                }
-              }
-            } catch (IOException e) {
-              logger.error("Error writing discreteInputs.bin", e);
-            }
-          });
-    }
-
-    @Override
-    public void onHoldingRegistersModified(List<HoldingRegisterModification> modifications) {
-      modificationQueue.submit(
-          () -> {
-            logger.trace("onHoldingRegistersModified: {}", modifications);
-
-            Path path =
-                device
-                    .deviceContext
-                    .getDeviceFolderPath()
-                    .resolve("holdingRegisters.bin")
-                    .toAbsolutePath();
-
-            try (FileChannel channel = openFileChannel(path)) {
-              ByteBuffer buffer = ByteBuffer.allocate(2);
-
-              for (HoldingRegisterModification m : modifications) {
-                buffer.clear();
-                buffer.put(m.value()[0]);
-                buffer.put(m.value()[1]);
-                buffer.flip();
-                channel.position(m.address() * 2L);
-                int bytesWritten = channel.write(buffer);
-                if (bytesWritten != buffer.capacity()) {
-                  throw new IOException(
-                      "failed to write all bytes to holdingRegisters.bin: wrote %s of %s"
-                          .formatted(bytesWritten, buffer.capacity()));
-                }
-              }
-            } catch (IOException e) {
-              logger.error("Error writing holdingRegisters.bin", e);
-            }
-          });
-    }
-
-    @Override
-    public void onInputRegistersModified(List<InputRegisterModification> modifications) {
-      modificationQueue.submit(
-          () -> {
-            logger.trace("onInputRegistersModified: {}", modifications);
-
-            Path path =
-                device
-                    .deviceContext
-                    .getDeviceFolderPath()
-                    .resolve("inputRegisters.bin")
-                    .toAbsolutePath();
-
-            try (FileChannel channel = openFileChannel(path)) {
-              ByteBuffer buffer = ByteBuffer.allocate(2);
-
-              for (InputRegisterModification m : modifications) {
-                buffer.clear();
-                buffer.put(m.value()[0]);
-                buffer.put(m.value()[1]);
-                buffer.flip();
-                channel.position(m.address() * 2L);
-                int bytesWritten = channel.write(buffer);
-                if (bytesWritten != buffer.capacity()) {
-                  throw new IOException(
-                      "failed to write all bytes to inputRegisters.bin: wrote %s of %s"
-                          .formatted(bytesWritten, buffer.capacity()));
-                }
-              }
-            } catch (IOException e) {
-              logger.error("Error writing inputRegisters.bin", e);
-            }
-          });
-    }
-  }
-
-  // endregion
-
   private static class PendingRead {
 
     volatile DataValue value;
@@ -740,6 +530,10 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
   record ValueRead(ModbusAddress address, String indexRange) {}
 
   record ValueWrite(ModbusAddress address, Variant variant, String indexRange) {}
+
+  private record IndexedValueRead(int index, ValueRead read) {}
+
+  private record IndexedValueWrite(int index, ValueWrite write) {}
 
   private record PendingValueRead(PendingRead pending, ValueRead read) {}
 

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDevice.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDevice.java
@@ -58,7 +58,7 @@ public class ModbusServerDevice extends AddressSpaceComposite implements Device 
     processImageManager =
         new ProcessImageManager(
             deviceConfig.processImage().separatePerUnitId(),
-            deviceConfig.persistence().persistData(),
+            deviceConfig.processImage().persistData(),
             deviceContext.getDeviceFolderPath(),
             OpcUa.SHARED_EXECUTOR);
 

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDevice.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDevice.java
@@ -8,12 +8,24 @@ import com.digitalpetri.modbus.tcp.server.NettyTcpServerTransport;
 import com.inductiveautomation.ignition.gateway.opcua.server.api.Device;
 import com.inductiveautomation.ignition.gateway.opcua.server.api.DeviceContext;
 import com.inductiveautomation.ignition.gateway.opcua.server.api.OpcUa;
+import java.io.UncheckedIOException;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.eclipse.milo.opcua.sdk.server.AddressSpaceComposite;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Runs the Modbus TCP endpoint and OPC UA address spaces for one Ignition device configuration.
+ *
+ * <p>The Ignition device framework creates this type through {@link
+ * ModbusServerDeviceExtensionPoint} and owns its lifecycle. Construction prepares process-image
+ * routing and persistent state before the network endpoint can accept requests. {@link #startup()}
+ * then starts the Modbus server and registers the browse and variable address spaces.
+ *
+ * <p>{@link #shutdown()} must be allowed to complete so protocol requests stop before persistence
+ * listeners are detached and queued writes are drained. A shut-down instance is not reusable.
+ */
 public class ModbusServerDevice extends AddressSpaceComposite implements Device {
 
   final Logger logger = LoggerFactory.getLogger(getClass());
@@ -21,15 +33,8 @@ public class ModbusServerDevice extends AddressSpaceComposite implements Device 
   private ModbusTcpServer server;
   private volatile String status = "";
 
-  final ProcessImage processImage = new ProcessImage();
-
-  final ReadWriteModbusServices services =
-      new ReadWriteModbusServices() {
-        @Override
-        protected Optional<ProcessImage> getProcessImage(int unitId) {
-          return Optional.of(processImage);
-        }
-      };
+  final ProcessImageManager processImageManager;
+  final ReadWriteModbusServices services;
 
   private BrowsableAddressSpace browsableAddressSpace;
   private ModbusAddressSpace modbusAddressSpace;
@@ -37,12 +42,38 @@ public class ModbusServerDevice extends AddressSpaceComposite implements Device 
   final DeviceContext deviceContext;
   final ModbusServerDeviceConfig deviceConfig;
 
+  /**
+   * Creates an unstarted device from validated Ignition settings.
+   *
+   * @param deviceContext the Ignition runtime context that owns the device and its OPC UA nodes.
+   * @param deviceConfig the decoded connection, browsing, process-image, and persistence settings.
+   */
   public ModbusServerDevice(DeviceContext deviceContext, ModbusServerDeviceConfig deviceConfig) {
 
     super(deviceContext.getServer());
 
     this.deviceContext = deviceContext;
     this.deviceConfig = deviceConfig;
+
+    processImageManager =
+        new ProcessImageManager(
+            deviceConfig.processImage().separatePerUnitId(),
+            deviceConfig.persistence().persistData(),
+            deviceContext.getDeviceFolderPath(),
+            OpcUa.SHARED_EXECUTOR);
+
+    services =
+        new ReadWriteModbusServices() {
+          @Override
+          protected Optional<ProcessImage> getProcessImage(int unitId) {
+            try {
+              return Optional.of(processImageManager.get(unitId));
+            } catch (IllegalStateException | UncheckedIOException e) {
+              // Shutdown and lazy persistence failures make this unit temporarily unavailable.
+              return Optional.empty();
+            }
+          }
+        };
   }
 
   @Override
@@ -50,6 +81,13 @@ public class ModbusServerDevice extends AddressSpaceComposite implements Device 
     return status;
   }
 
+  /**
+   * Starts the configured Modbus TCP listener and registers both OPC UA address spaces.
+   *
+   * <p>If the listener cannot start, the device status becomes {@code Error} and the failure is
+   * logged. Any resources that started successfully are rolled back, and interruption is restored
+   * on the calling thread.
+   */
   @Override
   public void startup() {
     var transport =
@@ -85,31 +123,81 @@ public class ModbusServerDevice extends AddressSpaceComposite implements Device 
     } catch (ExecutionException e) {
       status = "Error";
       logger.error("Error starting Modbus server", e);
+      rollbackStartup();
     } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
       status = "Error";
       logger.error("Error starting Modbus server", e);
+      rollbackStartup();
+      Thread.currentThread().interrupt();
+    } catch (RuntimeException e) {
+      status = "Error";
+      logger.error("Error starting Modbus server device", e);
+      rollbackStartup();
     }
   }
 
+  private void rollbackStartup() {
+    shutdownAddressSpaces();
+    stopServer();
+    closeProcessImageManager();
+  }
+
+  /**
+   * Unregisters OPC UA address spaces, stops the Modbus listener, and closes process-image storage.
+   *
+   * <p>Closing storage removes modification listeners and waits for accepted persistence writes to
+   * finish. This method is idempotent, and interruption while stopping the server is restored on
+   * the calling thread.
+   */
   @Override
   public void shutdown() {
-    if (browsableAddressSpace != null) {
-      browsableAddressSpace.shutdown();
-    }
-    if (modbusAddressSpace != null) {
-      modbusAddressSpace.shutdown();
+    shutdownAddressSpaces();
+    stopServer();
+    closeProcessImageManager();
+  }
+
+  private void shutdownAddressSpaces() {
+    ModbusAddressSpace localModbusAddressSpace = modbusAddressSpace;
+    modbusAddressSpace = null;
+    if (localModbusAddressSpace != null) {
+      try {
+        localModbusAddressSpace.shutdown();
+      } catch (RuntimeException e) {
+        logger.error("Error shutting down Modbus address space", e);
+      }
     }
 
-    if (server != null) {
+    BrowsableAddressSpace localBrowsableAddressSpace = browsableAddressSpace;
+    browsableAddressSpace = null;
+    if (localBrowsableAddressSpace != null) {
       try {
-        server.stop();
+        localBrowsableAddressSpace.shutdown();
+      } catch (RuntimeException e) {
+        logger.error("Error shutting down browsable address space", e);
+      }
+    }
+  }
+
+  private void stopServer() {
+    ModbusTcpServer localServer = server;
+    server = null;
+    if (localServer != null) {
+      try {
+        localServer.stop();
       } catch (ExecutionException e) {
         logger.error("Error stopping Modbus server", e);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         logger.error("Error stopping Modbus server", e);
       }
+    }
+  }
+
+  private void closeProcessImageManager() {
+    try {
+      processImageManager.close();
+    } catch (RuntimeException e) {
+      logger.error("Error closing process image manager", e);
     }
   }
 }

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfig.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfig.java
@@ -4,26 +4,33 @@ import com.inductiveautomation.ignition.gateway.dataroutes.openapi.annotations.D
 import com.inductiveautomation.ignition.gateway.dataroutes.openapi.annotations.Description;
 import com.inductiveautomation.ignition.gateway.dataroutes.openapi.annotations.FormCategory;
 import com.inductiveautomation.ignition.gateway.dataroutes.openapi.annotations.FormField;
+import com.inductiveautomation.ignition.gateway.dataroutes.openapi.annotations.Hidden;
 import com.inductiveautomation.ignition.gateway.dataroutes.openapi.annotations.Label;
 import com.inductiveautomation.ignition.gateway.dataroutes.openapi.annotations.Required;
 import com.inductiveautomation.ignition.gateway.web.nav.FormFieldType;
 
 /**
- * Defines the connection, OPC UA browsing, process-image, and persistence settings for a Modbus
+ * Defines the versioned connection, OPC UA browsing, and process-image settings for a Modbus
  * server device.
  *
  * <p>The Ignition resource form uses the component annotations to build its schema. Decoders may
  * omit optional nested settings; the canonical constructor applies their documented defaults.
  */
 public record ModbusServerDeviceConfig(
+    @Hidden
+        @Description("The version of this settings document.")
+        @DefaultValue("2")
+        int configVersion,
     Connectivity connectivity,
     Browsing browsing,
-    ProcessImageSettings processImage,
-    Persistence persistence) {
+    ProcessImageSettings processImage) {
+
+  /** Current persisted settings format. */
+  public static final int CURRENT_CONFIG_VERSION = 2;
 
   /** Applies documented defaults to optional nested settings. */
   public ModbusServerDeviceConfig {
-    processImage = processImage == null ? new ProcessImageSettings(false) : processImage;
+    processImage = processImage == null ? new ProcessImageSettings(false, false) : processImage;
   }
 
   /** Identifies the local interface and TCP port used by the Modbus server. */
@@ -89,21 +96,18 @@ public record ModbusServerDeviceConfig(
     }
   }
 
-  /** Selects unified process-image state or independent state for each Modbus unit ID. */
+  /** Selects process-image routing and retention behavior. */
   public record ProcessImageSettings(
+      @FormCategory("PROCESS IMAGE")
+          @FormField(FormFieldType.CHECKBOX)
+          @Label("")
+          @Description("Whether to persist the process image data across restarts.")
+          @DefaultValue("false")
+          boolean persistData,
       @FormCategory("PROCESS IMAGE")
           @FormField(FormFieldType.CHECKBOX)
           @Label("")
           @Description("Whether to use a separate process image for each unit ID.")
           @DefaultValue("false")
           boolean separatePerUnitId) {}
-
-  /** Selects whether process-image values are retained across device lifecycles. */
-  public record Persistence(
-      @FormCategory("PERSISTENCE")
-          @FormField(FormFieldType.CHECKBOX)
-          @Label("")
-          @Description("Whether to persist the process image data across restarts.")
-          @DefaultValue("false")
-          boolean persistData) {}
 }

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfig.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfig.java
@@ -8,9 +8,25 @@ import com.inductiveautomation.ignition.gateway.dataroutes.openapi.annotations.L
 import com.inductiveautomation.ignition.gateway.dataroutes.openapi.annotations.Required;
 import com.inductiveautomation.ignition.gateway.web.nav.FormFieldType;
 
+/**
+ * Defines the connection, OPC UA browsing, process-image, and persistence settings for a Modbus
+ * server device.
+ *
+ * <p>The Ignition resource form uses the component annotations to build its schema. Decoders may
+ * omit optional nested settings; the canonical constructor applies their documented defaults.
+ */
 public record ModbusServerDeviceConfig(
-    Connectivity connectivity, Browsing browsing, Persistence persistence) {
+    Connectivity connectivity,
+    Browsing browsing,
+    ProcessImageSettings processImage,
+    Persistence persistence) {
 
+  /** Applies documented defaults to optional nested settings. */
+  public ModbusServerDeviceConfig {
+    processImage = processImage == null ? new ProcessImageSettings(false) : processImage;
+  }
+
+  /** Identifies the local interface and TCP port used by the Modbus server. */
   public record Connectivity(
       @FormCategory("CONNECTIVITY")
           @FormField(FormFieldType.TEXT)
@@ -27,6 +43,12 @@ public record ModbusServerDeviceConfig(
           @DefaultValue("502")
           int port) {}
 
+  /**
+   * Selects the Modbus addresses and unit folders exposed by OPC UA browsing.
+   *
+   * <p>Browse ranges control discovery only. Valid Modbus addresses and unit IDs remain directly
+   * addressable even when they are absent from these ranges.
+   */
   public record Browsing(
       @FormCategory("BROWSING")
           @FormField(FormFieldType.TEXT)
@@ -51,8 +73,32 @@ public record ModbusServerDeviceConfig(
           @Label("Input Register Ranges")
           @Description("The input register ranges to create browsable Nodes for.")
           @DefaultValue("")
-          String inputRegisterBrowseRanges) {}
+          String inputRegisterBrowseRanges,
+      @FormCategory("BROWSING")
+          @FormField(FormFieldType.TEXT)
+          @Label("Unit ID Browse Ranges")
+          @Description(
+              "The unit ID ranges to create browsable Nodes for when using separate process "
+                  + "images.")
+          @DefaultValue("0")
+          String unitIdBrowseRanges) {
 
+    /** Applies the unit-0 browse default while preserving an explicit empty selection. */
+    public Browsing {
+      unitIdBrowseRanges = unitIdBrowseRanges == null ? "0" : unitIdBrowseRanges;
+    }
+  }
+
+  /** Selects unified process-image state or independent state for each Modbus unit ID. */
+  public record ProcessImageSettings(
+      @FormCategory("PROCESS IMAGE")
+          @FormField(FormFieldType.CHECKBOX)
+          @Label("")
+          @Description("Whether to use a separate process image for each unit ID.")
+          @DefaultValue("false")
+          boolean separatePerUnitId) {}
+
+  /** Selects whether process-image values are retained across device lifecycles. */
   public record Persistence(
       @FormCategory("PERSISTENCE")
           @FormField(FormFieldType.CHECKBOX)

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfigUpgrader.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfigUpgrader.java
@@ -1,0 +1,112 @@
+package com.kevinherron.ignition.modbus;
+
+import com.inductiveautomation.ignition.common.gson.JsonElement;
+import com.inductiveautomation.ignition.common.gson.JsonObject;
+import com.inductiveautomation.ignition.gateway.config.JsonSettingsUpgrader;
+
+/** Upgrades persisted Modbus server device settings to the current JSON format. */
+final class ModbusServerDeviceConfigUpgrader implements JsonSettingsUpgrader {
+
+  static final ModbusServerDeviceConfigUpgrader INSTANCE =
+      new ModbusServerDeviceConfigUpgrader();
+
+  private static final int LEGACY_CONFIG_VERSION = 1;
+
+  private ModbusServerDeviceConfigUpgrader() {}
+
+  /**
+   * Upgrades a settings document without mutating the caller's JSON tree.
+   *
+   * <p>Version 1 settings have no {@code configVersion} property and store persistence under
+   * {@code persistence.persistData}. Version 2 co-locates persistence and per-unit routing under
+   * {@code processImage}.
+   *
+   * @param settings the persisted extension-point settings.
+   * @return settings in the current format.
+   * @throws IllegalArgumentException if the document is malformed or uses a newer version.
+   */
+  @Override
+  public JsonElement upgrade(JsonElement settings) {
+    if (!settings.isJsonObject()) {
+      throw new IllegalArgumentException("Modbus server device settings must be a JSON object");
+    }
+
+    JsonObject upgraded = settings.getAsJsonObject().deepCopy();
+    int version = configVersion(upgraded);
+
+    if (version > ModbusServerDeviceConfig.CURRENT_CONFIG_VERSION) {
+      throw new IllegalArgumentException(
+          "unsupported Modbus server device configVersion: " + version);
+    }
+    if (version < LEGACY_CONFIG_VERSION) {
+      throw new IllegalArgumentException(
+          "invalid Modbus server device configVersion: " + version);
+    }
+
+    if (version == LEGACY_CONFIG_VERSION) {
+      upgradeLegacySettings(upgraded);
+    }
+
+    return upgraded;
+  }
+
+  private static int configVersion(JsonObject settings) {
+    JsonElement version = settings.get("configVersion");
+    if (version == null || version.isJsonNull()) {
+      return LEGACY_CONFIG_VERSION;
+    }
+    if (!version.isJsonPrimitive() || !version.getAsJsonPrimitive().isNumber()) {
+      throw new IllegalArgumentException("configVersion must be an integer");
+    }
+
+    try {
+      return version.getAsBigDecimal().intValueExact();
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException("configVersion must be an integer", e);
+    }
+  }
+
+  private static void upgradeLegacySettings(JsonObject settings) {
+    JsonObject processImage = getOrCreateProcessImage(settings);
+    JsonObject persistence = getOptionalPersistence(settings);
+
+    if (!processImage.has("persistData")) {
+      JsonElement persistData = persistence == null ? null : persistence.get("persistData");
+      if (persistData != null && !persistData.isJsonNull()) {
+        processImage.add("persistData", persistData.deepCopy());
+      } else {
+        processImage.addProperty("persistData", false);
+      }
+    }
+
+    if (!processImage.has("separatePerUnitId")) {
+      processImage.addProperty("separatePerUnitId", false);
+    }
+
+    settings.add("processImage", processImage);
+    settings.remove("persistence");
+    settings.addProperty("configVersion", ModbusServerDeviceConfig.CURRENT_CONFIG_VERSION);
+  }
+
+  private static JsonObject getOrCreateProcessImage(JsonObject settings) {
+    JsonElement property = settings.get("processImage");
+    if (property == null || property.isJsonNull()) {
+      return new JsonObject();
+    }
+    if (!property.isJsonObject()) {
+      throw new IllegalArgumentException("processImage must be a JSON object");
+    }
+    return property.getAsJsonObject();
+  }
+
+  private static JsonObject getOptionalPersistence(JsonObject settings) {
+    JsonElement property = settings.get("persistence");
+    if (property == null || property.isJsonNull()) {
+      return null;
+    }
+    if (!property.isJsonObject()) {
+      throw new IllegalArgumentException("persistence must be a JSON object");
+    }
+    return property.getAsJsonObject();
+  }
+}

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceExtensionPoint.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceExtensionPoint.java
@@ -10,9 +10,16 @@ import com.inductiveautomation.ignition.gateway.web.nav.ExtensionPointResourceFo
 import com.inductiveautomation.ignition.gateway.web.nav.WebUiComponent;
 import java.util.Optional;
 
+/**
+ * Registers the Modbus server device type with Ignition and defines its configuration boundary.
+ *
+ * <p>The extension point supplies the web configuration schema, validates settings before device
+ * creation, and creates {@link ModbusServerDevice} instances for the Ignition device lifecycle.
+ */
 public class ModbusServerDeviceExtensionPoint
     extends DeviceExtensionPoint<ModbusServerDeviceConfig> {
 
+  /** Creates the extension point registered by the gateway module hook. */
   protected ModbusServerDeviceExtensionPoint() {
     super(
         "com.kevinherron.modbus-server-driver",
@@ -73,6 +80,32 @@ public class ModbusServerDeviceExtensionPoint
     } catch (Exception e) {
       errors.addFieldMessage("browsing.inputRegisterBrowseRanges", "invalid input register ranges");
     }
+
+    try {
+      validateUnitIdBrowseRanges(settings.browsing().unitIdBrowseRanges());
+    } catch (IllegalArgumentException e) {
+      errors.addFieldMessage("browsing.unitIdBrowseRanges", "invalid unit ID ranges");
+    }
+  }
+
+  /**
+   * Validates the grammar and bounds of unit IDs selected for OPC UA browsing.
+   *
+   * <p>An empty value is valid and selects no unit folders. Entries are comma-separated unit IDs
+   * or inclusive ranges, and every bound must be between 0 and 255. This setting affects browsing
+   * only; it is not a protocol allowlist.
+   *
+   * @param ranges the unit ID browse-range expression.
+   * @throws IllegalArgumentException if an entry is malformed, reversed, or out of range.
+   */
+  static void validateUnitIdBrowseRanges(String ranges) {
+    if (ranges == null || ranges.isEmpty()) {
+      return;
+    }
+
+    // Delegating to the runtime parser guarantees validation accepts exactly the expressions
+    // BrowsableAddressSpace accepts at device startup.
+    BrowsableAddressSpace.expandUnitIdRanges(ranges);
   }
 
   @Override

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceExtensionPoint.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceExtensionPoint.java
@@ -1,5 +1,6 @@
 package com.kevinherron.ignition.modbus;
 
+import com.inductiveautomation.ignition.gateway.config.JsonSettingsUpgrader;
 import com.inductiveautomation.ignition.gateway.config.ValidationErrors;
 import com.inductiveautomation.ignition.gateway.dataroutes.openapi.SchemaUtil;
 import com.inductiveautomation.ignition.gateway.opcua.server.api.Device;
@@ -35,6 +36,11 @@ public class ModbusServerDeviceExtensionPoint
       ModbusServerDeviceConfig deviceConfig) {
 
     return new ModbusServerDevice(deviceContext, deviceConfig);
+  }
+
+  @Override
+  public Optional<JsonSettingsUpgrader> getSettingsUpgrader() {
+    return Optional.of(ModbusServerDeviceConfigUpgrader.INSTANCE);
   }
 
   @Override

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerModuleHook.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerModuleHook.java
@@ -38,6 +38,8 @@ public class ModbusServerModuleHook extends AbstractDeviceModuleHook {
 
   @Override
   public List<IdbMigrationStrategy> getRecordMigrationStrategies() {
+    // Encode the retired persistent record as version 1 settings. The extension-point upgrader
+    // then gives database records, resource JSON, and backups one canonical migration path.
     @SuppressWarnings("deprecation")
     var strategy =
         ExtensionPointRecordMigrationStrategy.newBuilder("com.kevinherron.modbus-server-driver")

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ProcessImageManager.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ProcessImageManager.java
@@ -1,0 +1,143 @@
+package com.kevinherron.ignition.modbus;
+
+import com.digitalpetri.modbus.server.ProcessImage;
+import com.kevinherron.ignition.modbus.address.ModbusAddress;
+import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Resolves Modbus unit IDs and OPC UA addresses to the process images owned by one {@link
+ * ModbusServerDevice}.
+ *
+ * <p>Unified mode returns one shared image for every unit ID. Separate mode returns a stable,
+ * independent image for each valid unit ID and treats an unqualified OPC UA address as unit 0. An
+ * image is not returned until its configured persistent state is ready for use.
+ *
+ * <p>The owning device must call {@link #close()} after its address spaces and Modbus server have
+ * stopped. The manager cannot be used after it is closed.
+ */
+final class ProcessImageManager implements AutoCloseable {
+
+  private final boolean separatePerUnitId;
+  private final ProcessImagePersistence persistence;
+  private final ProcessImage unifiedImage;
+  private final ConcurrentHashMap<Integer, ProcessImage> unitImages = new ConcurrentHashMap<>();
+
+  // get() holds the read lock while it creates and returns images so that close(), which takes
+  // the write lock, cannot detach persistence while an image is being created or handed out.
+  private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+  private boolean closed;
+
+  /**
+   * Creates a manager for a device and prepares the unified image immediately when unified mode is
+   * selected.
+   *
+   * @param separatePerUnitId whether each unit ID has an independent process image.
+   * @param persistData whether process-image values are persisted across device lifecycles.
+   * @param deviceFolderPath the device data directory used for persistent files.
+   * @param executor the executor used for persistence writes.
+   */
+  ProcessImageManager(
+      boolean separatePerUnitId,
+      boolean persistData,
+      Path deviceFolderPath,
+      Executor executor) {
+
+    this(
+        separatePerUnitId,
+        new ProcessImagePersistence(
+            deviceFolderPath, persistData, separatePerUnitId, executor));
+  }
+
+  /**
+   * Creates a manager using an existing persistence lifecycle.
+   *
+   * @param separatePerUnitId whether each unit ID has an independent process image.
+   * @param persistence the persistence lifecycle owned by this manager.
+   */
+  ProcessImageManager(
+      boolean separatePerUnitId, ProcessImagePersistence persistence) {
+
+    this.separatePerUnitId = separatePerUnitId;
+    this.persistence = persistence;
+    unifiedImage = separatePerUnitId ? null : createProcessImage(0);
+  }
+
+  /**
+   * Returns the process image selected by a Modbus unit ID.
+   *
+   * @param unitId the unit ID from 0 through 255.
+   * @return the selected process image.
+   * @throws IllegalArgumentException if {@code unitId} is outside the valid Modbus range.
+   * @throws IllegalStateException if the manager has been closed.
+   */
+  ProcessImage get(int unitId) {
+    validateUnitId(unitId);
+    lock.readLock().lock();
+    try {
+      if (closed) {
+        throw new IllegalStateException("process image manager is closed");
+      }
+
+      return separatePerUnitId
+          ? unitImages.computeIfAbsent(unitId, this::createProcessImage)
+          : unifiedImage;
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  /**
+   * Returns the process image selected by an OPC UA Modbus address.
+   *
+   * @param address the parsed address; an absent unit ID selects unit 0.
+   * @return the selected process image.
+   * @throws NullPointerException if {@code address} is null.
+   * @throws IllegalStateException if the manager has been closed.
+   */
+  ProcessImage get(ModbusAddress address) {
+    return get(address.getUnitId().orElse(0));
+  }
+
+  private ProcessImage createProcessImage(int unitId) {
+    var processImage = new ProcessImage();
+    persistence.initialize(unitId, processImage);
+    return processImage;
+  }
+
+  /**
+   * Validates a Modbus unit ID.
+   *
+   * @param unitId the unit ID to validate.
+   * @throws IllegalArgumentException if {@code unitId} is outside 0 through 255.
+   */
+  static void validateUnitId(int unitId) {
+    if (unitId < 0 || unitId > 255) {
+      throw new IllegalArgumentException("unit ID must be between 0 and 255: " + unitId);
+    }
+  }
+
+  /**
+   * Stops persistence tracking and waits for previously accepted writes to finish.
+   *
+   * <p>This method is idempotent. It waits for in-flight {@link #get(int)} calls, and calls made
+   * after it returns fail with {@link IllegalStateException}.
+   */
+  @Override
+  public void close() {
+    lock.writeLock().lock();
+    try {
+      if (closed) {
+        return;
+      }
+      closed = true;
+    } finally {
+      lock.writeLock().unlock();
+    }
+
+    persistence.close();
+    unitImages.clear();
+  }
+}

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ProcessImagePersistence.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ProcessImagePersistence.java
@@ -1,0 +1,401 @@
+package com.kevinherron.ignition.modbus;
+
+import static com.digitalpetri.modbus.server.ProcessImage.Modification.CoilModification;
+import static com.digitalpetri.modbus.server.ProcessImage.Modification.DiscreteInputModification;
+import static com.digitalpetri.modbus.server.ProcessImage.Modification.HoldingRegisterModification;
+import static com.digitalpetri.modbus.server.ProcessImage.Modification.InputRegisterModification;
+
+import com.digitalpetri.modbus.server.ProcessImage;
+import com.digitalpetri.modbus.server.ProcessImage.ModificationListener;
+import com.digitalpetri.modbus.server.ProcessImage.Transaction;
+import com.inductiveautomation.ignition.common.util.ExecutionQueue;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Coordinates persistent process-image storage for one device lifecycle.
+ *
+ * <p>{@link ProcessImageManager} calls {@link #initialize(int, ProcessImage)} before publishing an
+ * image. Initialization restores all four Modbus areas synchronously, then begins tracking later
+ * modifications. Persistent writes are serialized and complete asynchronously from the process
+ * image transaction that produced them.
+ *
+ * <p>When persistence is disabled, initialization and shutdown have no filesystem side effects.
+ * Load and write failures are logged and leave the in-memory image available, but a storage
+ * directory that cannot be created fails initialization so a device is never published with
+ * silently broken persistence. The owner must call {@link #close()} to detach listeners and wait
+ * for accepted writes before releasing the device.
+ */
+final class ProcessImagePersistence implements AutoCloseable {
+
+  private static final Logger logger = LoggerFactory.getLogger(ProcessImagePersistence.class);
+
+  private static final int ADDRESS_COUNT = 65_536;
+  private static final int BOOLEAN_FILE_SIZE = ADDRESS_COUNT;
+  private static final int REGISTER_FILE_SIZE = ADDRESS_COUNT * 2;
+
+  private final Path deviceRoot;
+  private final boolean enabled;
+  private final boolean separatePerUnitId;
+  private final ExecutionQueue modificationQueue;
+  private final Object lifecycleLock = new Object();
+  private final List<ListenerRegistration> registrations = new ArrayList<>();
+
+  private boolean closed;
+
+  /**
+   * Creates a persistence lifecycle for unified or per-unit storage.
+   *
+   * @param deviceRoot the device data directory that owns persistent files.
+   * @param enabled whether persistence is active for this lifecycle.
+   * @param separatePerUnitId whether files are stored beneath unit-specific directories.
+   * @param executor the executor used for serialized persistence writes.
+   */
+  ProcessImagePersistence(
+      Path deviceRoot, boolean enabled, boolean separatePerUnitId, Executor executor) {
+
+    this.deviceRoot = deviceRoot.toAbsolutePath();
+    this.enabled = enabled;
+    this.separatePerUnitId = separatePerUnitId;
+    modificationQueue = new ExecutionQueue(executor);
+  }
+
+  /**
+   * Restores an image and starts tracking its subsequent modifications.
+   *
+   * <p>Call this once for an image before making that image available to protocol requests. When
+   * persistence is disabled, this method returns without creating directories, files, or
+   * listeners. It must not be called after {@link #close()}.
+   *
+   * @param unitId the validated unit ID associated with the image.
+   * @param processImage the image to restore and observe.
+   * @throws IllegalArgumentException if persistence is enabled and {@code unitId} is outside 0
+   *     through 255.
+   * @throws UncheckedIOException if the persistence directory cannot be created; the image must
+   *     not be published without its persistent state.
+   */
+  void initialize(int unitId, ProcessImage processImage) {
+    if (!enabled) {
+      return;
+    }
+    ProcessImageManager.validateUnitId(unitId);
+
+    Path directory = directoryFor(unitId);
+    try {
+      Files.createDirectories(directory);
+    } catch (IOException e) {
+      logFailure("create directory", unitId, "all areas", directory, e);
+      throw new UncheckedIOException(
+          "unable to create persistence directory: " + directory, e);
+    }
+
+    processImage.with(
+        tx -> {
+          loadBooleans(tx, unitId, "coils", directory.resolve("coils.bin"), true);
+          loadBooleans(
+              tx,
+              unitId,
+              "discrete inputs",
+              directory.resolve("discreteInputs.bin"),
+              false);
+          loadRegisters(
+              tx,
+              unitId,
+              "holding registers",
+              directory.resolve("holdingRegisters.bin"),
+              true);
+          loadRegisters(
+              tx,
+              unitId,
+              "input registers",
+              directory.resolve("inputRegisters.bin"),
+              false);
+        });
+
+    var listener = new PersistenceListener(unitId, directory);
+    synchronized (lifecycleLock) {
+      if (closed) {
+        return;
+      }
+      processImage.addModificationListener(listener);
+      registrations.add(new ListenerRegistration(processImage, listener));
+    }
+  }
+
+  private void loadBooleans(
+      Transaction tx, int unitId, String area, Path path, boolean coils) {
+
+    ByteBuffer values = readPersistedFile(unitId, area, path, BOOLEAN_FILE_SIZE);
+    if (values == null) {
+      return;
+    }
+
+    if (coils) {
+      tx.writeCoils(map -> putBooleans(map, values));
+    } else {
+      tx.writeDiscreteInputs(map -> putBooleans(map, values));
+    }
+  }
+
+  private void loadRegisters(
+      Transaction tx, int unitId, String area, Path path, boolean holdingRegisters) {
+
+    ByteBuffer values = readPersistedFile(unitId, area, path, REGISTER_FILE_SIZE);
+    if (values == null) {
+      return;
+    }
+
+    if (holdingRegisters) {
+      tx.writeHoldingRegisters(map -> putRegisters(map, values));
+    } else {
+      tx.writeInputRegisters(map -> putRegisters(map, values));
+    }
+  }
+
+  /**
+   * Reads a persisted area file, or returns {@code null} when nothing was ever persisted.
+   *
+   * <p>Files are created and sized on first write, not here, so probing unit IDs does not
+   * materialize storage for units that never persisted a value.
+   */
+  private ByteBuffer readPersistedFile(int unitId, String area, Path path, int size) {
+    if (Files.notExists(path)) {
+      return null;
+    }
+
+    try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
+      ByteBuffer values = ByteBuffer.allocate(size);
+      readFully(channel, values);
+      return values.flip();
+    } catch (IOException e) {
+      logFailure("load", unitId, area, path, e);
+      return null;
+    }
+  }
+
+  private static void putBooleans(Map<Integer, Boolean> map, ByteBuffer values) {
+    for (int address = 0; address < values.limit(); address++) {
+      if (values.get(address) != 0) {
+        map.put(address, true);
+      }
+    }
+  }
+
+  private static void putRegisters(Map<Integer, byte[]> map, ByteBuffer values) {
+    for (int index = 0; index + 1 < values.limit(); index += 2) {
+      byte high = values.get(index);
+      byte low = values.get(index + 1);
+      if (high != 0 || low != 0) {
+        map.put(index / 2, new byte[] {high, low});
+      }
+    }
+  }
+
+  private Path directoryFor(int unitId) {
+    return separatePerUnitId
+        ? deviceRoot.resolve("units").resolve(Integer.toString(unitId))
+        : deviceRoot;
+  }
+
+  private static FileChannel openSizedFile(Path path, int size) throws IOException {
+    FileChannel channel = openFile(path);
+    try {
+      long currentSize = channel.size();
+      if (currentSize > size) {
+        channel.truncate(size);
+      } else if (currentSize < size) {
+        channel.position(size - 1L);
+        writeFully(channel, ByteBuffer.wrap(new byte[] {0}));
+      }
+      channel.position(0);
+      return channel;
+    } catch (IOException e) {
+      channel.close();
+      throw e;
+    }
+  }
+
+  private static FileChannel openFile(Path path) throws IOException {
+    return FileChannel.open(
+        path, StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+  }
+
+  private static void readFully(FileChannel channel, ByteBuffer buffer) throws IOException {
+    while (buffer.hasRemaining()) {
+      if (channel.read(buffer) == -1) {
+        break;
+      }
+    }
+  }
+
+  private static void writeFully(FileChannel channel, ByteBuffer buffer) throws IOException {
+    while (buffer.hasRemaining()) {
+      if (channel.write(buffer) == 0) {
+        Thread.onSpinWait();
+      }
+    }
+  }
+
+  private void submit(Runnable task) {
+    synchronized (lifecycleLock) {
+      if (!closed) {
+        modificationQueue.submit(task);
+      }
+    }
+  }
+
+  private void logFailure(String operation, int unitId, String area, Path path, IOException e) {
+    logger.error(
+        "Process image persistence {} failed: mode={}, unitId={}, area={}, path={}",
+        operation,
+        separatePerUnitId ? "separate" : "unified",
+        unitId,
+        area,
+        path,
+        e);
+  }
+
+  /**
+   * Detaches all persistence listeners and waits for previously accepted writes to finish.
+   *
+   * <p>This method is idempotent. Images modified after it returns are not persisted by this
+   * lifecycle.
+   */
+  @Override
+  public void close() {
+    if (!enabled) {
+      return;
+    }
+
+    synchronized (lifecycleLock) {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      for (ListenerRegistration registration : registrations) {
+        registration.processImage().removeModificationListener(registration.listener());
+      }
+      registrations.clear();
+    }
+
+    try {
+      modificationQueue.runOrSubmit(() -> {}).join();
+    } catch (CompletionException e) {
+      logger.error("Error draining process image persistence queue", e.getCause());
+    }
+  }
+
+  private final class PersistenceListener implements ModificationListener {
+
+    private final int unitId;
+    private final Path directory;
+
+    private PersistenceListener(int unitId, Path directory) {
+      this.unitId = unitId;
+      this.directory = directory;
+    }
+
+    @Override
+    public void onCoilsModified(List<CoilModification> modifications) {
+      List<BooleanWrite> writes =
+          modifications.stream()
+              .map(modification -> new BooleanWrite(modification.address(), modification.value()))
+              .toList();
+      submit(() -> writeBooleans(unitId, "coils", directory.resolve("coils.bin"), writes));
+    }
+
+    @Override
+    public void onDiscreteInputsModified(List<DiscreteInputModification> modifications) {
+      List<BooleanWrite> writes =
+          modifications.stream()
+              .map(modification -> new BooleanWrite(modification.address(), modification.value()))
+              .toList();
+      submit(
+          () ->
+              writeBooleans(
+                  unitId,
+                  "discrete inputs",
+                  directory.resolve("discreteInputs.bin"),
+                  writes));
+    }
+
+    @Override
+    public void onHoldingRegistersModified(List<HoldingRegisterModification> modifications) {
+      List<RegisterWrite> writes =
+          modifications.stream()
+              .map(
+                  modification ->
+                      new RegisterWrite(modification.address(), modification.value().clone()))
+              .toList();
+      submit(
+          () ->
+              writeRegisters(
+                  unitId,
+                  "holding registers",
+                  directory.resolve("holdingRegisters.bin"),
+                  writes));
+    }
+
+    @Override
+    public void onInputRegistersModified(List<InputRegisterModification> modifications) {
+      List<RegisterWrite> writes =
+          modifications.stream()
+              .map(
+                  modification ->
+                      new RegisterWrite(modification.address(), modification.value().clone()))
+              .toList();
+      submit(
+          () ->
+              writeRegisters(
+                  unitId,
+                  "input registers",
+                  directory.resolve("inputRegisters.bin"),
+                  writes));
+    }
+  }
+
+  private void writeBooleans(
+      int unitId, String area, Path path, List<BooleanWrite> writes) {
+
+    try (FileChannel channel = openSizedFile(path, BOOLEAN_FILE_SIZE)) {
+      for (BooleanWrite write : writes) {
+        channel.position(write.address());
+        writeFully(channel, ByteBuffer.wrap(new byte[] {(byte) (write.value() ? 1 : 0)}));
+      }
+    } catch (IOException e) {
+      logFailure("write", unitId, area, path, e);
+    }
+  }
+
+  private void writeRegisters(
+      int unitId, String area, Path path, List<RegisterWrite> writes) {
+
+    try (FileChannel channel = openSizedFile(path, REGISTER_FILE_SIZE)) {
+      for (RegisterWrite write : writes) {
+        channel.position(write.address() * 2L);
+        writeFully(channel, ByteBuffer.wrap(write.value()));
+      }
+    } catch (IOException e) {
+      logFailure("write", unitId, area, path, e);
+    }
+  }
+
+  private record ListenerRegistration(
+      ProcessImage processImage, ModificationListener listener) {}
+
+  private record BooleanWrite(int address, boolean value) {}
+
+  private record RegisterWrite(int address, byte[] value) {}
+}

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/package-info.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/package-info.java
@@ -1,0 +1,36 @@
+/**
+ * Implements the Ignition gateway device that exposes Modbus process-image data through Modbus TCP
+ * and OPC UA.
+ *
+ * <h2>Data flow</h2>
+ *
+ * <p>{@link ModbusServerDeviceExtensionPoint} validates and decodes device settings, then creates a
+ * {@link ModbusServerDevice}. The device owns the Modbus TCP server and two OPC UA address spaces:
+ * {@link BrowsableAddressSpace} supplies the configured browse hierarchy, while {@link
+ * ModbusAddressSpace} resolves variable addresses and reads or writes process-image values.
+ *
+ * <p>Both protocol paths select images through {@link ProcessImageManager}. Unified mode maps every
+ * unit ID to one image. Separate mode maps each valid unit ID to an independent image, with
+ * unqualified OPC UA addresses selecting unit 0. Browse configuration controls discovery only; it
+ * does not restrict which unit IDs either protocol can address.
+ *
+ * <h2>Lifecycle and persistence</h2>
+ *
+ * <p>The device creates its process-image manager before accepting Modbus requests. An image is
+ * made available only after {@link ProcessImagePersistence} has synchronously restored its
+ * configured dataset and attached a modification listener. Shutdown unregisters the OPC UA address
+ * spaces, stops the Modbus server, removes persistence listeners, and waits for accepted
+ * persistence writes to finish.
+ *
+ * <p>Persistence failures are logged without making an otherwise valid unit unavailable. Unified
+ * and separate modes use independent storage layouts, so changing modes neither copies nor deletes
+ * process-image data.
+ *
+ * <h2>Validation and extension boundaries</h2>
+ *
+ * <p>Device-form validation belongs in the extension point. OPC UA address syntax belongs in the
+ * {@code address} subpackage, and value conversion belongs in {@link ModbusValueAccess}.
+ * Process-image selection, storage ownership, and shutdown coordination remain in this package so
+ * the Modbus and OPC UA paths share the same lifecycle and routing rules.
+ */
+package com.kevinherron.ignition.modbus;

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/BrowsableAddressSpaceTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/BrowsableAddressSpaceTest.java
@@ -1,0 +1,174 @@
+package com.kevinherron.ignition.modbus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.kevinherron.ignition.modbus.BrowsableAddressSpace.FolderDefinition;
+import com.kevinherron.ignition.modbus.BrowsableAddressSpace.Range;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class BrowsableAddressSpaceTest {
+
+  @Nested
+  class UnitIdRangeExpansion {
+
+    // Stable ordering and de-duplication keep the browse tree deterministic when users enter
+    // overlapping or out-of-order expressions.
+    @Test
+    void expandsUnitIdRangesInAscendingOrderWithoutDuplicates() {
+      assertEquals(
+          List.of(0, 2, 10, 11, 12, 255),
+          BrowsableAddressSpace.expandUnitIdRanges("10-12,2,11,0,255"));
+    }
+
+    @Test
+    void emptyUnitIdRangesProducesNoUnits() {
+      assertEquals(List.of(), BrowsableAddressSpace.expandUnitIdRanges(""));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"-1", "256", "2-1", "1,,2", "1, 2", "one", "1-2-3", " ", "2147483648"})
+    void invalidUnitIdRangesFailExpansion(String ranges) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> BrowsableAddressSpace.expandUnitIdRanges(ranges),
+          () -> "invalid range accepted: " + ranges);
+    }
+
+    @Test
+    void nullUnitIdRangesFailExpansion() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> BrowsableAddressSpace.expandUnitIdRanges(null));
+    }
+  }
+
+  @Nested
+  class FolderHierarchy {
+
+    // Unified mode is the compatibility default, so configured unit IDs must not alter its
+    // historical root folders or their identifiers.
+    @Test
+    void unifiedFolderDefinitionsRemainUnqualifiedAndAtTheRoot() {
+      assertEquals(
+          List.of(
+              folder("Coils", "", "Coils", "Coils"),
+              folder("DiscreteInputs", "", "DiscreteInputs", "DiscreteInputs"),
+              folder("HoldingRegisters", "", "HoldingRegisters", "HoldingRegisters"),
+              folder("InputRegisters", "", "InputRegisters", "InputRegisters")),
+          BrowsableAddressSpace.folderDefinitions(false, List.of(7)));
+    }
+
+    // Browse ranges control discovery only; the generated hierarchy must include exactly the
+    // configured, normalized units without creating duplicate folders.
+    @Test
+    void separateFolderDefinitionsContainOnlySortedConfiguredUnits() {
+      List<FolderDefinition> definitions =
+          BrowsableAddressSpace.folderDefinitions(true, List.of(2, 0, 2));
+
+      assertEquals(
+          List.of(
+              folder("Unit0", "", "Unit0", "Unit 0"),
+              folder("Unit0.Coils", "Unit0", "Coils", "Coils"),
+              folder("Unit0.DiscreteInputs", "Unit0", "DiscreteInputs", "DiscreteInputs"),
+              folder(
+                  "Unit0.HoldingRegisters",
+                  "Unit0",
+                  "HoldingRegisters",
+                  "HoldingRegisters"),
+              folder("Unit0.InputRegisters", "Unit0", "InputRegisters", "InputRegisters"),
+              folder("Unit2", "", "Unit2", "Unit 2"),
+              folder("Unit2.Coils", "Unit2", "Coils", "Coils"),
+              folder("Unit2.DiscreteInputs", "Unit2", "DiscreteInputs", "DiscreteInputs"),
+              folder(
+                  "Unit2.HoldingRegisters",
+                  "Unit2",
+                  "HoldingRegisters",
+                  "HoldingRegisters"),
+              folder("Unit2.InputRegisters", "Unit2", "InputRegisters", "InputRegisters")),
+          definitions);
+    }
+
+    @Test
+    void separateFolderDefinitionsAreEmptyWhenNoUnitsAreConfigured() {
+      assertEquals(List.of(), BrowsableAddressSpace.folderDefinitions(true, List.of()));
+    }
+  }
+
+  @Nested
+  class BrowseIdentifiers {
+
+    // Existing OPC UA clients rely on these unqualified NodeIds in unified mode.
+    @Test
+    void unifiedAreaBrowseIdentifiersRemainUnqualified() {
+      List<Range> ranges = List.of(new Range(0, 1));
+
+      assertEquals(
+          List.of("C0", "C1"), BrowsableAddressSpace.browseIdentifiers("C", ranges, null));
+      assertEquals(
+          List.of("_HR0_", "_HR1_"),
+          BrowsableAddressSpace.browseIdentifiers("HR", ranges, null));
+    }
+
+    // Separate-mode leaves remain directly addressable while register grouping nodes live under
+    // their unit folder in the browse hierarchy.
+    @Test
+    void separateAreaBrowseIdentifiersUseQualifiedLeavesAndGroupingNodes() {
+      List<Range> ranges = List.of(new Range(5, 6));
+
+      assertEquals(
+          List.of("7.C5", "7.C6"),
+          BrowsableAddressSpace.browseIdentifiers("C", ranges, 7));
+      assertEquals(
+          List.of("Unit7._HR5_", "Unit7._HR6_"),
+          BrowsableAddressSpace.browseIdentifiers("HR", ranges, 7));
+    }
+
+    @Test
+    void registerGroupingNodesExposeUnitQualifiedVariableIdentifiers() {
+      assertEquals(
+          List.of(
+              "1.HR<int16>4",
+              "1.HR<uint16>4",
+              "1.HR<int32>4",
+              "1.HR<uint32>4",
+              "1.HR<int64>4",
+              "1.HR<uint64>4",
+              "1.HR<float>4",
+              "1.HR<double>4"),
+          BrowsableAddressSpace.registerAddressIdentifiers("HR", 4, 1));
+    }
+
+    @Test
+    void identifierHelpersIncludeLegalUnitIdAndAddressBoundaries() {
+      assertEquals("Unit0", BrowsableAddressSpace.unitFolderIdentifier(0));
+      assertEquals(
+          "Unit255.InputRegisters",
+          BrowsableAddressSpace.areaFolderIdentifier(255, "InputRegisters"));
+      assertEquals(
+          "Unit255._IR65535_",
+          BrowsableAddressSpace.registerFolderIdentifier(255, "IR", 65535));
+      assertEquals("255.DI0", BrowsableAddressSpace.variableIdentifier(255, "DI0"));
+    }
+
+    @Test
+    void identifierHelpersRejectUnitIdsOutsideModbusBounds() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> BrowsableAddressSpace.unitFolderIdentifier(-1));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> BrowsableAddressSpace.variableIdentifier(256, "C0"));
+    }
+  }
+
+  private static FolderDefinition folder(
+      String identifier, String parentIdentifier, String browseName, String displayName) {
+    return new FolderDefinition(identifier, parentIdentifier, browseName, displayName);
+  }
+}

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
@@ -1,11 +1,19 @@
 package com.kevinherron.ignition.modbus;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.digitalpetri.modbus.server.ProcessImage;
 import com.kevinherron.ignition.modbus.address.ModbusAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddress.ArrayAddress;
 import com.kevinherron.ignition.modbus.address.ModbusAddressParser;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,12 +31,16 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class ModbusAddressSpaceTest {
+
+  @TempDir Path temporaryDirectory;
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("readBooleansArguments")
@@ -718,6 +730,224 @@ class ModbusAddressSpaceTest {
 
     assertEquals(2, statuses.size());
     assertTrue(statuses.stream().allMatch(status -> status != null && status.isGood()));
+  }
+
+  @Nested
+  class PerUnitRouting {
+
+    // Unified mode must retain its legacy aliasing semantics even when callers use the newly
+    // accepted unit-qualified OPC UA syntax.
+    @Test
+    void unifiedModeAliasesQualifiedAndUnqualifiedAddresses() throws Exception {
+      try (ProcessImageManager manager = processImageManager(false)) {
+        List<StatusCode> statuses =
+            ModbusAddressSpace.writeValueAttributes(
+                manager,
+                List.of(
+                    valueWrite("HR<int16>0", (short) 11, null),
+                    valueWrite("7.HR<int16>0", (short) 22, null)));
+
+        assertAllGood(2, statuses);
+
+        List<DataValue> values =
+            ModbusAddressSpace.readValueAttributes(
+                manager,
+                List.of(
+                    valueRead("HR<int16>0", null),
+                    valueRead("0.HR<int16>0", null),
+                    valueRead("7.HR<int16>0", null)));
+
+        assertEquals(List.of((short) 22, (short) 22, (short) 22), scalarValues(values));
+      }
+    }
+
+    // Unqualified addresses are the unit-0 alias in separate mode, while boundary unit 255 must
+    // remain independently addressable.
+    @Test
+    void separateModeMapsUnqualifiedAddressesToUnitZero() throws Exception {
+      try (ProcessImageManager manager = processImageManager(true)) {
+        List<StatusCode> statuses =
+            ModbusAddressSpace.writeValueAttributes(
+                manager,
+                List.of(
+                    valueWrite("HR<int16>0", (short) 10, null),
+                    valueWrite("1.HR<int16>0", (short) 20, null),
+                    valueWrite("255.HR<int16>0", (short) 30, null)));
+
+        assertAllGood(3, statuses);
+
+        List<DataValue> values =
+            ModbusAddressSpace.readValueAttributes(
+                manager,
+                List.of(
+                    valueRead("0.HR<int16>0", null),
+                    valueRead("HR<int16>0", null),
+                    valueRead("1.HR<int16>0", null),
+                    valueRead("255.HR<int16>0", null)));
+
+        assertEquals(
+            List.of((short) 10, (short) 10, (short) 20, (short) 30),
+            scalarValues(values));
+      }
+    }
+
+    // Internally grouping operations by image must not reorder per-item statuses or values at the
+    // OPC UA service boundary, including failures interleaved with successful operations.
+    @Test
+    void mixedUnitBatchPreservesRequestOrderForValuesAndStatuses() throws Exception {
+      try (ProcessImageManager manager = processImageManager(true)) {
+        List<StatusCode> statuses =
+            ModbusAddressSpace.writeValueAttributes(
+                manager,
+                List.of(
+                    valueWrite("1.C0", true, null),
+                    valueWrite("2.HR<int16>0", (short) 22, null),
+                    valueWrite("1.DI0", true, null),
+                    valueWrite("2.IR<int16>0", (short) 44, null),
+                    valueWrite("1.HR<int16>1", "not a short", null)));
+
+        assertEquals(5, statuses.size());
+        assertAllGood(4, statuses.subList(0, 4));
+        assertStatus(StatusCodes.Bad_TypeMismatch, statuses.get(4));
+
+        List<DataValue> values =
+            ModbusAddressSpace.readValueAttributes(
+                manager,
+                List.of(
+                    valueRead("2.IR<int16>0", null),
+                    valueRead("1.C0", null),
+                    valueRead("2.HR<int16>0", null),
+                    valueRead("1.DI0", null)));
+
+        assertEquals(List.of((short) 44, true, (short) 22, true), scalarValues(values));
+      }
+    }
+
+    // Sequential transactions may be split by unit, but writes targeting one image must still be
+    // applied in request order so the final value reflects the last write.
+    @Test
+    void mixedUnitWritesPreserveOrderWithinEachImage() throws Exception {
+      try (ProcessImageManager manager = processImageManager(true)) {
+        List<StatusCode> statuses =
+            ModbusAddressSpace.writeValueAttributes(
+                manager,
+                List.of(
+                    valueWrite("1.HR<int16>0", (short) 1, null),
+                    valueWrite("2.HR<int16>0", (short) 8, null),
+                    valueWrite("1.HR<int16>0", (short) 3, null)));
+
+        assertAllGood(3, statuses);
+        assertEquals(
+            List.of((short) 3, (short) 8),
+            scalarValues(
+                ModbusAddressSpace.readValueAttributes(
+                    manager,
+                    List.of(
+                        valueRead("1.HR<int16>0", null),
+                        valueRead("2.HR<int16>0", null)))));
+      }
+    }
+
+    // A storage failure for one lazily initialized unit must not abort unrelated items in the same
+    // OPC UA request. The failed unit remains unavailable rather than publishing an empty image.
+    @Test
+    void lazyPersistenceFailureReturnsPerItemInternalError() throws Exception {
+      Path deviceRoot = temporaryDirectory.resolve("device");
+      Files.createDirectories(deviceRoot.resolve("units"));
+      Files.createFile(deviceRoot.resolve("units/1"));
+
+      try (var manager = new ProcessImageManager(true, true, deviceRoot, Runnable::run)) {
+        List<StatusCode> statuses =
+            ModbusAddressSpace.writeValueAttributes(
+                manager,
+                List.of(
+                    valueWrite("1.HR<int16>0", (short) 11, null),
+                    valueWrite("2.HR<int16>0", (short) 22, null)));
+
+        assertStatus(StatusCodes.Bad_InternalError, statuses.get(0));
+        assertTrue(statuses.get(1).isGood());
+
+        List<DataValue> values =
+            ModbusAddressSpace.readValueAttributes(
+                manager,
+                List.of(
+                    valueRead("1.HR<int16>0", null),
+                    valueRead("2.HR<int16>0", null)));
+
+        assertStatus(StatusCodes.Bad_InternalError, values.get(0).getStatusCode());
+        assertEquals((short) 22, values.get(1).getValue().getValue());
+      }
+    }
+
+    @Test
+    void accessRacingManagerShutdownReturnsBadShutdown() throws Exception {
+      ProcessImageManager manager = processImageManager(true);
+      manager.close();
+
+      List<StatusCode> statuses =
+          ModbusAddressSpace.writeValueAttributes(
+              manager, List.of(valueWrite("1.HR<int16>0", (short) 11, null)));
+      List<DataValue> values =
+          ModbusAddressSpace.readValueAttributes(
+              manager, List.of(valueRead("1.HR<int16>0", null)));
+
+      assertStatus(StatusCodes.Bad_Shutdown, statuses.get(0));
+      assertStatus(StatusCodes.Bad_Shutdown, values.get(0).getStatusCode());
+    }
+
+    // Adding a unit qualifier must not bypass the existing OPC UA IndexRange semantics for array
+    // writes or overwrite array elements outside the requested range.
+    @Test
+    void unitQualifiedArrayWritesHonorIndexRange() throws Exception {
+      try (ProcessImageManager manager = processImageManager(true)) {
+        List<StatusCode> initialStatuses =
+            ModbusAddressSpace.writeValueAttributes(
+                manager,
+                List.of(valueWrite("1.HR<int16[4]>10", new Short[] {1, 2, 3, 4}, null)));
+        assertAllGood(1, initialStatuses);
+
+        List<StatusCode> statuses =
+            ModbusAddressSpace.writeValueAttributes(
+                manager,
+                List.of(valueWrite("1.HR<int16[4]>10", new Short[] {8, 9}, "1:2")));
+
+        assertAllGood(1, statuses);
+        Object value =
+            ModbusAddressSpace.readValueAttributes(
+                    manager, List.of(valueRead("1.HR<int16[4]>10", null)))
+                .get(0)
+                .getValue()
+                .getValue();
+        assertArrayEquals(new Short[] {1, 8, 9, 4}, (Short[]) value);
+      }
+    }
+  }
+
+  private static ProcessImageManager processImageManager(boolean separatePerUnitId) {
+    return new ProcessImageManager(
+        separatePerUnitId, false, Path.of("unused-process-image-test-data"), Runnable::run);
+  }
+
+  private static ModbusAddressSpace.ValueRead valueRead(String address, String indexRange)
+      throws Exception {
+    return new ModbusAddressSpace.ValueRead(ModbusAddressParser.parse(address), indexRange);
+  }
+
+  private static ModbusAddressSpace.ValueWrite valueWrite(
+      String address, Object value, String indexRange) throws Exception {
+    return new ModbusAddressSpace.ValueWrite(
+        ModbusAddressParser.parse(address), new Variant(value), indexRange);
+  }
+
+  private static List<Object> scalarValues(List<DataValue> values) {
+    return values.stream().map(value -> value.getValue().getValue()).toList();
+  }
+
+  private static void assertAllGood(int expectedCount, List<StatusCode> statuses) {
+    assertEquals(expectedCount, statuses.size(), "status count must match the request count");
+    assertTrue(
+        statuses.stream().allMatch(status -> status != null && status.isGood()),
+        () -> "expected all Good statuses but got " + statuses);
   }
 
   private static void writeValue(

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfigTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfigTest.java
@@ -1,0 +1,109 @@
+package com.kevinherron.ignition.modbus;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.inductiveautomation.ignition.common.gson.Gson;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ModbusServerDeviceConfigTest {
+
+  private static final Gson GSON = new Gson();
+
+  @Nested
+  class JsonCompatibility {
+
+    // Existing gateway backups omit both properties, so decoding them must retain the historical
+    // unified image and must not unexpectedly remove unit 0 from the browse tree.
+    @Test
+    void missingPropertiesUseCompatibilityDefaults() {
+      ModbusServerDeviceConfig config =
+          GSON.fromJson(
+              """
+              {
+                "connectivity": {"bindAddress": "0.0.0.0", "port": 502},
+                "browsing": {
+                  "coilBrowseRanges": "",
+                  "discreteInputBrowseRanges": "",
+                  "holdingRegisterBrowseRanges": "",
+                  "inputRegisterBrowseRanges": ""
+                },
+                "persistence": {"persistData": false}
+              }
+              """,
+              ModbusServerDeviceConfig.class);
+
+      assertFalse(config.processImage().separatePerUnitId());
+      assertEquals("0", config.browsing().unitIdBrowseRanges());
+    }
+
+    // Ignition persists this record as JSON, so both mode choices and the exact browse expression
+    // must survive serialization rather than falling back to constructor defaults.
+    @Test
+    void explicitProcessImageSettingsSurviveJsonRoundTrip() {
+      ModbusServerDeviceConfig separate = roundTrip(config(true, "0,2,10-15"));
+      ModbusServerDeviceConfig unified = roundTrip(config(false, "0"));
+
+      assertTrue(separate.processImage().separatePerUnitId());
+      assertFalse(unified.processImage().separatePerUnitId());
+      assertEquals("0,2,10-15", separate.browsing().unitIdBrowseRanges());
+    }
+
+    // An explicit empty expression means no unit folders; normalizing it to the default "0"
+    // would change the user's browse tree after a save and reload.
+    @Test
+    void explicitEmptyUnitIdBrowseRangesSurvivesJsonRoundTrip() {
+      ModbusServerDeviceConfig config = roundTrip(config(true, ""));
+
+      assertEquals("", config.browsing().unitIdBrowseRanges());
+      assertDoesNotThrow(
+          () ->
+              ModbusServerDeviceExtensionPoint.validateUnitIdBrowseRanges(
+                  config.browsing().unitIdBrowseRanges()));
+    }
+  }
+
+  @Nested
+  class UnitIdBrowseRangeValidation {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0", "255", "0,2,10-15", "0-255", "001-002"})
+    void validUnitIdBrowseRangesPassValidation(String ranges) {
+      assertDoesNotThrow(
+          () -> ModbusServerDeviceExtensionPoint.validateUnitIdBrowseRanges(ranges),
+          () -> "valid range rejected: " + ranges);
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+          "-1", "256", "2-1", "1-256", "1-", "-1-2", "1--2", "1,", ",1", "1,,2",
+          "1.0", "one", "1 2", " 1", "1 ", "+1", "999999999999999999999"
+        })
+    void invalidUnitIdBrowseRangesFailValidation(String ranges) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> ModbusServerDeviceExtensionPoint.validateUnitIdBrowseRanges(ranges),
+          () -> "invalid range accepted: " + ranges);
+    }
+  }
+
+  private static ModbusServerDeviceConfig config(
+      boolean separatePerUnitId, String unitIdBrowseRanges) {
+    return new ModbusServerDeviceConfig(
+        new ModbusServerDeviceConfig.Connectivity("0.0.0.0", 502),
+        new ModbusServerDeviceConfig.Browsing("", "", "", "", unitIdBrowseRanges),
+        new ModbusServerDeviceConfig.ProcessImageSettings(separatePerUnitId),
+        new ModbusServerDeviceConfig.Persistence(false));
+  }
+
+  private static ModbusServerDeviceConfig roundTrip(ModbusServerDeviceConfig config) {
+    return GSON.fromJson(GSON.toJson(config), ModbusServerDeviceConfig.class);
+  }
+}

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfigTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfigTest.java
@@ -3,10 +3,13 @@ package com.kevinherron.ignition.modbus;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.inductiveautomation.ignition.common.gson.Gson;
+import com.inductiveautomation.ignition.common.gson.JsonElement;
+import com.inductiveautomation.ignition.common.gson.JsonObject;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -15,32 +18,111 @@ import org.junit.jupiter.params.provider.ValueSource;
 class ModbusServerDeviceConfigTest {
 
   private static final Gson GSON = new Gson();
+  private static final ModbusServerDeviceExtensionPoint EXTENSION_POINT =
+      new ModbusServerDeviceExtensionPoint();
 
   @Nested
   class JsonCompatibility {
 
-    // Existing gateway backups omit both properties, so decoding them must retain the historical
-    // unified image and must not unexpectedly remove unit 0 from the browse tree.
+    // Existing gateway resources have no version and keep persistence in its own object.
     @Test
-    void missingPropertiesUseCompatibilityDefaults() {
+    void legacySettingsMovePersistenceIntoProcessImage() throws Exception {
+      ModbusServerDeviceConfig config = decode(legacySettings(true));
+
+      assertEquals(ModbusServerDeviceConfig.CURRENT_CONFIG_VERSION, config.configVersion());
+      assertTrue(config.processImage().persistData());
+      assertFalse(config.processImage().separatePerUnitId());
+      assertEquals("0", config.browsing().unitIdBrowseRanges());
+    }
+
+    @Test
+    void explicitVersionOneSettingsUseTheLegacyUpgradePath() throws Exception {
+      JsonObject settings = parse(legacySettings(true));
+      settings.addProperty("configVersion", 1);
+
+      ModbusServerDeviceConfig config = decode(settings.toString());
+
+      assertEquals(ModbusServerDeviceConfig.CURRENT_CONFIG_VERSION, config.configVersion());
+      assertTrue(config.processImage().persistData());
+      assertFalse(config.processImage().separatePerUnitId());
+    }
+
+    // Draft builds of the per-unit feature may have written both the old persistence object and
+    // the new process-image object. Upgrading that shape must retain both choices.
+    @Test
+    void intermediateSettingsPreservePerUnitMode() throws Exception {
       ModbusServerDeviceConfig config =
-          GSON.fromJson(
+          decode(
               """
               {
                 "connectivity": {"bindAddress": "0.0.0.0", "port": 502},
-                "browsing": {
-                  "coilBrowseRanges": "",
-                  "discreteInputBrowseRanges": "",
-                  "holdingRegisterBrowseRanges": "",
-                  "inputRegisterBrowseRanges": ""
-                },
-                "persistence": {"persistData": false}
+                "browsing": {},
+                "processImage": {"separatePerUnitId": true},
+                "persistence": {"persistData": true}
               }
-              """,
-              ModbusServerDeviceConfig.class);
+              """);
 
-      assertFalse(config.processImage().separatePerUnitId());
-      assertEquals("0", config.browsing().unitIdBrowseRanges());
+      assertTrue(config.processImage().persistData());
+      assertTrue(config.processImage().separatePerUnitId());
+    }
+
+    // The editable form omits configVersion, so its otherwise-current payload must be stamped
+    // without requiring the retired persistence object.
+    @Test
+    void versionlessCurrentSettingsFromFormAreStamped() throws Exception {
+      ModbusServerDeviceConfig config =
+          decode(
+              """
+              {
+                "connectivity": {"bindAddress": "0.0.0.0", "port": 502},
+                "browsing": {},
+                "processImage": {"persistData": true, "separatePerUnitId": true}
+              }
+              """);
+
+      assertEquals(ModbusServerDeviceConfig.CURRENT_CONFIG_VERSION, config.configVersion());
+      assertTrue(config.processImage().persistData());
+      assertTrue(config.processImage().separatePerUnitId());
+    }
+
+    // When a hand-written document contains both paths, the current location is authoritative.
+    @Test
+    void currentPersistenceValueWinsOverLegacyValue() throws Exception {
+      ModbusServerDeviceConfig config =
+          decode(
+              """
+              {
+                "connectivity": {"bindAddress": "0.0.0.0", "port": 502},
+                "browsing": {},
+                "processImage": {"persistData": false, "separatePerUnitId": true},
+                "persistence": {"persistData": true}
+              }
+              """);
+
+      assertFalse(config.processImage().persistData());
+      assertTrue(config.processImage().separatePerUnitId());
+    }
+
+    @Test
+    void upgradeDoesNotMutateInputAndIsIdempotent() {
+      JsonObject legacy = parse(legacySettings(false));
+
+      JsonObject upgraded = upgrade(legacy);
+
+      assertNotSame(legacy, upgraded);
+      assertTrue(legacy.has("persistence"));
+      assertFalse(legacy.has("configVersion"));
+      assertFalse(upgraded.has("persistence"));
+      assertFalse(upgraded.getAsJsonObject("processImage").get("persistData").getAsBoolean());
+      assertEquals(upgraded, upgrade(upgraded));
+    }
+
+    @Test
+    void futureVersionIsRejected() {
+      JsonObject settings = parse(legacySettings(false));
+      settings.addProperty("configVersion", ModbusServerDeviceConfig.CURRENT_CONFIG_VERSION + 1);
+
+      assertThrows(IllegalArgumentException.class, () -> upgrade(settings));
     }
 
     // Ignition persists this record as JSON, so both mode choices and the exact browse expression
@@ -53,6 +135,7 @@ class ModbusServerDeviceConfigTest {
       assertTrue(separate.processImage().separatePerUnitId());
       assertFalse(unified.processImage().separatePerUnitId());
       assertEquals("0,2,10-15", separate.browsing().unitIdBrowseRanges());
+      assertEquals(ModbusServerDeviceConfig.CURRENT_CONFIG_VERSION, separate.configVersion());
     }
 
     // An explicit empty expression means no unit folders; normalizing it to the default "0"
@@ -66,6 +149,37 @@ class ModbusServerDeviceConfigTest {
           () ->
               ModbusServerDeviceExtensionPoint.validateUnitIdBrowseRanges(
                   config.browsing().unitIdBrowseRanges()));
+    }
+
+    @Test
+    void encodedSettingsUseOnlyTheCurrentPublicShape() {
+      JsonObject encoded = EXTENSION_POINT.encode(config(true, "0")).getAsJsonObject();
+
+      assertEquals(
+          ModbusServerDeviceConfig.CURRENT_CONFIG_VERSION,
+          encoded.get("configVersion").getAsInt());
+      assertFalse(encoded.has("persistence"));
+      assertTrue(encoded.getAsJsonObject("processImage").has("persistData"));
+      assertTrue(encoded.getAsJsonObject("processImage").has("separatePerUnitId"));
+    }
+  }
+
+  @Nested
+  class SettingsSchema {
+
+    @Test
+    void settingsSchemaHidesVersionAndDocumentsProcessImageShape() {
+      JsonObject properties =
+          EXTENSION_POINT.settingsSchema().orElseThrow().getAsJsonObject("properties");
+      JsonObject processImageProperties =
+          properties.getAsJsonObject("processImage").getAsJsonObject("properties");
+
+      assertFalse(properties.has("configVersion"));
+      assertFalse(properties.has("persistence"));
+      assertTrue(processImageProperties.has("persistData"));
+      assertTrue(processImageProperties.has("separatePerUnitId"));
+      assertEquals("PROCESS IMAGE", formCategory(processImageProperties, "persistData"));
+      assertEquals("PROCESS IMAGE", formCategory(processImageProperties, "separatePerUnitId"));
     }
   }
 
@@ -97,13 +211,53 @@ class ModbusServerDeviceConfigTest {
   private static ModbusServerDeviceConfig config(
       boolean separatePerUnitId, String unitIdBrowseRanges) {
     return new ModbusServerDeviceConfig(
+        ModbusServerDeviceConfig.CURRENT_CONFIG_VERSION,
         new ModbusServerDeviceConfig.Connectivity("0.0.0.0", 502),
         new ModbusServerDeviceConfig.Browsing("", "", "", "", unitIdBrowseRanges),
-        new ModbusServerDeviceConfig.ProcessImageSettings(separatePerUnitId),
-        new ModbusServerDeviceConfig.Persistence(false));
+        new ModbusServerDeviceConfig.ProcessImageSettings(false, separatePerUnitId));
   }
 
   private static ModbusServerDeviceConfig roundTrip(ModbusServerDeviceConfig config) {
     return GSON.fromJson(GSON.toJson(config), ModbusServerDeviceConfig.class);
+  }
+
+  private static ModbusServerDeviceConfig decode(String json) throws Exception {
+    return EXTENSION_POINT.decode(upgrade(parse(json)));
+  }
+
+  private static JsonObject upgrade(JsonElement settings) {
+    return EXTENSION_POINT
+        .getSettingsUpgrader()
+        .orElseThrow()
+        .upgrade(settings)
+        .getAsJsonObject();
+  }
+
+  private static JsonObject parse(String json) {
+    return GSON.fromJson(json, JsonObject.class);
+  }
+
+  private static String legacySettings(boolean persistData) {
+    return """
+        {
+          "connectivity": {"bindAddress": "0.0.0.0", "port": 502},
+          "browsing": {
+            "coilBrowseRanges": "",
+            "discreteInputBrowseRanges": "",
+            "holdingRegisterBrowseRanges": "",
+            "inputRegisterBrowseRanges": ""
+          },
+          "persistence": {"persistData": %s}
+        }
+        """
+        .formatted(persistData);
+  }
+
+  private static String formCategory(JsonObject properties, String propertyName) {
+    return properties
+        .getAsJsonObject(propertyName)
+        .getAsJsonObject("x-form")
+        .get("category")
+        .getAsString();
   }
 }

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ProcessImageManagerTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ProcessImageManagerTest.java
@@ -1,0 +1,189 @@
+package com.kevinherron.ignition.modbus;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.digitalpetri.modbus.pdu.ReadHoldingRegistersRequest;
+import com.digitalpetri.modbus.pdu.WriteSingleRegisterRequest;
+import com.digitalpetri.modbus.server.ProcessImage;
+import com.digitalpetri.modbus.server.ReadWriteModbusServices;
+import com.kevinherron.ignition.modbus.address.ModbusAddressParser;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ProcessImageManagerTest {
+
+  @TempDir Path temporaryDirectory;
+
+  @Nested
+  class ImageSelection {
+
+    // Unified mode is the compatibility default, so every valid Modbus unit must continue to
+    // observe the same process image.
+    @Test
+    void unifiedModeReturnsOneImageForEveryUnit() {
+      try (var manager = manager(false)) {
+        ProcessImage image = manager.get(0);
+
+        assertSame(image, manager.get(1));
+        assertSame(image, manager.get(255));
+      }
+    }
+
+    @Test
+    void separateModeReturnsStableDistinctImages() {
+      try (var manager = manager(true)) {
+        ProcessImage unit0 = manager.get(0);
+        ProcessImage unit1 = manager.get(1);
+
+        assertSame(unit0, manager.get(0));
+        assertSame(unit1, manager.get(1));
+        assertNotSame(unit0, unit1);
+        assertNotSame(unit1, manager.get(255));
+      }
+    }
+
+    // Unqualified OPC UA addresses intentionally alias unit 0 rather than a separate implicit
+    // image, while an explicit prefix selects that unit's independent image.
+    @Test
+    void unqualifiedAddressSelectsUnitZeroInSeparateMode() throws Exception {
+      try (var manager = manager(true)) {
+        assertSame(manager.get(0), manager.get(ModbusAddressParser.parse("HR0")));
+        assertSame(manager.get(7), manager.get(ModbusAddressParser.parse("7.HR0")));
+        assertNotSame(
+            manager.get(ModbusAddressParser.parse("HR0")),
+            manager.get(ModbusAddressParser.parse("7.HR0")));
+      }
+    }
+
+    @Test
+    void unitIdsOutsideTheModbusRangeAreRejected() {
+      try (var manager = manager(true)) {
+        assertThrows(IllegalArgumentException.class, () -> manager.get(-1));
+        assertThrows(IllegalArgumentException.class, () -> manager.get(256));
+      }
+    }
+
+    // Concurrent lazy initialization must never expose competing images for the same unit; doing
+    // so would split protocol reads and writes depending on which caller won the race.
+    @Test
+    void concurrentFirstAccessPublishesOneImage() throws Exception {
+      try (var manager = manager(true)) {
+        int taskCount = 16;
+        ExecutorService executor = Executors.newFixedThreadPool(taskCount);
+        var ready = new CountDownLatch(taskCount);
+        var start = new CountDownLatch(1);
+        List<Future<ProcessImage>> futures = new ArrayList<>();
+
+        try {
+          for (int i = 0; i < taskCount; i++) {
+            futures.add(
+                executor.submit(
+                    () -> {
+                      ready.countDown();
+                      start.await();
+                      return manager.get(42);
+                    }));
+          }
+
+          assertTrue(
+              ready.await(5, TimeUnit.SECONDS),
+              "all workers must reach the start gate before testing concurrent access");
+          start.countDown();
+
+          ProcessImage expected = futures.get(0).get(5, TimeUnit.SECONDS);
+          for (Future<ProcessImage> future : futures) {
+            assertSame(expected, future.get(5, TimeUnit.SECONDS));
+          }
+        } finally {
+          executor.shutdownNow();
+        }
+      }
+    }
+  }
+
+  @Nested
+  class ProtocolRouting {
+
+    // This exercises the actual Modbus service boundary so a future device wiring change cannot
+    // bypass the manager and accidentally partition the default unified image.
+    @Test
+    void modbusServicesAliasUnitsInUnifiedMode() throws Exception {
+      try (var manager = manager(false)) {
+        ReadWriteModbusServices services = services(manager);
+
+        services.writeSingleRegister(null, 7, new WriteSingleRegisterRequest(3, 0x1234));
+
+        assertArrayEquals(
+            new byte[] {0x12, 0x34},
+            services
+                .readHoldingRegisters(null, 1, new ReadHoldingRegistersRequest(3, 1))
+                .registers());
+      }
+    }
+
+    // The baseline read from another unit proves isolation rather than merely confirming that the
+    // write reached its intended image.
+    @Test
+    void modbusServicesIsolateUnitsInSeparateMode() throws Exception {
+      try (var manager = manager(true)) {
+        ReadWriteModbusServices services = services(manager);
+
+        services.writeSingleRegister(null, 7, new WriteSingleRegisterRequest(3, 0x1234));
+
+        assertArrayEquals(
+            new byte[] {0x12, 0x34},
+            services
+                .readHoldingRegisters(null, 7, new ReadHoldingRegistersRequest(3, 1))
+                .registers());
+        assertArrayEquals(
+            new byte[] {0, 0},
+            services
+                .readHoldingRegisters(null, 1, new ReadHoldingRegistersRequest(3, 1))
+                .registers());
+      }
+    }
+  }
+
+  @Nested
+  class Lifecycle {
+
+    @Test
+    void accessAfterCloseIsRejected() {
+      ProcessImageManager manager = manager(false);
+      manager.close();
+
+      assertThrows(IllegalStateException.class, () -> manager.get(0));
+    }
+  }
+
+  private ProcessImageManager manager(boolean separatePerUnitId) {
+    return new ProcessImageManager(
+        separatePerUnitId,
+        false,
+        temporaryDirectory.resolve("device"),
+        Runnable::run);
+  }
+
+  private static ReadWriteModbusServices services(ProcessImageManager manager) {
+    return new ReadWriteModbusServices() {
+      @Override
+      protected Optional<ProcessImage> getProcessImage(int unitId) {
+        return Optional.of(manager.get(unitId));
+      }
+    };
+  }
+}

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ProcessImagePersistenceTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ProcessImagePersistenceTest.java
@@ -1,0 +1,315 @@
+package com.kevinherron.ignition.modbus;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.digitalpetri.modbus.server.ProcessImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ProcessImagePersistenceTest {
+
+  private static final int LAST_ADDRESS = 65_535;
+
+  @TempDir Path temporaryDirectory;
+
+  @Nested
+  class StorageLayout {
+
+    // Disabled persistence must be inert: creating its lifecycle may not leave empty directories,
+    // files, or listeners that begin writing later.
+    @Test
+    void disabledPersistenceCreatesNoFilesDirectoriesOrListeners() throws Exception {
+      Path deviceRoot = temporaryDirectory.resolve("disabled-device");
+      var image = new ProcessImage();
+      var persistence = new ProcessImagePersistence(deviceRoot, false, true, Runnable::run);
+
+      persistence.initialize(1, image);
+      writeAllAreas(image, 4, true, true, new byte[] {0x12, 0x34}, new byte[] {0x56, 0x78});
+      persistence.close();
+
+      assertFalse(Files.exists(deviceRoot));
+
+      writeAllAreas(image, 5, true, true, new byte[] {0x11, 0x22}, new byte[] {0x33, 0x44});
+      assertFalse(Files.exists(deviceRoot));
+    }
+
+    // Address 65,535 guards the upper-bound slot that was previously omitted from persisted
+    // files; the size assertions also protect compatibility with the established file layout.
+    @Test
+    void unifiedFilesRoundTripAllAreasIncludingLastAddress() throws Exception {
+      Path deviceRoot = temporaryDirectory.resolve("unified-device");
+      var image = new ProcessImage();
+
+      try (var persistence =
+          new ProcessImagePersistence(deviceRoot, true, false, Runnable::run)) {
+        persistence.initialize(0, image);
+        writeAllAreas(image, 10, true, true, new byte[] {0x12, 0x34}, new byte[] {0x56, 0x78});
+        writeAllAreas(
+            image,
+            LAST_ADDRESS,
+            true,
+            true,
+            new byte[] {(byte) 0x9A, (byte) 0xBC},
+            new byte[] {(byte) 0xDE, (byte) 0xF0});
+      }
+
+      assertEquals(65_536, Files.size(deviceRoot.resolve("coils.bin")));
+      assertEquals(65_536, Files.size(deviceRoot.resolve("discreteInputs.bin")));
+      assertEquals(131_072, Files.size(deviceRoot.resolve("holdingRegisters.bin")));
+      assertEquals(131_072, Files.size(deviceRoot.resolve("inputRegisters.bin")));
+      assertFalse(Files.exists(deviceRoot.resolve("units")));
+
+      var restored = new ProcessImage();
+      try (var persistence =
+          new ProcessImagePersistence(deviceRoot, true, false, Runnable::run)) {
+        persistence.initialize(0, restored);
+        assertAllAreas(
+            restored, 10, true, true, new byte[] {0x12, 0x34}, new byte[] {0x56, 0x78});
+        assertAllAreas(
+            restored,
+            LAST_ADDRESS,
+            true,
+            true,
+            new byte[] {(byte) 0x9A, (byte) 0xBC},
+            new byte[] {(byte) 0xDE, (byte) 0xF0});
+      }
+    }
+
+    // Identical addresses in different unit directories must restore independently; otherwise a
+    // restart would silently collapse the separate process images back into one dataset.
+    @Test
+    void separateFilesRoundTripAndIsolateTheSameOffsets() throws Exception {
+      Path deviceRoot = temporaryDirectory.resolve("separate-device");
+      var unit1 = new ProcessImage();
+      var unit2 = new ProcessImage();
+
+      try (var persistence =
+          new ProcessImagePersistence(deviceRoot, true, true, Runnable::run)) {
+        persistence.initialize(1, unit1);
+        persistence.initialize(2, unit2);
+        writeAllAreas(
+            unit1, 20, true, false, new byte[] {0x11, 0x11}, new byte[] {0x22, 0x22});
+        writeAllAreas(
+            unit2, 20, false, true, new byte[] {0x33, 0x33}, new byte[] {0x44, 0x44});
+      }
+
+      assertTrue(Files.exists(deviceRoot.resolve("units/1/coils.bin")));
+      assertTrue(Files.exists(deviceRoot.resolve("units/2/coils.bin")));
+      assertFalse(Files.exists(deviceRoot.resolve("coils.bin")));
+
+      var restoredUnit1 = new ProcessImage();
+      var restoredUnit2 = new ProcessImage();
+      try (var persistence =
+          new ProcessImagePersistence(deviceRoot, true, true, Runnable::run)) {
+        persistence.initialize(1, restoredUnit1);
+        persistence.initialize(2, restoredUnit2);
+        assertAllAreas(
+            restoredUnit1,
+            20,
+            true,
+            false,
+            new byte[] {0x11, 0x11},
+            new byte[] {0x22, 0x22});
+        assertAllAreas(
+            restoredUnit2,
+            20,
+            false,
+            true,
+            new byte[] {0x33, 0x33},
+            new byte[] {0x44, 0x44});
+      }
+    }
+
+    // Switching modes must select an independent storage layout without copying, deleting, or
+    // overwriting the last dataset saved by either mode.
+    @Test
+    void switchingModesPreservesIndependentDatasets() throws Exception {
+      Path deviceRoot = temporaryDirectory.resolve("mode-switch-device");
+
+      writeHoldingRegister(deviceRoot, false, 0, 0, new byte[] {0x11, 0x11});
+      writeHoldingRegister(deviceRoot, true, 0, 0, new byte[] {0x22, 0x22});
+
+      assertArrayEquals(
+          new byte[] {0x11, 0x11}, readHoldingRegister(deviceRoot, false, 0, 0));
+      assertArrayEquals(
+          new byte[] {0x22, 0x22}, readHoldingRegister(deviceRoot, true, 0, 0));
+
+      writeHoldingRegister(deviceRoot, false, 0, 1, new byte[] {0x33, 0x33});
+
+      assertArrayEquals(
+          new byte[] {0x22, 0x22}, readHoldingRegister(deviceRoot, true, 0, 0));
+      assertArrayEquals(
+          new byte[] {0x11, 0x11}, readHoldingRegister(deviceRoot, false, 0, 0));
+      assertArrayEquals(
+          new byte[] {0x33, 0x33}, readHoldingRegister(deviceRoot, false, 0, 1));
+    }
+  }
+
+  @Nested
+  class Lifecycle {
+
+    // close() is the durability boundary: it must wait for already accepted writes and detach
+    // listeners so later image changes cannot leak into the stopped device's files.
+    @Test
+    void closeDrainsQueuedWritesAndRemovesListeners() throws Exception {
+      Path deviceRoot = temporaryDirectory.resolve("drain-device");
+      ExecutorService persistenceExecutor = Executors.newSingleThreadExecutor();
+      ExecutorService closeExecutor = Executors.newSingleThreadExecutor();
+      var blockerStarted = new CountDownLatch(1);
+      var releaseBlocker = new CountDownLatch(1);
+      var closeStarted = new CountDownLatch(1);
+
+      persistenceExecutor.execute(
+          () -> {
+            blockerStarted.countDown();
+            await(releaseBlocker);
+          });
+      assertTrue(
+          blockerStarted.await(5, TimeUnit.SECONDS),
+          "the persistence executor must be blocked before a write is queued");
+
+      var image = new ProcessImage();
+      var persistence =
+          new ProcessImagePersistence(deviceRoot, true, false, persistenceExecutor);
+
+      try {
+        persistence.initialize(0, image);
+        writeHoldingRegister(image, 8, new byte[] {0x12, 0x34});
+
+        Future<?> closeFuture =
+            closeExecutor.submit(
+                () -> {
+                  closeStarted.countDown();
+                  persistence.close();
+                });
+        assertTrue(
+            closeStarted.await(5, TimeUnit.SECONDS),
+            "the close task must start before checking its drain behavior");
+        assertThrows(
+            TimeoutException.class,
+            () -> closeFuture.get(100, TimeUnit.MILLISECONDS),
+            "close must wait while a previously accepted persistence write is blocked");
+
+        releaseBlocker.countDown();
+        closeFuture.get(5, TimeUnit.SECONDS);
+
+        writeHoldingRegister(image, 8, new byte[] {0x56, 0x78});
+
+        assertArrayEquals(
+            new byte[] {0x12, 0x34}, readHoldingRegister(deviceRoot, false, 0, 8));
+      } finally {
+        releaseBlocker.countDown();
+        persistence.close();
+        closeExecutor.shutdownNow();
+        persistenceExecutor.shutdownNow();
+      }
+    }
+  }
+
+  private static void writeHoldingRegister(
+      Path deviceRoot,
+      boolean separatePerUnitId,
+      int unitId,
+      int address,
+      byte[] value) {
+
+    var image = new ProcessImage();
+    try (var persistence =
+        new ProcessImagePersistence(
+            deviceRoot, true, separatePerUnitId, Runnable::run)) {
+      persistence.initialize(unitId, image);
+      writeHoldingRegister(image, address, value);
+    }
+  }
+
+  private static void writeHoldingRegister(ProcessImage image, int address, byte[] value) {
+    image.with(tx -> tx.writeHoldingRegisters(map -> map.put(address, value)));
+  }
+
+  private static byte[] readHoldingRegister(
+      Path deviceRoot, boolean separatePerUnitId, int unitId, int address) {
+
+    var image = new ProcessImage();
+    try (var persistence =
+        new ProcessImagePersistence(
+            deviceRoot, true, separatePerUnitId, Runnable::run)) {
+      persistence.initialize(unitId, image);
+      return holdingRegister(image, address);
+    }
+  }
+
+  private static void writeAllAreas(
+      ProcessImage image,
+      int address,
+      boolean coil,
+      boolean discreteInput,
+      byte[] holdingRegister,
+      byte[] inputRegister) {
+
+    image.with(
+        tx -> {
+          tx.writeCoils(map -> map.put(address, coil));
+          tx.writeDiscreteInputs(map -> map.put(address, discreteInput));
+          tx.writeHoldingRegisters(map -> map.put(address, holdingRegister));
+          tx.writeInputRegisters(map -> map.put(address, inputRegister));
+        });
+  }
+
+  private static void assertAllAreas(
+      ProcessImage image,
+      int address,
+      boolean coil,
+      boolean discreteInput,
+      byte[] holdingRegister,
+      byte[] inputRegister) {
+
+    image.with(
+        tx -> {
+          assertEquals(coil, tx.readCoils(map -> map.getOrDefault(address, false)));
+          assertEquals(
+              discreteInput,
+              tx.readDiscreteInputs(map -> map.getOrDefault(address, false)));
+          assertArrayEquals(
+              holdingRegister,
+              tx.readHoldingRegisters(map -> map.getOrDefault(address, new byte[2])));
+          assertArrayEquals(
+              inputRegister,
+              tx.readInputRegisters(map -> map.getOrDefault(address, new byte[2])));
+        });
+  }
+
+  private static byte[] holdingRegister(ProcessImage image, int address) {
+    return image.get(
+        tx ->
+            tx.readHoldingRegisters(
+                map -> map.getOrDefault(address, new byte[2]).clone()));
+  }
+
+  private static void await(CountDownLatch latch) {
+    boolean interrupted = false;
+    while (true) {
+      try {
+        latch.await();
+        break;
+      } catch (InterruptedException e) {
+        interrupted = true;
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.release>17</maven.compiler.release>
 
     <!-- Dependencies -->
-    <ignition-sdk.version>8.3.0</ignition-sdk.version>
+    <ignition-sdk.version>8.3.3</ignition-sdk.version>
     <modbus.version>2.1.5</modbus.version>
 
     <!-- Test Dependencies -->


### PR DESCRIPTION
This adds optional per-unit process images for deployments that represent multiple independent Modbus units through one server device. When enabled, each unit ID has its own coils, discrete inputs, holding registers, and input registers.

The existing unified process image remains the default, preserving the current behavior where all unit IDs share the same data.

## What changed

- Route Modbus reads and writes to the process image for the requested unit ID.
- Support unit-qualified OPC UA addresses such as `7.HR<int16>0`.
- Treat addresses without a unit ID as unit 0 when separate mode is enabled.
- Add configurable unit folders to the OPC UA browse tree.
- Store persisted per-unit data under `units/<unitId>/`.
- Keep unified and per-unit persisted datasets independent when switching modes.
- Document the configuration, address syntax, browsing behavior, and persistence layout.
