### PR TITLE
Set up mise and Google Java Format

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+java = "temurin-17.0.19+10"
+maven = "3.9.16"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ Modbus clients can read or write as expected using any of the standard Modbus fu
 OPC UA clients can additionally write to Discrete Input and Input Register areas, which are
 read-only from Modbus clients.
 
+## Development
+
+The repository pins its Java and Maven toolchain with `mise`:
+
+```shell
+mise install
+```
+
+Run the full build through the pinned toolchain:
+
+```shell
+mise exec -- mvn clean verify
+```
+
+Apply Google Java Format with Spotless:
+
+```shell
+mise exec -- mvn spotless:apply
+```
+
 ## Connection Security
 
 The per-device `security.allowedIpAddresses` setting, labeled **Allowed IP Addresses** in the

--- a/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/ArrayModbusToOpcUaIT.java
+++ b/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/ArrayModbusToOpcUaIT.java
@@ -156,8 +156,8 @@ public class ArrayModbusToOpcUaIT {
     // changing its Java element type or declared shape.
     @ParameterizedTest(name = "{0}")
     @MethodSource("registerArrayCases")
-    void registerArrayValuesRoundTripForEverySupportedAreaTypeAndRank(
-        RegisterArrayCase testCase) throws Exception {
+    void registerArrayValuesRoundTripForEverySupportedAreaTypeAndRank(RegisterArrayCase testCase)
+        throws Exception {
 
       NodeId nodeId = nodeId(testCase.address());
 
@@ -175,8 +175,7 @@ public class ArrayModbusToOpcUaIT {
     @MethodSource("arrayMetadataCases")
     void arrayNodesExposeTheirDeclaredMetadata(ArrayMetadataCase testCase) throws Exception {
 
-      assertArrayMetadata(
-          nodeId(testCase.address()), testCase.dataType(), testCase.dimensions());
+      assertArrayMetadata(nodeId(testCase.address()), testCase.dataType(), testCase.dimensions());
     }
 
     // Boolean arrays use a bit-oriented Modbus representation but must retain their OPC UA rank
@@ -279,13 +278,11 @@ public class ArrayModbusToOpcUaIT {
       Boolean[] expected = {true, false, true, true, false, true};
 
       modbusClient.writeMultipleCoils(
-          0,
-          new WriteMultipleCoilsRequest(ARRAY_OFFSET, expected.length, packBooleans(expected)));
+          0, new WriteMultipleCoilsRequest(ARRAY_OFFSET, expected.length, packBooleans(expected)));
 
       assertArrayEquals(
           expected,
-          (Boolean[])
-              readValue(nodeId("C<bool[6]>" + ARRAY_OFFSET)).getValue().getValue());
+          (Boolean[]) readValue(nodeId("C<bool[6]>" + ARRAY_OFFSET)).getValue().getValue());
     }
 
     // A direct Modbus register write must be decoded into the declared OPC UA scalar element type.
@@ -294,14 +291,11 @@ public class ArrayModbusToOpcUaIT {
       byte[] registers = hex("1234 FEDC 0001");
 
       modbusClient.writeMultipleRegisters(
-          0,
-          new WriteMultipleRegistersRequest(
-              ARRAY_OFFSET, registers.length / 2, registers));
+          0, new WriteMultipleRegistersRequest(ARRAY_OFFSET, registers.length / 2, registers));
 
       assertArrayEquals(
           new Short[] {(short) 0x1234, (short) 0xFEDC, (short) 1},
-          (Short[])
-              readValue(nodeId("HR<int16[3]>" + ARRAY_OFFSET)).getValue().getValue());
+          (Short[]) readValue(nodeId("HR<int16[3]>" + ARRAY_OFFSET)).getValue().getValue());
     }
 
     // Multi-dimensional OPC UA values are flattened on the Modbus wire but must be reconstructed
@@ -311,9 +305,7 @@ public class ArrayModbusToOpcUaIT {
       byte[] registers = hex("00000001 00000002 00000003 00000004");
 
       modbusClient.writeMultipleRegisters(
-          0,
-          new WriteMultipleRegistersRequest(
-              ARRAY_OFFSET, registers.length / 2, registers));
+          0, new WriteMultipleRegistersRequest(ARRAY_OFFSET, registers.length / 2, registers));
 
       Matrix matrix =
           assertInstanceOf(
@@ -350,9 +342,7 @@ public class ArrayModbusToOpcUaIT {
       String address = "HR<int32[2][3]>" + ARRAY_OFFSET;
       Integer[] initial = {10, 20, 30, 40, 50, 60};
       assertGood(
-          writeValue(
-              nodeId(address),
-              new Matrix(initial, new int[] {2, 3}, OpcUaDataType.Int32)));
+          writeValue(nodeId(address), new Matrix(initial, new int[] {2, 3}, OpcUaDataType.Int32)));
 
       assertEquals(60, readValue(nodeId(address + "[1][2]")).getValue().getValue());
     }
@@ -364,9 +354,7 @@ public class ArrayModbusToOpcUaIT {
       String address = "HR<int32[2][3]>" + ARRAY_OFFSET;
       Integer[] initial = {10, 20, 30, 40, 50, 60};
       assertGood(
-          writeValue(
-              nodeId(address),
-              new Matrix(initial, new int[] {2, 3}, OpcUaDataType.Int32)));
+          writeValue(nodeId(address), new Matrix(initial, new int[] {2, 3}, OpcUaDataType.Int32)));
 
       assertGood(writeValue(nodeId(address + "[1][2]"), 99));
 
@@ -375,18 +363,15 @@ public class ArrayModbusToOpcUaIT {
       assertNotNull(fullValue);
       Object elements = fullValue.getElements();
       assertNotNull(elements);
-      assertArrayEquals(
-          new Integer[] {10, 20, 30, 40, 50, 99}, (Integer[]) elements);
-      assertArrayEquals(
-          hex("00000063"), readRegisters("HR", ARRAY_OFFSET + (5 * 2), 2));
+      assertArrayEquals(new Integer[] {10, 20, 30, 40, 50, 99}, (Integer[]) elements);
+      assertArrayEquals(hex("00000063"), readRegisters("HR", ARRAY_OFFSET + (5 * 2), 2));
     }
 
     // OPC UA Part 3 §5.6.2 requires a selected element node to advertise scalar metadata even
     // when its parent Variable is an array or matrix.
     @ParameterizedTest(name = "{0}")
     @MethodSource("indexedMetadataCases")
-    void indexedElementNodesExposeScalarMetadata(IndexedMetadataCase testCase)
-        throws Exception {
+    void indexedElementNodesExposeScalarMetadata(IndexedMetadataCase testCase) throws Exception {
 
       assertScalarMetadata(nodeId(testCase.address()), testCase.dataType());
     }
@@ -403,8 +388,7 @@ public class ArrayModbusToOpcUaIT {
 
       assertEquals(Boolean.TRUE, readValue(bitNode).getValue().getValue());
       assertArrayEquals(
-          new Short[] {0, 32},
-          (Short[]) readValue(nodeId(address)).getValue().getValue());
+          new Short[] {0, 32}, (Short[]) readValue(nodeId(address)).getValue().getValue());
     }
 
     // Three-dimensional Boolean indexes must flatten in row-major order before selecting the
@@ -416,8 +400,7 @@ public class ArrayModbusToOpcUaIT {
       Arrays.fill(initial, false);
       assertGood(
           writeValue(
-              nodeId(address),
-              new Matrix(initial, new int[] {2, 2, 2}, OpcUaDataType.Boolean)));
+              nodeId(address), new Matrix(initial, new int[] {2, 2, 2}, OpcUaDataType.Boolean)));
 
       NodeId indexedNode = nodeId(address + "[1][0][1]");
       assertGood(writeValue(indexedNode, true));
@@ -453,8 +436,8 @@ public class ArrayModbusToOpcUaIT {
     // elements while preserving every element outside the range.
     @ParameterizedTest(name = "{0}")
     @MethodSource("oneDimensionalRangeCases")
-    void oneDimensionalRangeWritesPreserveUnselectedElements(
-        OneDimensionalRangeCase testCase) throws Exception {
+    void oneDimensionalRangeWritesPreserveUnselectedElements(OneDimensionalRangeCase testCase)
+        throws Exception {
 
       NodeId nodeId = nodeId(testCase.address());
       assertGood(writeValue(nodeId, testCase.initial()));
@@ -464,16 +447,15 @@ public class ArrayModbusToOpcUaIT {
       assertArrayEquals(
           (Object[]) testCase.expectedFullValue(),
           (Object[]) readValue(nodeId).getValue().getValue());
-      assertArrayEquals(
-          testCase.expectedModbusValue(), readModbusArray(testCase.address(), 6));
+      assertArrayEquals(testCase.expectedModbusValue(), readModbusArray(testCase.address(), 6));
     }
 
     // OPC UA Part 4 §7.27 defines one NumericRange component per matrix dimension; the returned
     // Matrix must retain the dimensions of the selected block.
     @ParameterizedTest(name = "{0}")
     @MethodSource("twoDimensionalRangeCases")
-    void twoDimensionalRangeReadsPreserveTheSelectedShape(
-        TwoDimensionalRangeCase testCase) throws Exception {
+    void twoDimensionalRangeReadsPreserveTheSelectedShape(TwoDimensionalRangeCase testCase)
+        throws Exception {
 
       NodeId nodeId = nodeId(testCase.address());
       assertGood(
@@ -490,36 +472,31 @@ public class ArrayModbusToOpcUaIT {
       assertNotNull(dimensions);
       assertNotNull(elements);
       assertArrayEquals(new int[] {2, 2}, dimensions);
-      assertArrayEquals(
-          (Object[]) testCase.expectedSliceElements(), (Object[]) elements);
+      assertArrayEquals((Object[]) testCase.expectedSliceElements(), (Object[]) elements);
     }
 
     // A matrix range write must map each update coordinate into the full row-major matrix without
     // overwriting values outside the selected block.
     @ParameterizedTest(name = "{0}")
     @MethodSource("twoDimensionalRangeCases")
-    void twoDimensionalRangeWritesPreserveUnselectedElements(
-        TwoDimensionalRangeCase testCase) throws Exception {
+    void twoDimensionalRangeWritesPreserveUnselectedElements(TwoDimensionalRangeCase testCase)
+        throws Exception {
 
       NodeId nodeId = nodeId(testCase.address());
       assertGood(
           writeValue(
               nodeId,
               new Matrix(testCase.initialElements(), new int[] {3, 3}, testCase.dataType())));
-      Matrix update =
-          new Matrix(testCase.updateElements(), new int[] {2, 2}, testCase.dataType());
+      Matrix update = new Matrix(testCase.updateElements(), new int[] {2, 2}, testCase.dataType());
 
       assertGood(writeValue(nodeId, "0:1,1:2", update));
 
-      Matrix fullValue =
-          assertInstanceOf(Matrix.class, readValue(nodeId).getValue().getValue());
+      Matrix fullValue = assertInstanceOf(Matrix.class, readValue(nodeId).getValue().getValue());
       assertNotNull(fullValue);
       Object elements = fullValue.getElements();
       assertNotNull(elements);
-      assertArrayEquals(
-          (Object[]) testCase.expectedFullElements(), (Object[]) elements);
-      assertArrayEquals(
-          testCase.expectedModbusValue(), readModbusArray(testCase.address(), 9));
+      assertArrayEquals((Object[]) testCase.expectedFullElements(), (Object[]) elements);
+      assertArrayEquals(testCase.expectedModbusValue(), readModbusArray(testCase.address(), 9));
     }
 
     // A three-dimensional NumericRange proves that range coordinates are not accidentally handled
@@ -532,13 +509,10 @@ public class ArrayModbusToOpcUaIT {
           writeValue(
               nodeId,
               new Matrix(
-                  shorts(0, 1, 2, 3, 4, 5, 6, 7),
-                  new int[] {2, 2, 2},
-                  OpcUaDataType.Int16)));
+                  shorts(0, 1, 2, 3, 4, 5, 6, 7), new int[] {2, 2, 2}, OpcUaDataType.Int16)));
 
       Matrix slice =
-          assertInstanceOf(
-              Matrix.class, readValue(nodeId, "0:1,1,0:1").getValue().getValue());
+          assertInstanceOf(Matrix.class, readValue(nodeId, "0:1,1,0:1").getValue().getValue());
 
       assertNotNull(slice);
       int[] dimensions = slice.getDimensions();
@@ -558,21 +532,16 @@ public class ArrayModbusToOpcUaIT {
           writeValue(
               nodeId,
               new Matrix(
-                  shorts(0, 1, 2, 3, 4, 5, 6, 7),
-                  new int[] {2, 2, 2},
-                  OpcUaDataType.Int16)));
-      Matrix update =
-          new Matrix(shorts(50, 70), new int[] {1, 2, 1}, OpcUaDataType.Int16);
+                  shorts(0, 1, 2, 3, 4, 5, 6, 7), new int[] {2, 2, 2}, OpcUaDataType.Int16)));
+      Matrix update = new Matrix(shorts(50, 70), new int[] {1, 2, 1}, OpcUaDataType.Int16);
 
       assertGood(writeValue(nodeId, "1,0:1,1", update));
 
-      Matrix fullValue =
-          assertInstanceOf(Matrix.class, readValue(nodeId).getValue().getValue());
+      Matrix fullValue = assertInstanceOf(Matrix.class, readValue(nodeId).getValue().getValue());
       assertNotNull(fullValue);
       Object elements = fullValue.getElements();
       assertNotNull(elements);
-      assertArrayEquals(
-          shorts(0, 1, 2, 3, 4, 50, 6, 70), (Short[]) elements);
+      assertArrayEquals(shorts(0, 1, 2, 3, 4, 50, 6, 70), (Short[]) elements);
     }
 
     // OPC UA Part 4 §7.27 treats a String NumericRange as a substring selection.
@@ -606,9 +575,7 @@ public class ArrayModbusToOpcUaIT {
       NodeId nodeId = nodeId(area + "<string10>" + ARRAY_OFFSET);
       assertGood(writeValue(nodeId, "HELLOWORLD"));
 
-      assertStatus(
-          StatusCodes.Bad_IndexRangeDataMismatch,
-          writeValue(nodeId, "0:4", "NO"));
+      assertStatus(StatusCodes.Bad_IndexRangeDataMismatch, writeValue(nodeId, "0:4", "NO"));
       assertEquals("HELLOWORLD", readValue(nodeId).getValue().getValue());
     }
 
@@ -621,16 +588,14 @@ public class ArrayModbusToOpcUaIT {
       assertGood(writeValue(nodeId, new String[] {"alpha", "beta", "gamma", "delta"}));
 
       assertArrayEquals(
-          new String[] {"bet"},
-          (String[]) readValue(nodeId, "1,0:2").getValue().getValue());
+          new String[] {"bet"}, (String[]) readValue(nodeId, "1,0:2").getValue().getValue());
     }
 
     // A String-array range write must preserve both unselected array elements and unselected
     // characters in the selected element.
     @ParameterizedTest(name = "{0} String array write")
     @MethodSource("registerAreas")
-    void stringArrayRangeWritesPreserveUnselectedValuesAndCharacters(String area)
-        throws Exception {
+    void stringArrayRangeWritesPreserveUnselectedValuesAndCharacters(String area) throws Exception {
 
       NodeId nodeId = nodeId(area + "<string8[4]>" + (ARRAY_OFFSET + 16));
       assertGood(writeValue(nodeId, new String[] {"alpha", "beta", "gamma", "delta"}));
@@ -663,8 +628,7 @@ public class ArrayModbusToOpcUaIT {
     // no data, and clients depend on that distinction for request correction.
     @ParameterizedTest(name = "{0}")
     @MethodSource("invalidReadRangeCases")
-    void invalidRangeReadsReturnTheSpecifiedStatus(InvalidRangeCase testCase)
-        throws Exception {
+    void invalidRangeReadsReturnTheSpecifiedStatus(InvalidRangeCase testCase) throws Exception {
 
       NodeId nodeId = nodeId("HR<int16[6]>" + ARRAY_OFFSET);
       assertGood(writeValue(nodeId, shorts(0, 1, 2, 3, 4, 5)));
@@ -677,8 +641,7 @@ public class ArrayModbusToOpcUaIT {
     // device update.
     @ParameterizedTest(name = "{0}")
     @MethodSource("invalidWriteRangeCases")
-    void invalidRangeWritesDoNotMutateTheArray(InvalidRangeCase testCase)
-        throws Exception {
+    void invalidRangeWritesDoNotMutateTheArray(InvalidRangeCase testCase) throws Exception {
 
       NodeId nodeId = nodeId("HR<int16[6]>" + ARRAY_OFFSET);
       Short[] initial = shorts(0, 1, 2, 3, 4, 5);
@@ -696,15 +659,10 @@ public class ArrayModbusToOpcUaIT {
     void multidimensionalRangesRequireEveryDimensionWithoutMutation() throws Exception {
       NodeId nodeId = nodeId("HR<int16[2][2]>" + ARRAY_OFFSET);
       Short[] initial = shorts(0, 1, 2, 3);
-      assertGood(
-          writeValue(
-              nodeId,
-              new Matrix(initial, new int[] {2, 2}, OpcUaDataType.Int16)));
+      assertGood(writeValue(nodeId, new Matrix(initial, new int[] {2, 2}, OpcUaDataType.Int16)));
 
       assertStatus(StatusCodes.Bad_IndexRangeNoData, readValue(nodeId, "1").getStatusCode());
-      assertStatus(
-          StatusCodes.Bad_IndexRangeNoData,
-          writeValue(nodeId, "1", new Short[] {8, 9}));
+      assertStatus(StatusCodes.Bad_IndexRangeNoData, writeValue(nodeId, "1", new Short[] {8, 9}));
 
       Matrix actual = assertInstanceOf(Matrix.class, readValue(nodeId).getValue().getValue());
       assertArrayEquals(initial, (Short[]) actual.getElements());
@@ -783,8 +741,7 @@ public class ArrayModbusToOpcUaIT {
       assertEquals(3, results.length);
       assertTrue(Arrays.stream(results).allMatch(StatusCode::isGood));
       assertEquals((short) 12, readValue(first).getValue().getValue());
-      assertArrayEquals(
-          shorts(1, 20, 30, 4), (Short[]) readValue(ranged).getValue().getValue());
+      assertArrayEquals(shorts(1, 20, 30, 4), (Short[]) readValue(ranged).getValue().getValue());
       assertEquals(Boolean.FALSE, readValue(last).getValue().getValue());
     }
 
@@ -843,14 +800,12 @@ public class ArrayModbusToOpcUaIT {
     @Test
     void matrixWritesRejectFlatArraysWithoutMutation() throws Exception {
       NodeId nodeId = nodeId("HR<int16[2][2]>" + (ARRAY_OFFSET + 10));
-      Matrix initial =
-          new Matrix(shorts(1, 2, 3, 4), new int[] {2, 2}, OpcUaDataType.Int16);
+      Matrix initial = new Matrix(shorts(1, 2, 3, 4), new int[] {2, 2}, OpcUaDataType.Int16);
       assertGood(writeValue(nodeId, initial));
 
       assertStatus(StatusCodes.Bad_TypeMismatch, writeValue(nodeId, shorts(1, 2, 3, 4)));
 
-      Matrix actual =
-          assertInstanceOf(Matrix.class, readValue(nodeId).getValue().getValue());
+      Matrix actual = assertInstanceOf(Matrix.class, readValue(nodeId).getValue().getValue());
       assertNotNull(actual);
       Object actualElements = actual.getElements();
       assertNotNull(actualElements);
@@ -862,16 +817,13 @@ public class ArrayModbusToOpcUaIT {
     @Test
     void matrixWritesRejectDifferentDimensionsWithoutMutation() throws Exception {
       NodeId nodeId = nodeId("HR<int16[2][2]>" + (ARRAY_OFFSET + 10));
-      Matrix initial =
-          new Matrix(shorts(1, 2, 3, 4), new int[] {2, 2}, OpcUaDataType.Int16);
+      Matrix initial = new Matrix(shorts(1, 2, 3, 4), new int[] {2, 2}, OpcUaDataType.Int16);
       assertGood(writeValue(nodeId, initial));
 
-      Matrix reshaped =
-          new Matrix(shorts(1, 2, 3, 4), new int[] {1, 4}, OpcUaDataType.Int16);
+      Matrix reshaped = new Matrix(shorts(1, 2, 3, 4), new int[] {1, 4}, OpcUaDataType.Int16);
       assertStatus(StatusCodes.Bad_TypeMismatch, writeValue(nodeId, reshaped));
 
-      Matrix actual =
-          assertInstanceOf(Matrix.class, readValue(nodeId).getValue().getValue());
+      Matrix actual = assertInstanceOf(Matrix.class, readValue(nodeId).getValue().getValue());
       assertNotNull(actual);
       Object actualElements = actual.getElements();
       assertNotNull(actualElements);
@@ -942,10 +894,7 @@ public class ArrayModbusToOpcUaIT {
   private DataValue readAttribute(NodeId nodeId, AttributeId attributeId) throws Exception {
     DataValue[] results =
         opcUaClient
-            .read(
-                0.0,
-                TimestampsToReturn.Neither,
-                List.of(readValueId(nodeId, attributeId, "")))
+            .read(0.0, TimestampsToReturn.Neither, List.of(readValueId(nodeId, attributeId, "")))
             .getResults();
     assertNotNull(results);
     assertEquals(1, results.length);
@@ -973,21 +922,17 @@ public class ArrayModbusToOpcUaIT {
 
   private static WriteValue writeRequest(NodeId nodeId, String indexRange, Object value) {
     return new WriteValue(
-        nodeId,
-        AttributeId.Value.uid(),
-        indexRange,
-        DataValue.valueOnly(new Variant(value)));
+        nodeId, AttributeId.Value.uid(), indexRange, DataValue.valueOnly(new Variant(value)));
   }
 
   private static NodeId nodeId(String address) {
     return NodeId.parse("ns=1;s=[modbus-server]" + address);
   }
 
-  private void assertArrayMetadata(
-      NodeId nodeId, OpcUaDataType dataType, int[] dimensions) throws Exception {
+  private void assertArrayMetadata(NodeId nodeId, OpcUaDataType dataType, int[] dimensions)
+      throws Exception {
     assertEquals(
-        dataType.getNodeId(),
-        readAttribute(nodeId, AttributeId.DataType).getValue().getValue());
+        dataType.getNodeId(), readAttribute(nodeId, AttributeId.DataType).getValue().getValue());
     assertEquals(
         dimensions.length, readAttribute(nodeId, AttributeId.ValueRank).getValue().getValue());
 
@@ -995,14 +940,12 @@ public class ArrayModbusToOpcUaIT {
         Arrays.stream(dimensions).mapToObj(Unsigned::uint).toArray(UInteger[]::new);
     assertArrayEquals(
         expectedDimensions,
-        (UInteger[])
-            readAttribute(nodeId, AttributeId.ArrayDimensions).getValue().getValue());
+        (UInteger[]) readAttribute(nodeId, AttributeId.ArrayDimensions).getValue().getValue());
   }
 
   private void assertScalarMetadata(NodeId nodeId, OpcUaDataType dataType) throws Exception {
     assertEquals(
-        dataType.getNodeId(),
-        readAttribute(nodeId, AttributeId.DataType).getValue().getValue());
+        dataType.getNodeId(), readAttribute(nodeId, AttributeId.DataType).getValue().getValue());
     assertEquals(-1, readAttribute(nodeId, AttributeId.ValueRank).getValue().getValue());
     assertNull(readAttribute(nodeId, AttributeId.ArrayDimensions).getValue().getValue());
   }
@@ -1075,9 +1018,7 @@ public class ArrayModbusToOpcUaIT {
           int elementCount = Arrays.stream(shape).reduce(1, Math::multiplyExact);
           Object elements = repeatElements(type.seedElements(), elementCount);
           Object value =
-              shape.length == 1
-                  ? elements
-                  : new Matrix(elements, shape, type.dataType());
+              shape.length == 1 ? elements : new Matrix(elements, shape, type.dataType());
           byte[] registers = repeatBytes(type.encodedSeed(), elementCount / 2);
           String address =
               area + "<" + type.syntax() + formatDimensions(shape) + ">" + ARRAY_OFFSET;
@@ -1085,13 +1026,7 @@ public class ArrayModbusToOpcUaIT {
 
           cases.add(
               new RegisterArrayCase(
-                  caseName,
-                  address,
-                  type.dataType(),
-                  shape,
-                  value,
-                  elements,
-                  registers));
+                  caseName, address, type.dataType(), shape, value, elements, registers));
         }
       }
     }
@@ -1102,10 +1037,7 @@ public class ArrayModbusToOpcUaIT {
   private static List<RegisterType> registerTypes() {
     return List.of(
         new RegisterType(
-            "int16",
-            OpcUaDataType.Int16,
-            shorts(0x1234, (short) 0xFEDC),
-            hex("1234 FEDC")),
+            "int16", OpcUaDataType.Int16, shorts(0x1234, (short) 0xFEDC), hex("1234 FEDC")),
         new RegisterType(
             "uint16",
             OpcUaDataType.UInt16,
@@ -1129,15 +1061,10 @@ public class ArrayModbusToOpcUaIT {
         new RegisterType(
             "uint64",
             OpcUaDataType.UInt64,
-            new ULong[] {
-              ulong(0x0123456789ABCDEFL), ulong(0xFEDCBA9876543210L)
-            },
+            new ULong[] {ulong(0x0123456789ABCDEFL), ulong(0xFEDCBA9876543210L)},
             hex("0123456789ABCDEF FEDCBA9876543210")),
         new RegisterType(
-            "float",
-            OpcUaDataType.Float,
-            new Float[] {1.25f, -2.5f},
-            hex("3FA00000 C0200000")),
+            "float", OpcUaDataType.Float, new Float[] {1.25f, -2.5f}, hex("3FA00000 C0200000")),
         new RegisterType(
             "double",
             OpcUaDataType.Double,
@@ -1167,11 +1094,7 @@ public class ArrayModbusToOpcUaIT {
   }
 
   private static ArrayMetadataCase metadataCase(
-      String name,
-      String area,
-      String syntax,
-      OpcUaDataType dataType,
-      int... dimensions) {
+      String name, String area, String syntax, OpcUaDataType dataType, int... dimensions) {
 
     String address = area + "<" + syntax + formatDimensions(dimensions) + ">" + ARRAY_OFFSET;
     return new ArrayMetadataCase(name, address, dataType, dimensions);
@@ -1184,12 +1107,9 @@ public class ArrayModbusToOpcUaIT {
     for (String area : List.of("C", "DI")) {
       for (int[] shape : dimensions) {
         int elementCount = Arrays.stream(shape).reduce(1, Math::multiplyExact);
-        Boolean[] elements =
-            (Boolean[]) repeatElements(new Boolean[] {true, false}, elementCount);
+        Boolean[] elements = (Boolean[]) repeatElements(new Boolean[] {true, false}, elementCount);
         Object value =
-            shape.length == 1
-                ? elements
-                : new Matrix(elements, shape, OpcUaDataType.Boolean);
+            shape.length == 1 ? elements : new Matrix(elements, shape, OpcUaDataType.Boolean);
         String address = area + "<bool" + formatDimensions(shape) + ">" + ARRAY_OFFSET;
         cases.add(
             new BooleanArrayCase(
@@ -1213,19 +1133,13 @@ public class ArrayModbusToOpcUaIT {
         new RegisterModifierCase(
             "HR @LH", "HR<int32[2]@LH>" + ARRAY_OFFSET, values, hex("56781234 CDEF90AB")),
         new RegisterModifierCase(
-            "HR @LE@LH",
-            "HR<int32[2]@LE@LH>" + ARRAY_OFFSET,
-            values,
-            hex("34127856 AB90EFCD")),
+            "HR @LE@LH", "HR<int32[2]@LE@LH>" + ARRAY_OFFSET, values, hex("34127856 AB90EFCD")),
         new RegisterModifierCase(
             "IR @LE", "IR<int32[2]@LE>" + ARRAY_OFFSET, values, hex("78563412 EFCDAB90")),
         new RegisterModifierCase(
             "IR @LH", "IR<int32[2]@LH>" + ARRAY_OFFSET, values, hex("56781234 CDEF90AB")),
         new RegisterModifierCase(
-            "IR @LE@LH",
-            "IR<int32[2]@LE@LH>" + ARRAY_OFFSET,
-            values,
-            hex("34127856 AB90EFCD")));
+            "IR @LE@LH", "IR<int32[2]@LE@LH>" + ARRAY_OFFSET, values, hex("34127856 AB90EFCD")));
   }
 
   private static Stream<IndexedMetadataCase> indexedMetadataCases() {
@@ -1349,10 +1263,7 @@ public class ArrayModbusToOpcUaIT {
   private static Stream<InvalidRangeCase> invalidWriteRangeCases() {
     return Stream.of(
         new InvalidRangeCase(
-            "malformed write range",
-            "1::2",
-            new Short[] {9, 9},
-            StatusCodes.Bad_IndexRangeInvalid),
+            "malformed write range", "1::2", new Short[] {9, 9}, StatusCodes.Bad_IndexRangeInvalid),
         new InvalidRangeCase(
             "trailing colon in write range",
             "1:",
@@ -1391,8 +1302,7 @@ public class ArrayModbusToOpcUaIT {
 
   private static Object repeatElements(Object seedElements, int elementCount) {
     int seedLength = Array.getLength(seedElements);
-    Object elements =
-        Array.newInstance(seedElements.getClass().getComponentType(), elementCount);
+    Object elements = Array.newInstance(seedElements.getClass().getComponentType(), elementCount);
     for (int i = 0; i < elementCount; i++) {
       Array.set(elements, i, Array.get(seedElements, i % seedLength));
     }

--- a/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/ModbusToOpcUaIT.java
+++ b/msd-gateway-tests/src/test/java/com/kevinherron/ignition/modbus/ModbusToOpcUaIT.java
@@ -158,15 +158,12 @@ public class ModbusToOpcUaIT {
         modbusClient.readHoldingRegisters(42, new ReadHoldingRegistersRequest(address, 1));
     assertArrayEquals(new byte[] {0x5A, 0x3C}, modbusResponse.registers());
 
-    NodeId unqualifiedNodeId =
-        NodeId.parse("ns=1;s=[modbus-server]HR<int16>%d".formatted(address));
-    NodeId prefixedNodeId =
-        NodeId.parse("ns=1;s=[modbus-server]99.HR<int16>%d".formatted(address));
+    NodeId unqualifiedNodeId = NodeId.parse("ns=1;s=[modbus-server]HR<int16>%d".formatted(address));
+    NodeId prefixedNodeId = NodeId.parse("ns=1;s=[modbus-server]99.HR<int16>%d".formatted(address));
 
     DataValue unqualifiedValue =
         opcUaClient.readValue(0.0, TimestampsToReturn.Both, unqualifiedNodeId);
-    DataValue prefixedValue =
-        opcUaClient.readValue(0.0, TimestampsToReturn.Both, prefixedNodeId);
+    DataValue prefixedValue = opcUaClient.readValue(0.0, TimestampsToReturn.Both, prefixedNodeId);
 
     assertEquals(expected, unqualifiedValue.getValue().getValue());
     assertEquals(expected, prefixedValue.getValue().getValue());

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/BrowsableAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/BrowsableAddressSpace.java
@@ -151,8 +151,7 @@ public class BrowsableAddressSpace extends ManagedAddressSpaceFragmentWithLifecy
           String area = matcher.group(2);
           int address = Integer.parseInt(matcher.group(3));
 
-          return ReferenceResult.of(
-              createRegisterAddressReferences(nodeId, area, address, unitId));
+          return ReferenceResult.of(createRegisterAddressReferences(nodeId, area, address, unitId));
         }
       }
 
@@ -372,8 +371,7 @@ public class BrowsableAddressSpace extends ManagedAddressSpaceFragmentWithLifecy
           case NodeId -> nodeId;
           case NodeClass -> NodeClass.Object;
           case BrowseName -> device.deviceContext.qualifiedName(syntheticFolderName(nodeId));
-          case DisplayName, Description ->
-              LocalizedText.english(syntheticFolderName(nodeId));
+          case DisplayName, Description -> LocalizedText.english(syntheticFolderName(nodeId));
           default -> null;
         };
 
@@ -470,16 +468,12 @@ public class BrowsableAddressSpace extends ManagedAddressSpaceFragmentWithLifecy
     if (separatePerUnitId) {
       for (int unitId : new TreeSet<>(unitIds)) {
         String unitIdentifier = unitFolderIdentifier(unitId);
-        definitions.add(
-            new FolderDefinition(unitIdentifier, "", unitIdentifier, "Unit " + unitId));
+        definitions.add(new FolderDefinition(unitIdentifier, "", unitIdentifier, "Unit " + unitId));
 
         for (String areaName : AREA_NAMES) {
           definitions.add(
               new FolderDefinition(
-                  areaFolderIdentifier(unitId, areaName),
-                  unitIdentifier,
-                  areaName,
-                  areaName));
+                  areaFolderIdentifier(unitId, areaName), unitIdentifier, areaName, areaName));
         }
       }
     } else {

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusAddressSpace.java
@@ -47,8 +47,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The fragment resolves Modbus address strings as variable nodes, exposes their value and
  * metadata attributes, and supplies monitored values through the OPC UA subscription model. Value
- * operations select images through {@link ProcessImageManager}; unqualified addresses select unit
- * 0 in separate mode, and mixed-unit batches retain their original result order.
+ * operations select images through {@link ProcessImageManager}; unqualified addresses select unit 0
+ * in separate mode, and mixed-unit batches retain their original result order.
  *
  * <p>Its {@link Lifecycle} must be started before use and shut down with the owning device.
  */
@@ -207,8 +207,7 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
             try {
               values.add(
                   new DataValue(
-                      ModbusValueAccess.readValueAttribute(
-                          tx, read.address(), read.indexRange())));
+                      ModbusValueAccess.readValueAttribute(tx, read.address(), read.indexRange())));
             } catch (UaException e) {
               values.add(new DataValue(e.getStatusCode()));
             } catch (RuntimeException e) {
@@ -223,8 +222,8 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
   /**
    * Reads a batch through the manager-selected process images.
    *
-   * <p>Each image is read in one sequential transaction. Returned values correspond positionally
-   * to {@code reads}, including when the batch contains several unit IDs. A request racing device
+   * <p>Each image is read in one sequential transaction. Returned values correspond positionally to
+   * {@code reads}, including when the batch contains several unit IDs. A request racing device
    * shutdown returns {@code Bad_Shutdown}; a persistence initialization failure returns {@code
    * Bad_InternalError}.
    *
@@ -244,7 +243,8 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       ValueRead read = reads.get(i);
       try {
         ProcessImage processImage = processImageManager.get(read.address());
-        groups.computeIfAbsent(processImage, ignored -> new ArrayList<>())
+        groups
+            .computeIfAbsent(processImage, ignored -> new ArrayList<>())
             .add(new IndexedValueRead(i, read));
       } catch (IllegalStateException e) {
         values[i] = new DataValue(StatusCodes.Bad_Shutdown);
@@ -451,7 +451,8 @@ public class ModbusAddressSpace implements AddressSpaceFragment, Lifecycle {
       ValueWrite write = writes.get(i);
       try {
         ProcessImage processImage = processImageManager.get(write.address());
-        groups.computeIfAbsent(processImage, ignored -> new ArrayList<>())
+        groups
+            .computeIfAbsent(processImage, ignored -> new ArrayList<>())
             .add(new IndexedValueWrite(i, write));
       } catch (IllegalStateException e) {
         statuses[i] = new StatusCode(StatusCodes.Bad_Shutdown);

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfig.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfig.java
@@ -18,9 +18,7 @@ import com.inductiveautomation.ignition.gateway.web.nav.FormFieldType;
  * omit optional nested settings; the canonical constructor applies their documented defaults.
  */
 public record ModbusServerDeviceConfig(
-    @Hidden
-        @Description("The version of this settings document.")
-        @DefaultValue("2")
+    @Hidden @Description("The version of this settings document.") @DefaultValue("2")
         int configVersion,
     Connectivity connectivity,
     Browsing browsing,
@@ -120,8 +118,8 @@ public record ModbusServerDeviceConfig(
           @FormField(FormFieldType.CHECKBOX)
           @Label("")
           @Description("Whether to use a separate process image for each unit ID.")
-           @DefaultValue("false")
-           boolean separatePerUnitId) {}
+          @DefaultValue("false")
+          boolean separatePerUnitId) {}
 
   /** Controls which remote addresses may open Modbus TCP connections. */
   public record Security(

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfigUpgrader.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfigUpgrader.java
@@ -7,8 +7,7 @@ import com.inductiveautomation.ignition.gateway.config.JsonSettingsUpgrader;
 /** Upgrades persisted Modbus server device settings to the current JSON format. */
 final class ModbusServerDeviceConfigUpgrader implements JsonSettingsUpgrader {
 
-  static final ModbusServerDeviceConfigUpgrader INSTANCE =
-      new ModbusServerDeviceConfigUpgrader();
+  static final ModbusServerDeviceConfigUpgrader INSTANCE = new ModbusServerDeviceConfigUpgrader();
 
   private static final int LEGACY_CONFIG_VERSION = 1;
 
@@ -17,9 +16,9 @@ final class ModbusServerDeviceConfigUpgrader implements JsonSettingsUpgrader {
   /**
    * Upgrades a settings document without mutating the caller's JSON tree.
    *
-   * <p>Version 1 settings have no {@code configVersion} property and store persistence under
-   * {@code persistence.persistData}. Version 2 co-locates persistence and per-unit routing under
-   * {@code processImage}.
+   * <p>Version 1 settings have no {@code configVersion} property and store persistence under {@code
+   * persistence.persistData}. Version 2 co-locates persistence and per-unit routing under {@code
+   * processImage}.
    *
    * @param settings the persisted extension-point settings.
    * @return settings in the current format.
@@ -39,8 +38,7 @@ final class ModbusServerDeviceConfigUpgrader implements JsonSettingsUpgrader {
           "unsupported Modbus server device configVersion: " + version);
     }
     if (version < LEGACY_CONFIG_VERSION) {
-      throw new IllegalArgumentException(
-          "invalid Modbus server device configVersion: " + version);
+      throw new IllegalArgumentException("invalid Modbus server device configVersion: " + version);
     }
 
     if (version == LEGACY_CONFIG_VERSION) {

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceExtensionPoint.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ModbusServerDeviceExtensionPoint.java
@@ -16,8 +16,8 @@ import java.util.Optional;
  * Registers the Modbus server device type with Ignition and defines its configuration boundary.
  *
  * <p>The extension point supplies the web configuration schema, validates settings—including
- * connection admission—before device creation, and creates {@link ModbusServerDevice} instances
- * for the Ignition device lifecycle.
+ * connection admission—before device creation, and creates {@link ModbusServerDevice} instances for
+ * the Ignition device lifecycle.
  */
 public class ModbusServerDeviceExtensionPoint
     extends DeviceExtensionPoint<ModbusServerDeviceConfig> {
@@ -109,8 +109,8 @@ public class ModbusServerDeviceExtensionPoint
   /**
    * Validates the grammar and bounds of unit IDs selected for OPC UA browsing.
    *
-   * <p>An empty value is valid and selects no unit folders. Entries are comma-separated unit IDs
-   * or inclusive ranges, and every bound must be between 0 and 255. This setting affects browsing
+   * <p>An empty value is valid and selects no unit folders. Entries are comma-separated unit IDs or
+   * inclusive ranges, and every bound must be between 0 and 255. This setting affects browsing
    * only; it is not a protocol allowlist.
    *
    * @param ranges the unit ID browse-range expression.

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ProcessImageManager.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ProcessImageManager.java
@@ -40,15 +40,11 @@ final class ProcessImageManager implements AutoCloseable {
    * @param executor the executor used for persistence writes.
    */
   ProcessImageManager(
-      boolean separatePerUnitId,
-      boolean persistData,
-      Path deviceFolderPath,
-      Executor executor) {
+      boolean separatePerUnitId, boolean persistData, Path deviceFolderPath, Executor executor) {
 
     this(
         separatePerUnitId,
-        new ProcessImagePersistence(
-            deviceFolderPath, persistData, separatePerUnitId, executor));
+        new ProcessImagePersistence(deviceFolderPath, persistData, separatePerUnitId, executor));
   }
 
   /**
@@ -57,8 +53,7 @@ final class ProcessImageManager implements AutoCloseable {
    * @param separatePerUnitId whether each unit ID has an independent process image.
    * @param persistence the persistence lifecycle owned by this manager.
    */
-  ProcessImageManager(
-      boolean separatePerUnitId, ProcessImagePersistence persistence) {
+  ProcessImageManager(boolean separatePerUnitId, ProcessImagePersistence persistence) {
 
     this.separatePerUnitId = separatePerUnitId;
     this.persistence = persistence;

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ProcessImagePersistence.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/ProcessImagePersistence.java
@@ -76,15 +76,15 @@ final class ProcessImagePersistence implements AutoCloseable {
    * Restores an image and starts tracking its subsequent modifications.
    *
    * <p>Call this once for an image before making that image available to protocol requests. When
-   * persistence is disabled, this method returns without creating directories, files, or
-   * listeners. It must not be called after {@link #close()}.
+   * persistence is disabled, this method returns without creating directories, files, or listeners.
+   * It must not be called after {@link #close()}.
    *
    * @param unitId the validated unit ID associated with the image.
    * @param processImage the image to restore and observe.
    * @throws IllegalArgumentException if persistence is enabled and {@code unitId} is outside 0
    *     through 255.
-   * @throws UncheckedIOException if the persistence directory cannot be created; the image must
-   *     not be published without its persistent state.
+   * @throws UncheckedIOException if the persistence directory cannot be created; the image must not
+   *     be published without its persistent state.
    */
   void initialize(int unitId, ProcessImage processImage) {
     if (!enabled) {
@@ -97,31 +97,18 @@ final class ProcessImagePersistence implements AutoCloseable {
       Files.createDirectories(directory);
     } catch (IOException e) {
       logFailure("create directory", unitId, "all areas", directory, e);
-      throw new UncheckedIOException(
-          "unable to create persistence directory: " + directory, e);
+      throw new UncheckedIOException("unable to create persistence directory: " + directory, e);
     }
 
     processImage.with(
         tx -> {
           loadBooleans(tx, unitId, "coils", directory.resolve("coils.bin"), true);
           loadBooleans(
-              tx,
-              unitId,
-              "discrete inputs",
-              directory.resolve("discreteInputs.bin"),
-              false);
+              tx, unitId, "discrete inputs", directory.resolve("discreteInputs.bin"), false);
           loadRegisters(
-              tx,
-              unitId,
-              "holding registers",
-              directory.resolve("holdingRegisters.bin"),
-              true);
+              tx, unitId, "holding registers", directory.resolve("holdingRegisters.bin"), true);
           loadRegisters(
-              tx,
-              unitId,
-              "input registers",
-              directory.resolve("inputRegisters.bin"),
-              false);
+              tx, unitId, "input registers", directory.resolve("inputRegisters.bin"), false);
         });
 
     var listener = new PersistenceListener(unitId, directory);
@@ -134,8 +121,7 @@ final class ProcessImagePersistence implements AutoCloseable {
     }
   }
 
-  private void loadBooleans(
-      Transaction tx, int unitId, String area, Path path, boolean coils) {
+  private void loadBooleans(Transaction tx, int unitId, String area, Path path, boolean coils) {
 
     ByteBuffer values = readPersistedFile(unitId, area, path, BOOLEAN_FILE_SIZE);
     if (values == null) {
@@ -325,10 +311,7 @@ final class ProcessImagePersistence implements AutoCloseable {
       submit(
           () ->
               writeBooleans(
-                  unitId,
-                  "discrete inputs",
-                  directory.resolve("discreteInputs.bin"),
-                  writes));
+                  unitId, "discrete inputs", directory.resolve("discreteInputs.bin"), writes));
     }
 
     @Override
@@ -342,10 +325,7 @@ final class ProcessImagePersistence implements AutoCloseable {
       submit(
           () ->
               writeRegisters(
-                  unitId,
-                  "holding registers",
-                  directory.resolve("holdingRegisters.bin"),
-                  writes));
+                  unitId, "holding registers", directory.resolve("holdingRegisters.bin"), writes));
     }
 
     @Override
@@ -359,15 +339,11 @@ final class ProcessImagePersistence implements AutoCloseable {
       submit(
           () ->
               writeRegisters(
-                  unitId,
-                  "input registers",
-                  directory.resolve("inputRegisters.bin"),
-                  writes));
+                  unitId, "input registers", directory.resolve("inputRegisters.bin"), writes));
     }
   }
 
-  private void writeBooleans(
-      int unitId, String area, Path path, List<BooleanWrite> writes) {
+  private void writeBooleans(int unitId, String area, Path path, List<BooleanWrite> writes) {
 
     try (FileChannel channel = openSizedFile(path, BOOLEAN_FILE_SIZE)) {
       for (BooleanWrite write : writes) {
@@ -379,8 +355,7 @@ final class ProcessImagePersistence implements AutoCloseable {
     }
   }
 
-  private void writeRegisters(
-      int unitId, String area, Path path, List<RegisterWrite> writes) {
+  private void writeRegisters(int unitId, String area, Path path, List<RegisterWrite> writes) {
 
     try (FileChannel channel = openSizedFile(path, REGISTER_FILE_SIZE)) {
       for (RegisterWrite write : writes) {
@@ -392,8 +367,7 @@ final class ProcessImagePersistence implements AutoCloseable {
     }
   }
 
-  private record ListenerRegistration(
-      ProcessImage processImage, ModificationListener listener) {}
+  private record ListenerRegistration(ProcessImage processImage, ModificationListener listener) {}
 
   private record BooleanWrite(int address, boolean value) {}
 

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/address/ModbusAddressParser.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/address/ModbusAddressParser.java
@@ -164,15 +164,13 @@ public class ModbusAddressParser {
 
     long extent;
     try {
-      extent =
-          Math.addExact(offset, Math.multiplyExact(elementCount, entriesPerElement));
+      extent = Math.addExact(offset, Math.multiplyExact(elementCount, entriesPerElement));
     } catch (ArithmeticException e) {
       throw new Exception("address extent exceeds the Modbus address space", e);
     }
 
     if (extent > ADDRESS_SPACE_SIZE) {
-      throw new Exception(
-          "address extent %d exceeds the Modbus address space".formatted(extent));
+      throw new Exception("address extent %d exceeds the Modbus address space".formatted(extent));
     }
   }
 
@@ -342,9 +340,7 @@ public class ModbusAddressParser {
 
       boolean conflictsWithExisting =
           set.stream()
-              .anyMatch(
-                  existing ->
-                      existing.getClass() == m.getClass() && !existing.equals(m));
+              .anyMatch(existing -> existing.getClass() == m.getClass() && !existing.equals(m));
       if (conflictsWithExisting) {
         return Optional.empty();
       }

--- a/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
+++ b/msd-gateway/src/main/java/com/kevinherron/ignition/modbus/util/ModbusByteUtil.java
@@ -128,7 +128,9 @@ public final class ModbusByteUtil {
 
     for (int i = 0; i < arrayLength; i++) {
       Array.set(
-          array, i, getScalarValueForBytes(registerBytes, i * bytesPerElement, dataType, modifiers));
+          array,
+          i,
+          getScalarValueForBytes(registerBytes, i * bytesPerElement, dataType, modifiers));
     }
 
     return array;

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/BrowsableAddressSpaceTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/BrowsableAddressSpaceTest.java
@@ -31,8 +31,7 @@ class BrowsableAddressSpaceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(
-        strings = {"-1", "256", "2-1", "1,,2", "1, 2", "one", "1-2-3", " ", "2147483648"})
+    @ValueSource(strings = {"-1", "256", "2-1", "1,,2", "1, 2", "one", "1-2-3", " ", "2147483648"})
     void invalidUnitIdRangesFailExpansion(String ranges) {
       assertThrows(
           IllegalArgumentException.class,
@@ -43,8 +42,7 @@ class BrowsableAddressSpaceTest {
     @Test
     void nullUnitIdRangesFailExpansion() {
       assertThrows(
-          IllegalArgumentException.class,
-          () -> BrowsableAddressSpace.expandUnitIdRanges(null));
+          IllegalArgumentException.class, () -> BrowsableAddressSpace.expandUnitIdRanges(null));
     }
   }
 
@@ -76,20 +74,12 @@ class BrowsableAddressSpaceTest {
               folder("Unit0", "", "Unit0", "Unit 0"),
               folder("Unit0.Coils", "Unit0", "Coils", "Coils"),
               folder("Unit0.DiscreteInputs", "Unit0", "DiscreteInputs", "DiscreteInputs"),
-              folder(
-                  "Unit0.HoldingRegisters",
-                  "Unit0",
-                  "HoldingRegisters",
-                  "HoldingRegisters"),
+              folder("Unit0.HoldingRegisters", "Unit0", "HoldingRegisters", "HoldingRegisters"),
               folder("Unit0.InputRegisters", "Unit0", "InputRegisters", "InputRegisters"),
               folder("Unit2", "", "Unit2", "Unit 2"),
               folder("Unit2.Coils", "Unit2", "Coils", "Coils"),
               folder("Unit2.DiscreteInputs", "Unit2", "DiscreteInputs", "DiscreteInputs"),
-              folder(
-                  "Unit2.HoldingRegisters",
-                  "Unit2",
-                  "HoldingRegisters",
-                  "HoldingRegisters"),
+              folder("Unit2.HoldingRegisters", "Unit2", "HoldingRegisters", "HoldingRegisters"),
               folder("Unit2.InputRegisters", "Unit2", "InputRegisters", "InputRegisters")),
           definitions);
     }
@@ -108,11 +98,9 @@ class BrowsableAddressSpaceTest {
     void unifiedAreaBrowseIdentifiersRemainUnqualified() {
       List<Range> ranges = List.of(new Range(0, 1));
 
+      assertEquals(List.of("C0", "C1"), BrowsableAddressSpace.browseIdentifiers("C", ranges, null));
       assertEquals(
-          List.of("C0", "C1"), BrowsableAddressSpace.browseIdentifiers("C", ranges, null));
-      assertEquals(
-          List.of("_HR0_", "_HR1_"),
-          BrowsableAddressSpace.browseIdentifiers("HR", ranges, null));
+          List.of("_HR0_", "_HR1_"), BrowsableAddressSpace.browseIdentifiers("HR", ranges, null));
     }
 
     // Separate-mode leaves remain directly addressable while register grouping nodes live under
@@ -122,8 +110,7 @@ class BrowsableAddressSpaceTest {
       List<Range> ranges = List.of(new Range(5, 6));
 
       assertEquals(
-          List.of("7.C5", "7.C6"),
-          BrowsableAddressSpace.browseIdentifiers("C", ranges, 7));
+          List.of("7.C5", "7.C6"), BrowsableAddressSpace.browseIdentifiers("C", ranges, 7));
       assertEquals(
           List.of("Unit7._HR5_", "Unit7._HR6_"),
           BrowsableAddressSpace.browseIdentifiers("HR", ranges, 7));
@@ -151,16 +138,14 @@ class BrowsableAddressSpaceTest {
           "Unit255.InputRegisters",
           BrowsableAddressSpace.areaFolderIdentifier(255, "InputRegisters"));
       assertEquals(
-          "Unit255._IR65535_",
-          BrowsableAddressSpace.registerFolderIdentifier(255, "IR", 65535));
+          "Unit255._IR65535_", BrowsableAddressSpace.registerFolderIdentifier(255, "IR", 65535));
       assertEquals("255.DI0", BrowsableAddressSpace.variableIdentifier(255, "DI0"));
     }
 
     @Test
     void identifierHelpersRejectUnitIdsOutsideModbusBounds() {
       assertThrows(
-          IllegalArgumentException.class,
-          () -> BrowsableAddressSpace.unitFolderIdentifier(-1));
+          IllegalArgumentException.class, () -> BrowsableAddressSpace.unitFolderIdentifier(-1));
       assertThrows(
           IllegalArgumentException.class,
           () -> BrowsableAddressSpace.variableIdentifier(256, "C0"));

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusAddressSpaceTest.java
@@ -104,15 +104,13 @@ class ModbusAddressSpaceTest {
 
   @Test
   void getRegisterWriteBytesRejectsShortArray() throws Exception {
-    assertRegisterWriteTypeMismatch(
-        "HR<int16[10]>0", new Short[] {1, 2, 3, 4, 5});
+    assertRegisterWriteTypeMismatch("HR<int16[10]>0", new Short[] {1, 2, 3, 4, 5});
   }
 
   @Test
   void getRegisterWriteBytesRejectsWrongMatrixShape() throws Exception {
     assertRegisterWriteTypeMismatch(
-        "HR<int16[2][2]>0",
-        new Matrix(new Short[] {1, 2, 3, 4, 5, 6}, new int[] {2, 3}));
+        "HR<int16[2][2]>0", new Matrix(new Short[] {1, 2, 3, 4, 5, 6}, new int[] {2, 3}));
   }
 
   @Test
@@ -129,8 +127,7 @@ class ModbusAddressSpaceTest {
   void registerArrayWriteReadBytesRoundTrip() throws Exception {
     ModbusAddress address = ModbusAddressParser.parse("HR<int16[10]>0");
     Short[] value = new Short[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    byte[] writtenBytes =
-        ModbusValueAccess.getRegisterWriteBytes(address, new Variant(value));
+    byte[] writtenBytes = ModbusValueAccess.getRegisterWriteBytes(address, new Variant(value));
     Map<Integer, byte[]> registers = new java.util.HashMap<>();
 
     for (int i = 0; i < writtenBytes.length / 2; i++) {
@@ -145,8 +142,7 @@ class ModbusAddressSpaceTest {
     ArrayAddress address = arrayAddress("C<bool[2][2]>0");
 
     Object value =
-        ModbusValueAccess.shapeBooleanArray(
-            address, new boolean[] {true, false, false, true});
+        ModbusValueAccess.shapeBooleanArray(address, new boolean[] {true, false, false, true});
 
     Matrix matrix = assertInstanceOf(Matrix.class, value);
     assertArrayEquals(new int[] {2, 2}, matrix.getDimensions());
@@ -166,8 +162,7 @@ class ModbusAddressSpaceTest {
     Matrix matrix = assertInstanceOf(Matrix.class, value);
     assertArrayEquals(new int[] {2, 3}, matrix.getDimensions());
     assertArrayEquals(
-        new Boolean[] {true, false, true, false, true, false},
-        (Boolean[]) matrix.getElements());
+        new Boolean[] {true, false, true, false, true, false}, (Boolean[]) matrix.getElements());
     assertEquals(Boolean.class, matrix.getElementType().orElseThrow());
     assertEquals(OpcUaDataType.Boolean, matrix.getDataType().orElseThrow());
   }
@@ -176,11 +171,9 @@ class ModbusAddressSpaceTest {
   void shapeOneDimensionalBooleanArrayAsBoxedArray() throws Exception {
     ArrayAddress address = arrayAddress("C<bool[3]>0");
 
-    Object value =
-        ModbusValueAccess.shapeBooleanArray(address, new boolean[] {true, false, true});
+    Object value = ModbusValueAccess.shapeBooleanArray(address, new boolean[] {true, false, true});
 
-    assertArrayEquals(
-        new Boolean[] {true, false, true}, assertInstanceOf(Boolean[].class, value));
+    assertArrayEquals(new Boolean[] {true, false, true}, assertInstanceOf(Boolean[].class, value));
   }
 
   @Test
@@ -189,8 +182,7 @@ class ModbusAddressSpaceTest {
     Matrix matrix =
         assertInstanceOf(
             Matrix.class,
-            ModbusValueAccess.shapeBooleanArray(
-                address, new boolean[] {true, false, false, true}));
+            ModbusValueAccess.shapeBooleanArray(address, new boolean[] {true, false, false, true}));
 
     Variant valueRank = ModbusAddressSpace.readAddressAttribute(AttributeId.ValueRank, address);
     Variant arrayDimensions =
@@ -206,8 +198,7 @@ class ModbusAddressSpaceTest {
   void shapedCoilMatrixCanBeWrittenBackToSameAddress() throws Exception {
     ArrayAddress address = arrayAddress("C<bool[2][2]>0");
     Object value =
-        ModbusValueAccess.shapeBooleanArray(
-            address, new boolean[] {true, false, false, true});
+        ModbusValueAccess.shapeBooleanArray(address, new boolean[] {true, false, false, true});
     Map<Integer, Boolean> booleans = new HashMap<>();
 
     ModbusValueAccess.writeBooleanArray(booleans, address, new Variant(value));
@@ -270,28 +261,22 @@ class ModbusAddressSpaceTest {
 
     assertArrayEquals(
         new Short[] {2, 3, 4},
-        (Short[])
-            ModbusAddressSpace.readValueAttribute(processImage, address, "2:4").getValue());
+        (Short[]) ModbusAddressSpace.readValueAttribute(processImage, address, "2:4").getValue());
     assertArrayEquals(
         new Short[] {0},
-        (Short[])
-            ModbusAddressSpace.readValueAttribute(processImage, address, "0").getValue());
+        (Short[]) ModbusAddressSpace.readValueAttribute(processImage, address, "0").getValue());
   }
 
   @Test
   void readHoldingRegisterSubmatrix() throws Exception {
     ProcessImage processImage = new ProcessImage();
     ModbusAddress address = ModbusAddressParser.parse("HR<int16[4][4]>0");
-    writeValue(
-        processImage,
-        address,
-        new Matrix(shorts(0, 16), new int[] {4, 4}));
+    writeValue(processImage, address, new Matrix(shorts(0, 16), new int[] {4, 4}));
 
     Matrix matrix =
         assertInstanceOf(
             Matrix.class,
-            ModbusAddressSpace.readValueAttribute(processImage, address, "1:2,0:1")
-                .getValue());
+            ModbusAddressSpace.readValueAttribute(processImage, address, "1:2,0:1").getValue());
 
     assertArrayEquals(new int[] {2, 2}, matrix.getDimensions());
     assertArrayEquals(new Short[] {4, 5, 8, 9}, (Short[]) matrix.getElements());
@@ -302,14 +287,11 @@ class ModbusAddressSpaceTest {
     ProcessImage processImage = new ProcessImage();
     ModbusAddress address = ModbusAddressParser.parse("C<bool[8]>0");
     writeValue(
-        processImage,
-        address,
-        new Boolean[] {false, true, false, true, true, false, true, false});
+        processImage, address, new Boolean[] {false, true, false, true, true, false, true, false});
 
     assertArrayEquals(
         new Boolean[] {true, true, false},
-        (Boolean[])
-            ModbusAddressSpace.readValueAttribute(processImage, address, "3:5").getValue());
+        (Boolean[]) ModbusAddressSpace.readValueAttribute(processImage, address, "3:5").getValue());
   }
 
   @Test
@@ -323,18 +305,14 @@ class ModbusAddressSpaceTest {
 
     assertArrayEquals(
         new Short[] {0, 1, 20, 30, 40, 5, 6, 7, 8, 9},
-        (Short[])
-            ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+        (Short[]) ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
   }
 
   @Test
   void rangedHoldingRegisterMatrixWritePreservesUnselectedCells() throws Exception {
     ProcessImage processImage = new ProcessImage();
     ModbusAddress address = ModbusAddressParser.parse("HR<int16[4][4]>0");
-    writeValue(
-        processImage,
-        address,
-        new Matrix(shorts(0, 16), new int[] {4, 4}));
+    writeValue(processImage, address, new Matrix(shorts(0, 16), new int[] {4, 4}));
 
     ModbusAddressSpace.writeValueAttribute(
         processImage,
@@ -361,8 +339,7 @@ class ModbusAddressSpaceTest {
 
     assertArrayEquals(
         new Short[] {0, 0, 7, 8, 0, 0},
-        (Short[])
-            ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+        (Short[]) ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
   }
 
   @Test
@@ -404,8 +381,7 @@ class ModbusAddressSpaceTest {
         ModbusAddressSpace.writeValueAttributes(
             processImage,
             List.of(
-                new ModbusAddressSpace.ValueWrite(
-                    register, new Variant((short) 99), "1::2"),
+                new ModbusAddressSpace.ValueWrite(register, new Variant((short) 99), "1::2"),
                 new ModbusAddressSpace.ValueWrite(coil, new Variant(false), "1::2"),
                 new ModbusAddressSpace.ValueWrite(register, new Variant((short) 99), "1:"),
                 new ModbusAddressSpace.ValueWrite(coil, new Variant(false), "1,")));
@@ -415,10 +391,8 @@ class ModbusAddressSpaceTest {
     assertStatus(StatusCodes.Bad_IndexRangeInvalid, statuses.get(2));
     assertStatus(StatusCodes.Bad_IndexRangeInvalid, statuses.get(3));
     assertEquals(
-        (short) 7,
-        ModbusAddressSpace.readValueAttribute(processImage, register, null).getValue());
-    assertEquals(
-        true, ModbusAddressSpace.readValueAttribute(processImage, coil, null).getValue());
+        (short) 7, ModbusAddressSpace.readValueAttribute(processImage, register, null).getValue());
+    assertEquals(true, ModbusAddressSpace.readValueAttribute(processImage, coil, null).getValue());
   }
 
   @Test
@@ -438,8 +412,7 @@ class ModbusAddressSpaceTest {
     assertStatus(StatusCodes.Bad_IndexRangeDataMismatch, statuses.get(0));
     assertArrayEquals(
         initial,
-        (Short[])
-            ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+        (Short[]) ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
   }
 
   @Test
@@ -488,8 +461,7 @@ class ModbusAddressSpaceTest {
     assertStatus(StatusCodes.Bad_TypeMismatch, status);
     assertArrayEquals(
         initial,
-        (Short[])
-            ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
+        (Short[]) ModbusAddressSpace.readValueAttribute(processImage, address, null).getValue());
   }
 
   @Test
@@ -501,8 +473,7 @@ class ModbusAddressSpaceTest {
     StatusCode status =
         ModbusAddressSpace.writeValueAttributes(
                 processImage,
-                List.of(
-                    new ModbusAddressSpace.ValueWrite(address, new Variant("NO"), "0:4")))
+                List.of(new ModbusAddressSpace.ValueWrite(address, new Variant("NO"), "0:4")))
             .get(0);
 
     assertStatus(StatusCodes.Bad_IndexRangeDataMismatch, status);
@@ -615,9 +586,7 @@ class ModbusAddressSpaceTest {
     StatusCode status =
         ModbusAddressSpace.writeValueAttributes(
                 processImage,
-                List.of(
-                    new ModbusAddressSpace.ValueWrite(
-                        address, new Variant("ÉÉÉÉÉ"), "0:4")))
+                List.of(new ModbusAddressSpace.ValueWrite(address, new Variant("ÉÉÉÉÉ"), "0:4")))
             .get(0);
 
     assertStatus(StatusCodes.Bad_IndexRangeDataMismatch, status);
@@ -785,9 +754,7 @@ class ModbusAddressSpaceTest {
                     valueRead("1.HR<int16>0", null),
                     valueRead("255.HR<int16>0", null)));
 
-        assertEquals(
-            List.of((short) 10, (short) 10, (short) 20, (short) 30),
-            scalarValues(values));
+        assertEquals(List.of((short) 10, (short) 10, (short) 20, (short) 30), scalarValues(values));
       }
     }
 
@@ -842,9 +809,7 @@ class ModbusAddressSpaceTest {
             scalarValues(
                 ModbusAddressSpace.readValueAttributes(
                     manager,
-                    List.of(
-                        valueRead("1.HR<int16>0", null),
-                        valueRead("2.HR<int16>0", null)))));
+                    List.of(valueRead("1.HR<int16>0", null), valueRead("2.HR<int16>0", null)))));
       }
     }
 
@@ -869,10 +834,7 @@ class ModbusAddressSpaceTest {
 
         List<DataValue> values =
             ModbusAddressSpace.readValueAttributes(
-                manager,
-                List.of(
-                    valueRead("1.HR<int16>0", null),
-                    valueRead("2.HR<int16>0", null)));
+                manager, List.of(valueRead("1.HR<int16>0", null), valueRead("2.HR<int16>0", null)));
 
         assertStatus(StatusCodes.Bad_InternalError, values.get(0).getStatusCode());
         assertEquals((short) 22, values.get(1).getValue().getValue());
@@ -888,8 +850,7 @@ class ModbusAddressSpaceTest {
           ModbusAddressSpace.writeValueAttributes(
               manager, List.of(valueWrite("1.HR<int16>0", (short) 11, null)));
       List<DataValue> values =
-          ModbusAddressSpace.readValueAttributes(
-              manager, List.of(valueRead("1.HR<int16>0", null)));
+          ModbusAddressSpace.readValueAttributes(manager, List.of(valueRead("1.HR<int16>0", null)));
 
       assertStatus(StatusCodes.Bad_Shutdown, statuses.get(0));
       assertStatus(StatusCodes.Bad_Shutdown, values.get(0).getStatusCode());
@@ -902,14 +863,12 @@ class ModbusAddressSpaceTest {
       try (ProcessImageManager manager = processImageManager(true)) {
         List<StatusCode> initialStatuses =
             ModbusAddressSpace.writeValueAttributes(
-                manager,
-                List.of(valueWrite("1.HR<int16[4]>10", new Short[] {1, 2, 3, 4}, null)));
+                manager, List.of(valueWrite("1.HR<int16[4]>10", new Short[] {1, 2, 3, 4}, null)));
         assertAllGood(1, initialStatuses);
 
         List<StatusCode> statuses =
             ModbusAddressSpace.writeValueAttributes(
-                manager,
-                List.of(valueWrite("1.HR<int16[4]>10", new Short[] {8, 9}, "1:2")));
+                manager, List.of(valueWrite("1.HR<int16[4]>10", new Short[] {8, 9}, "1:2")));
 
         assertAllGood(1, statuses);
         Object value =
@@ -950,8 +909,8 @@ class ModbusAddressSpaceTest {
         () -> "expected all Good statuses but got " + statuses);
   }
 
-  private static void writeValue(
-      ProcessImage processImage, ModbusAddress address, Object value) throws UaException {
+  private static void writeValue(ProcessImage processImage, ModbusAddress address, Object value)
+      throws UaException {
     ModbusAddressSpace.writeValueAttribute(processImage, address, new Variant(value), null);
   }
 
@@ -989,17 +948,12 @@ class ModbusAddressSpaceTest {
         Arguments.of(
             "HR<int16[10]>0",
             new Short[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-            new byte[] {
-              0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9, 0, 10
-            }),
+            new byte[] {0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9, 0, 10}),
         Arguments.of(
             "HR<float[4]>0",
             new Float[] {1.0f, -2.5f, 0.0f, 3.75f},
             new byte[] {
-              0x3F, (byte) 0x80, 0, 0,
-              (byte) 0xC0, 0x20, 0, 0,
-              0, 0, 0, 0,
-              0x40, 0x70, 0, 0
+              0x3F, (byte) 0x80, 0, 0, (byte) 0xC0, 0x20, 0, 0, 0, 0, 0, 0, 0x40, 0x70, 0, 0
             }),
         Arguments.of(
             "IR<uint16[3]>0",

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfigTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusServerDeviceConfigTest.java
@@ -140,8 +140,7 @@ class ModbusServerDeviceConfigTest {
           GSON.fromJson("{\"security\": null}", ModbusServerDeviceConfig.class);
       ModbusServerDeviceConfig nullField =
           GSON.fromJson(
-              "{\"security\": {\"allowedIpAddresses\": null}}",
-              ModbusServerDeviceConfig.class);
+              "{\"security\": {\"allowedIpAddresses\": null}}", ModbusServerDeviceConfig.class);
 
       assertEquals("*", nullObject.security().allowedIpAddresses());
       assertEquals("*", nullField.security().allowedIpAddresses());
@@ -151,8 +150,7 @@ class ModbusServerDeviceConfigTest {
     void explicitBlankSecurityValueIsPreservedForValidation() {
       ModbusServerDeviceConfig config =
           GSON.fromJson(
-              "{\"security\": {\"allowedIpAddresses\": \"  \"}}",
-              ModbusServerDeviceConfig.class);
+              "{\"security\": {\"allowedIpAddresses\": \"  \"}}", ModbusServerDeviceConfig.class);
 
       assertEquals("  ", config.security().allowedIpAddresses());
     }
@@ -163,11 +161,9 @@ class ModbusServerDeviceConfigTest {
           new ModbusServerDeviceConfig(
               ModbusServerDeviceConfig.CURRENT_CONFIG_VERSION,
               new ModbusServerDeviceConfig.Connectivity("127.0.0.1", 1502),
-              new ModbusServerDeviceConfig.Browsing(
-                  "0-9", "10-19", "20-29", "30-39", "0,2"),
+              new ModbusServerDeviceConfig.Browsing("0-9", "10-19", "20-29", "30-39", "0,2"),
               new ModbusServerDeviceConfig.ProcessImageSettings(true, true),
-              new ModbusServerDeviceConfig.Security(
-                  "192.168.1.50, 10.0.0.0/8, 172.16.*"));
+              new ModbusServerDeviceConfig.Security("192.168.1.50, 10.0.0.0/8, 172.16.*"));
 
       assertEquals(expected, roundTrip(expected));
     }
@@ -203,12 +199,12 @@ class ModbusServerDeviceConfigTest {
       JsonObject encoded = EXTENSION_POINT.encode(config(true, "0")).getAsJsonObject();
 
       assertEquals(
-          ModbusServerDeviceConfig.CURRENT_CONFIG_VERSION,
-          encoded.get("configVersion").getAsInt());
+          ModbusServerDeviceConfig.CURRENT_CONFIG_VERSION, encoded.get("configVersion").getAsInt());
       assertFalse(encoded.has("persistence"));
       assertTrue(encoded.getAsJsonObject("processImage").has("persistData"));
       assertTrue(encoded.getAsJsonObject("processImage").has("separatePerUnitId"));
-      assertEquals("*", encoded.getAsJsonObject("security").get("allowedIpAddresses").getAsString());
+      assertEquals(
+          "*", encoded.getAsJsonObject("security").get("allowedIpAddresses").getAsString());
     }
   }
 
@@ -249,8 +245,23 @@ class ModbusServerDeviceConfigTest {
     @ParameterizedTest
     @ValueSource(
         strings = {
-          "-1", "256", "2-1", "1-256", "1-", "-1-2", "1--2", "1,", ",1", "1,,2",
-          "1.0", "one", "1 2", " 1", "1 ", "+1", "999999999999999999999"
+          "-1",
+          "256",
+          "2-1",
+          "1-256",
+          "1-",
+          "-1-2",
+          "1--2",
+          "1,",
+          ",1",
+          "1,,2",
+          "1.0",
+          "one",
+          "1 2",
+          " 1",
+          "1 ",
+          "+1",
+          "999999999999999999999"
         })
     void invalidUnitIdBrowseRangesFailValidation(String ranges) {
       assertThrows(
@@ -278,11 +289,7 @@ class ModbusServerDeviceConfigTest {
   }
 
   private static JsonObject upgrade(JsonElement settings) {
-    return EXTENSION_POINT
-        .getSettingsUpgrader()
-        .orElseThrow()
-        .upgrade(settings)
-        .getAsJsonObject();
+    return EXTENSION_POINT.getSettingsUpgrader().orElseThrow().upgrade(settings).getAsJsonObject();
   }
 
   private static JsonObject parse(String json) {

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusValueAccessTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ModbusValueAccessTest.java
@@ -79,8 +79,7 @@ class ModbusValueAccessTest {
 
       Matrix value =
           assertInstanceOf(
-              Matrix.class,
-              read(processImage, "HR<int32[3][2]>100", "1,0:1").getValue());
+              Matrix.class, read(processImage, "HR<int32[3][2]>100", "1,0:1").getValue());
 
       assertArrayEquals(new int[] {1, 2}, value.getDimensions());
       assertArrayEquals(new Integer[] {20, 21}, (Integer[]) value.getElements());
@@ -106,8 +105,7 @@ class ModbusValueAccessTest {
             assertEquals(Map.of(10, true), tx.readCoils(Map::copyOf));
             assertEquals(Map.of(10, false), tx.readDiscreteInputs(Map::copyOf));
             assertArrayEquals(
-                new byte[] {0, 11},
-                tx.readHoldingRegisters(registers -> registers.get(10)));
+                new byte[] {0, 11}, tx.readHoldingRegisters(registers -> registers.get(10)));
             assertArrayEquals(
                 new byte[] {0, 22}, tx.readInputRegisters(registers -> registers.get(10)));
           });
@@ -186,10 +184,8 @@ class ModbusValueAccessTest {
         Arguments.of("Int16", "HR<int16>0.15", "HR<int16>0", (short) 1, (short) 0x8001),
         Arguments.of("UInt16", "HR<uint16>10.15", "HR<uint16>10", ushort(1), ushort(0x8001)),
         Arguments.of("Int32", "HR<int32>20.31", "HR<int32>20", 1, 0x8000_0001),
-        Arguments.of(
-            "UInt32", "HR<uint32>30.31", "HR<uint32>30", uint(1), uint(0x8000_0001L)),
-        Arguments.of(
-            "Int64", "HR<int64>40.63", "HR<int64>40", 1L, Long.MIN_VALUE | 1L),
+        Arguments.of("UInt32", "HR<uint32>30.31", "HR<uint32>30", uint(1), uint(0x8000_0001L)),
+        Arguments.of("Int64", "HR<int64>40.63", "HR<int64>40", 1L, Long.MIN_VALUE | 1L),
         Arguments.of(
             "UInt64", "HR<uint64>50.63", "HR<uint64>50", ulong(1), ulong(Long.MIN_VALUE | 1L)));
   }
@@ -236,11 +232,9 @@ class ModbusValueAccessTest {
                   for (int i = 0; i < values.length; i++) {
                     int value = values[i];
                     registers.put(
-                        offset + i * 2,
-                        new byte[] {(byte) (value >>> 24), (byte) (value >>> 16)});
+                        offset + i * 2, new byte[] {(byte) (value >>> 24), (byte) (value >>> 16)});
                     registers.put(
-                        offset + i * 2 + 1,
-                        new byte[] {(byte) (value >>> 8), (byte) value});
+                        offset + i * 2 + 1, new byte[] {(byte) (value >>> 8), (byte) value});
                   }
                 }));
   }

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ProcessImageManagerTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ProcessImageManagerTest.java
@@ -172,10 +172,7 @@ class ProcessImageManagerTest {
 
   private ProcessImageManager manager(boolean separatePerUnitId) {
     return new ProcessImageManager(
-        separatePerUnitId,
-        false,
-        temporaryDirectory.resolve("device"),
-        Runnable::run);
+        separatePerUnitId, false, temporaryDirectory.resolve("device"), Runnable::run);
   }
 
   private static ReadWriteModbusServices services(ProcessImageManager manager) {

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ProcessImagePersistenceTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/ProcessImagePersistenceTest.java
@@ -53,8 +53,7 @@ class ProcessImagePersistenceTest {
       Path deviceRoot = temporaryDirectory.resolve("unified-device");
       var image = new ProcessImage();
 
-      try (var persistence =
-          new ProcessImagePersistence(deviceRoot, true, false, Runnable::run)) {
+      try (var persistence = new ProcessImagePersistence(deviceRoot, true, false, Runnable::run)) {
         persistence.initialize(0, image);
         writeAllAreas(image, 10, true, true, new byte[] {0x12, 0x34}, new byte[] {0x56, 0x78});
         writeAllAreas(
@@ -73,11 +72,9 @@ class ProcessImagePersistenceTest {
       assertFalse(Files.exists(deviceRoot.resolve("units")));
 
       var restored = new ProcessImage();
-      try (var persistence =
-          new ProcessImagePersistence(deviceRoot, true, false, Runnable::run)) {
+      try (var persistence = new ProcessImagePersistence(deviceRoot, true, false, Runnable::run)) {
         persistence.initialize(0, restored);
-        assertAllAreas(
-            restored, 10, true, true, new byte[] {0x12, 0x34}, new byte[] {0x56, 0x78});
+        assertAllAreas(restored, 10, true, true, new byte[] {0x12, 0x34}, new byte[] {0x56, 0x78});
         assertAllAreas(
             restored,
             LAST_ADDRESS,
@@ -96,14 +93,11 @@ class ProcessImagePersistenceTest {
       var unit1 = new ProcessImage();
       var unit2 = new ProcessImage();
 
-      try (var persistence =
-          new ProcessImagePersistence(deviceRoot, true, true, Runnable::run)) {
+      try (var persistence = new ProcessImagePersistence(deviceRoot, true, true, Runnable::run)) {
         persistence.initialize(1, unit1);
         persistence.initialize(2, unit2);
-        writeAllAreas(
-            unit1, 20, true, false, new byte[] {0x11, 0x11}, new byte[] {0x22, 0x22});
-        writeAllAreas(
-            unit2, 20, false, true, new byte[] {0x33, 0x33}, new byte[] {0x44, 0x44});
+        writeAllAreas(unit1, 20, true, false, new byte[] {0x11, 0x11}, new byte[] {0x22, 0x22});
+        writeAllAreas(unit2, 20, false, true, new byte[] {0x33, 0x33}, new byte[] {0x44, 0x44});
       }
 
       assertTrue(Files.exists(deviceRoot.resolve("units/1/coils.bin")));
@@ -112,24 +106,13 @@ class ProcessImagePersistenceTest {
 
       var restoredUnit1 = new ProcessImage();
       var restoredUnit2 = new ProcessImage();
-      try (var persistence =
-          new ProcessImagePersistence(deviceRoot, true, true, Runnable::run)) {
+      try (var persistence = new ProcessImagePersistence(deviceRoot, true, true, Runnable::run)) {
         persistence.initialize(1, restoredUnit1);
         persistence.initialize(2, restoredUnit2);
         assertAllAreas(
-            restoredUnit1,
-            20,
-            true,
-            false,
-            new byte[] {0x11, 0x11},
-            new byte[] {0x22, 0x22});
+            restoredUnit1, 20, true, false, new byte[] {0x11, 0x11}, new byte[] {0x22, 0x22});
         assertAllAreas(
-            restoredUnit2,
-            20,
-            false,
-            true,
-            new byte[] {0x33, 0x33},
-            new byte[] {0x44, 0x44});
+            restoredUnit2, 20, false, true, new byte[] {0x33, 0x33}, new byte[] {0x44, 0x44});
       }
     }
 
@@ -142,19 +125,14 @@ class ProcessImagePersistenceTest {
       writeHoldingRegister(deviceRoot, false, 0, 0, new byte[] {0x11, 0x11});
       writeHoldingRegister(deviceRoot, true, 0, 0, new byte[] {0x22, 0x22});
 
-      assertArrayEquals(
-          new byte[] {0x11, 0x11}, readHoldingRegister(deviceRoot, false, 0, 0));
-      assertArrayEquals(
-          new byte[] {0x22, 0x22}, readHoldingRegister(deviceRoot, true, 0, 0));
+      assertArrayEquals(new byte[] {0x11, 0x11}, readHoldingRegister(deviceRoot, false, 0, 0));
+      assertArrayEquals(new byte[] {0x22, 0x22}, readHoldingRegister(deviceRoot, true, 0, 0));
 
       writeHoldingRegister(deviceRoot, false, 0, 1, new byte[] {0x33, 0x33});
 
-      assertArrayEquals(
-          new byte[] {0x22, 0x22}, readHoldingRegister(deviceRoot, true, 0, 0));
-      assertArrayEquals(
-          new byte[] {0x11, 0x11}, readHoldingRegister(deviceRoot, false, 0, 0));
-      assertArrayEquals(
-          new byte[] {0x33, 0x33}, readHoldingRegister(deviceRoot, false, 0, 1));
+      assertArrayEquals(new byte[] {0x22, 0x22}, readHoldingRegister(deviceRoot, true, 0, 0));
+      assertArrayEquals(new byte[] {0x11, 0x11}, readHoldingRegister(deviceRoot, false, 0, 0));
+      assertArrayEquals(new byte[] {0x33, 0x33}, readHoldingRegister(deviceRoot, false, 0, 1));
     }
   }
 
@@ -182,8 +160,7 @@ class ProcessImagePersistenceTest {
           "the persistence executor must be blocked before a write is queued");
 
       var image = new ProcessImage();
-      var persistence =
-          new ProcessImagePersistence(deviceRoot, true, false, persistenceExecutor);
+      var persistence = new ProcessImagePersistence(deviceRoot, true, false, persistenceExecutor);
 
       try {
         persistence.initialize(0, image);
@@ -208,8 +185,7 @@ class ProcessImagePersistenceTest {
 
         writeHoldingRegister(image, 8, new byte[] {0x56, 0x78});
 
-        assertArrayEquals(
-            new byte[] {0x12, 0x34}, readHoldingRegister(deviceRoot, false, 0, 8));
+        assertArrayEquals(new byte[] {0x12, 0x34}, readHoldingRegister(deviceRoot, false, 0, 8));
       } finally {
         releaseBlocker.countDown();
         persistence.close();
@@ -220,16 +196,11 @@ class ProcessImagePersistenceTest {
   }
 
   private static void writeHoldingRegister(
-      Path deviceRoot,
-      boolean separatePerUnitId,
-      int unitId,
-      int address,
-      byte[] value) {
+      Path deviceRoot, boolean separatePerUnitId, int unitId, int address, byte[] value) {
 
     var image = new ProcessImage();
     try (var persistence =
-        new ProcessImagePersistence(
-            deviceRoot, true, separatePerUnitId, Runnable::run)) {
+        new ProcessImagePersistence(deviceRoot, true, separatePerUnitId, Runnable::run)) {
       persistence.initialize(unitId, image);
       writeHoldingRegister(image, address, value);
     }
@@ -244,8 +215,7 @@ class ProcessImagePersistenceTest {
 
     var image = new ProcessImage();
     try (var persistence =
-        new ProcessImagePersistence(
-            deviceRoot, true, separatePerUnitId, Runnable::run)) {
+        new ProcessImagePersistence(deviceRoot, true, separatePerUnitId, Runnable::run)) {
       persistence.initialize(unitId, image);
       return holdingRegister(image, address);
     }
@@ -280,22 +250,18 @@ class ProcessImagePersistenceTest {
         tx -> {
           assertEquals(coil, tx.readCoils(map -> map.getOrDefault(address, false)));
           assertEquals(
-              discreteInput,
-              tx.readDiscreteInputs(map -> map.getOrDefault(address, false)));
+              discreteInput, tx.readDiscreteInputs(map -> map.getOrDefault(address, false)));
           assertArrayEquals(
               holdingRegister,
               tx.readHoldingRegisters(map -> map.getOrDefault(address, new byte[2])));
           assertArrayEquals(
-              inputRegister,
-              tx.readInputRegisters(map -> map.getOrDefault(address, new byte[2])));
+              inputRegister, tx.readInputRegisters(map -> map.getOrDefault(address, new byte[2])));
         });
   }
 
   private static byte[] holdingRegister(ProcessImage image, int address) {
     return image.get(
-        tx ->
-            tx.readHoldingRegisters(
-                map -> map.getOrDefault(address, new byte[2]).clone()));
+        tx -> tx.readHoldingRegisters(map -> map.getOrDefault(address, new byte[2]).clone()));
   }
 
   private static void await(CountDownLatch latch) {

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/address/ModbusAddressParserTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/address/ModbusAddressParserTest.java
@@ -330,8 +330,7 @@ class ModbusAddressParserTest {
   @Test
   void rejectsOversizedArrayExtentWithoutAllocation() {
     assertThrows(
-        Exception.class,
-        () -> ModbusAddressParser.parse("HR<int64[99999][99999][99999]>0"));
+        Exception.class, () -> ModbusAddressParser.parse("HR<int64[99999][99999][99999]>0"));
     assertFalse(ModbusAddressParser.isValidAddress("HR<int64[99999][99999][99999]>0"));
   }
 
@@ -346,22 +345,18 @@ class ModbusAddressParserTest {
 
   @Test
   void rejectsExtentThatWouldOverflowToNegativeInt() {
-    assertThrows(
-        Exception.class, () -> ModbusAddressParser.parse("HR<int64[536870912]>0"));
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<int64[536870912]>0"));
   }
 
   @Test
   void rejectsStringRegisterCountThatPreviouslyOverflowedNegative() {
     assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<string2147483647>0"));
-    assertThrows(
-        Exception.class,
-        () -> ModbusAddressParser.parse("HR<string2147483647[2]>0"));
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<string2147483647[2]>0"));
   }
 
   @Test
   void rejectsOversizedDeclaredExtentOnIndexedScalar() {
-    assertThrows(
-        Exception.class, () -> ModbusAddressParser.parse("HR<int16[65537]>0[0]"));
+    assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<int16[65537]>0[0]"));
   }
 
   @Test
@@ -404,7 +399,6 @@ class ModbusAddressParserTest {
     assertThrows(Exception.class, () -> ModbusAddressParser.parse("HR<int16@BEL>0"));
 
     assertEquals(1, ModbusAddressParser.parse("HR<int16@BE>0").getDataTypeModifiers().size());
-    assertEquals(
-        2, ModbusAddressParser.parse("HR<int16@BE@HL>0").getDataTypeModifiers().size());
+    assertEquals(2, ModbusAddressParser.parse("HR<int16@BE@HL>0").getDataTypeModifiers().size());
   }
 }

--- a/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/util/ModbusByteUtilTest.java
+++ b/msd-gateway/src/test/java/com/kevinherron/ignition/modbus/util/ModbusByteUtilTest.java
@@ -332,10 +332,7 @@ class ModbusByteUtilTest {
             UaException.class,
             () ->
                 ModbusByteUtil.getBytesForArrayValue(
-                    new Short[] {1, 2},
-                    new ModbusDataType.Int16(),
-                    NO_MODIFIERS,
-                    new int[] {3}));
+                    new Short[] {1, 2}, new ModbusDataType.Int16(), NO_MODIFIERS, new int[] {3}));
 
     assertEquals(StatusCodes.Bad_TypeMismatch, exception.getStatusCode().getValue());
   }

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <checkstyle.version>12.2.0</checkstyle.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
+    <spotless-maven-plugin.version>3.8.0</spotless-maven-plugin.version>
   </properties>
 
   <modules>
@@ -95,5 +96,26 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless-maven-plugin.version}</version>
+        <configuration>
+          <java>
+            <googleJavaFormat/>
+          </java>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>


### PR DESCRIPTION
## Summary

- pin Temurin 17 and Maven 3.9.16 with `mise`
- configure the Spotless Maven plugin to enforce Google Java Format during the build
- document the pinned build and formatting commands
- apply Google Java Format to the existing Java source and test baseline in a separate commit

## Why

A pinned local toolchain makes builds reproducible across developer environments, while the
Spotless check prevents formatting drift from entering the project.

## Impact

Developers can install the expected Java and Maven versions with `mise install`, run Maven through
`mise exec --`, and use `mvn spotless:apply` to format Java sources. Normal Maven verification now
checks formatting.

## Validation

- `mise exec -- mvn spotless:apply`
- `mise exec -- mvn clean verify` (380 tests passed)
